### PR TITLE
Improve payment filtering

### DIFF
--- a/lib/cubit/payments/models/payment/payment_filters.dart
+++ b/lib/cubit/payments/models/payment/payment_filters.dart
@@ -15,6 +15,10 @@ class PaymentFilters implements Exception {
 
   PaymentFilters.initial() : this();
 
+  bool get hasTypeFilters => filters != null && filters != PaymentType.values;
+
+  bool get hasDateFilters => fromTimestamp != null || toTimestamp != null;
+
   PaymentFilters copyWith({
     List<PaymentType>? filters,
     int? fromTimestamp,

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -81,8 +81,12 @@ class AccountPage extends StatelessWidget {
                 SliverPersistentHeader(
                   pinned: true,
                   delegate: FixedSliverDelegate(
-                    _bottomPlaceholderSpace(context, filteredPayments),
-                    child: Container(),
+                    _bottomPlaceholderSpace(
+                      context,
+                      paymentFilters.hasDateFilters,
+                      filteredPayments.length,
+                    ),
+                    child: const SizedBox.shrink(),
                   ),
                 ),
               );
@@ -126,16 +130,15 @@ class AccountPage extends StatelessWidget {
 
   double _bottomPlaceholderSpace(
     BuildContext context,
-    List<PaymentData> payments,
+    bool hasDateFilters,
+    int paymentsSize,
   ) {
-    if (payments.isEmpty) return 0.0;
-    double listHeightSpace =
-        MediaQuery.of(context).size.height - kMinExtent - kToolbarHeight - _kFilterMaxSize - 25.0;
-    const endDate = null;
-    double dateFilterSpace = endDate != null ? 0.65 : 0.0;
-    double bottomPlaceholderSpace =
-        (listHeightSpace - (_kPaymentListItemHeight + 8) * (payments.length + 1 + dateFilterSpace))
-            .clamp(0.0, listHeightSpace);
-    return bottomPlaceholderSpace;
+    if (paymentsSize == 0) return 0.0;
+
+    final screenSize = MediaQuery.of(context).size;
+    double listHeightSpace = screenSize.height - kMinExtent - kToolbarHeight - _kFilterMaxSize - 25.0;
+    double dateFilterSpace = hasDateFilters ? 0.65 : 0.0;
+    double requiredSpace = (_kPaymentListItemHeight + 8) * (paymentsSize + 1 + dateFilterSpace);
+    return (listHeightSpace - requiredSpace).clamp(0.0, listHeightSpace);
   }
 }

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -72,7 +72,6 @@ class AccountPage extends StatelessWidget {
             if (showSliver) {
               slivers.add(
                 PaymentsList(
-                  filteredPayments,
                   _kPaymentListItemHeight,
                   firstPaymentItemKey,
                 ),

--- a/lib/routes/home/widgets/payments_list/payments_list.dart
+++ b/lib/routes/home/widgets/payments_list/payments_list.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:l_breez/cubit/payments/models/models.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/payment_item.dart';
 
 const _kBottomPadding = 8.0;
 
 class PaymentsList extends StatelessWidget {
-  final List<PaymentData> _payments;
   final double _itemHeight;
   final GlobalKey firstPaymentItemKey;
 
   const PaymentsList(
-    this._payments,
     this._itemHeight,
     this.firstPaymentItemKey, {
     super.key,
@@ -18,16 +17,20 @@ class PaymentsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverFixedExtentList(
-      itemExtent: _itemHeight + _kBottomPadding,
-      delegate: SliverChildBuilderDelegate(
-        (context, index) => PaymentItem(
-          _payments[index],
-          0 == index,
-          firstPaymentItemKey,
-        ),
-        childCount: _payments.length,
-      ),
+    return BlocBuilder<PaymentsCubit, PaymentsState>(
+      builder: (context, paymentsState) {
+        return SliverFixedExtentList(
+          itemExtent: _itemHeight + _kBottomPadding,
+          delegate: SliverChildBuilderDelegate(
+            (context, index) => PaymentItem(
+              paymentsState.filteredPayments[index],
+              0 == index,
+              firstPaymentItemKey,
+            ),
+            childCount: paymentsState.filteredPayments.length,
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
This PR improves payment filtering logic following the internal discussion wrt https://github.com/breez/l-breez/pull/121#discussion_r1703982681.

- Added helper fields, `hasTypeFilters` & `hasDateFilters` on `PaymentFilters`.
  - Refactor `_bottomPlaceholderSpace` to use `hasDateFilters` 6a49f7f
- Return payments directly if there aren't any payment filters
- Use sets instead of `any` for payment type filtering to avoid performance issues with large payment lists
- Get filtered payments list from bloc on `PaymentsList` widget 53a19a8