### PR TITLE
Apply "Send/Receive: Add BIP21 support" changes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -132,7 +132,7 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
     - MLImage (= 1.0.0-beta5)
     - MLKitCommon (~> 11.0)
-  - mobile_scanner (5.1.1):
+  - mobile_scanner (5.2.1):
     - Flutter
     - GoogleMLKit/BarcodeScanning (~> 6.0.0)
   - nanopb (2.30910.0):
@@ -274,7 +274,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
   FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_breez_liquid: 835497cd8ad7e251381c24f8132768b278a5d6d4
+  flutter_breez_liquid: 25615dbdf0dd058755f23d1b97202090fa0f49bc
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
@@ -292,7 +292,7 @@ SPEC CHECKSUMS:
   MLKitBarcodeScanning: 10ca0845a6d15f2f6e911f682a1998b68b973e8b
   MLKitCommon: afec63980417d29ffbb4790529a1b0a2291699e1
   MLKitVision: e858c5f125ecc288e4a31127928301eaba9ae0c1
-  mobile_scanner: 8564358885a9253c43f822435b70f9345c87224f
+  mobile_scanner: 131a34df36b024cc53457809fb991700f16f72d7
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,13 +10,15 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		5100250EAC487F7657675A96 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48E0372F8F4F2937E6FA35CF /* Pods_RunnerTests.framework */; };
-		60BD2E2B6DB7070D154EC3B9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B5874DEEC49139D2D385880 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		AEE3FC7BF2127506B3B47EDC /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D405973BE989198BCECEE1B1 /* Pods_RunnerTests.framework */; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
+		E88FB9F52C7756900037463D /* breez_sdk_liquid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */; };
+		E88FB9F62C7756900037463D /* breez_sdk_liquid.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F325AC6B41F279698197A009 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECE5C85E65C4A6F4E6DFD7AA /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +38,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				E88FB9F62C7756900037463D /* breez_sdk_liquid.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -46,20 +49,22 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		15FBC21547B00E119F1FE42E /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPay.swift"; sourceTree = "<group>"; };
-		268F883F00340D6E5C89020D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		16822853BB54AB47EA9C5B78 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		36136CA437BFC850907F553A /* ServiceLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceLogger.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ServiceLogger.swift"; sourceTree = "<group>"; };
 		36D0B41A3417E9CC03930119 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPayInvoice.swift"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3CFC330343DC60A4CE33ED07 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		3E1CAF3B78F6335D47F0E20E /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		3FCE86AB511842FD78C29C16 /* BreezSDKConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKConnector.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/BreezSDKConnector.swift"; sourceTree = "<group>"; };
 		44631C1F894000A1C00B4B41 /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/SDKNotificationService.swift"; sourceTree = "<group>"; };
-		48E0372F8F4F2937E6FA35CF /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7113A41F6947744AAFC51D5F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		55AC790161DF17F7D3728297 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		79AEC1C5FC619286B254FCB8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		788BF76E8D742799D2B005E2 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		927F5AFB6C3894E17B1F6D0B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		941FBF81DE56E38CB9B607EF /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/TaskProtocol.swift"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -68,17 +73,16 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9B5874DEEC49139D2D385880 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A91886188D7722C76D07717B /* LnurlPayInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInfo.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPayInfo.swift"; sourceTree = "<group>"; };
-		AC7BF3374401F34C6B9B903F /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ACD7135B1733C7A905A92BC5 /* ReceivePayment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceivePayment.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/ReceivePayment.swift"; sourceTree = "<group>"; };
 		BCD162BC443C0AE50AE693BF /* RedeemSwap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RedeemSwap.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/RedeemSwap.swift"; sourceTree = "<group>"; };
 		BE49C1F5DD1913DD5BEAA00F /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Constants.swift"; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		D9112D42B08B0BCAF8075DCD /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		D405973BE989198BCECEE1B1 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = breez_sdk_liquid.xcframework; path = ".symlinks/plugins/flutter_breez_liquid/ios/../../../../../../breez-sdk-liquid/packages/flutter/ios/Frameworks/breez_sdk_liquid.xcframework"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
+		ECE5C85E65C4A6F4E6DFD7AA /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F10B8BD13646D7188373EBFA /* ServiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceConfig.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ServiceConfig.swift"; sourceTree = "<group>"; };
-		F4B85EF5A5612F5364851DE2 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F937E02F522B34DA0603EE0C /* BreezSDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDK.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/BreezSDK.swift"; sourceTree = "<group>"; };
 		FF2B4C3B077B63A01FF73FC6 /* ResourceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResourceHelper.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ResourceHelper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -88,7 +92,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5100250EAC487F7657675A96 /* Pods_RunnerTests.framework in Frameworks */,
+				AEE3FC7BF2127506B3B47EDC /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,28 +100,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				60BD2E2B6DB7070D154EC3B9 /* Pods_Runner.framework in Frameworks */,
+				F325AC6B41F279698197A009 /* Pods_Runner.framework in Frameworks */,
+				E88FB9F52C7756900037463D /* breez_sdk_liquid.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		285B6EBEBD4F0C7E41515D0A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */,
+				ECE5C85E65C4A6F4E6DFD7AA /* Pods_Runner.framework */,
+				D405973BE989198BCECEE1B1 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
-			sourceTree = "<group>";
-		};
-		3E028226F75732E5293E462D /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				9B5874DEEC49139D2D385880 /* Pods_Runner.framework */,
-				48E0372F8F4F2937E6FA35CF /* Pods_RunnerTests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		6ED43DD1619018FCC51A7E28 /* breez_sdk-OnDemandResources */ = {
@@ -147,8 +153,8 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				C3419851600CFDF0D267D1CB /* Pods */,
-				3E028226F75732E5293E462D /* Frameworks */,
 				C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */,
+				285B6EBEBD4F0C7E41515D0A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -200,13 +206,13 @@
 		C3419851600CFDF0D267D1CB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				79AEC1C5FC619286B254FCB8 /* Pods-Runner.debug.xcconfig */,
-				268F883F00340D6E5C89020D /* Pods-Runner.release.xcconfig */,
-				F4B85EF5A5612F5364851DE2 /* Pods-Runner.profile.xcconfig */,
-				AC7BF3374401F34C6B9B903F /* Pods-RunnerTests.debug.xcconfig */,
-				D9112D42B08B0BCAF8075DCD /* Pods-RunnerTests.release.xcconfig */,
-				7113A41F6947744AAFC51D5F /* Pods-RunnerTests.profile.xcconfig */,
 				6ED43DD1619018FCC51A7E28 /* breez_sdk-OnDemandResources */,
+				788BF76E8D742799D2B005E2 /* Pods-Runner.debug.xcconfig */,
+				927F5AFB6C3894E17B1F6D0B /* Pods-Runner.release.xcconfig */,
+				3CFC330343DC60A4CE33ED07 /* Pods-Runner.profile.xcconfig */,
+				16822853BB54AB47EA9C5B78 /* Pods-RunnerTests.debug.xcconfig */,
+				3E1CAF3B78F6335D47F0E20E /* Pods-RunnerTests.release.xcconfig */,
+				55AC790161DF17F7D3728297 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -218,7 +224,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				CDD6695F1619144FBD916503 /* [CP] Check Pods Manifest.lock */,
+				5E01F8E8506A5403B0605986 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -237,15 +243,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				F5DE0E4A1B63DF9D9871950B /* [CP] Check Pods Manifest.lock */,
+				1C558C089C7A8200146280FD /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				7803F8B4800AA49042835056 /* [CP] Embed Pods Frameworks */,
-				C84A08011AD1D686F1E16909 /* [CP] Copy Pods Resources */,
+				67DBBAAEBD43BDFF1D506FDB /* [CP] Embed Pods Frameworks */,
+				946A342371715158F4C4F0E2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -288,8 +294,6 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
-			packageReferences = (
-			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -323,6 +327,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1C558C089C7A8200146280FD /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -339,56 +365,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		7803F8B4800AA49042835056 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		C84A08011AD1D686F1E16909 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CDD6695F1619144FBD916503 /* [CP] Check Pods Manifest.lock */ = {
+		5E01F8E8506A5403B0605986 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -410,27 +387,54 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F5DE0E4A1B63DF9D9871950B /* [CP] Check Pods Manifest.lock */ = {
+		67DBBAAEBD43BDFF1D506FDB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		946A342371715158F4C4F0E2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -537,7 +541,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F4B85EF5A5612F5364851DE2 /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = 3CFC330343DC60A4CE33ED07 /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -565,7 +569,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AC7BF3374401F34C6B9B903F /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 16822853BB54AB47EA9C5B78 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -583,7 +587,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D9112D42B08B0BCAF8075DCD /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 3E1CAF3B78F6335D47F0E20E /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -599,7 +603,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7113A41F6947744AAFC51D5F /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 55AC790161DF17F7D3728297 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -728,7 +732,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 79AEC1C5FC619286B254FCB8 /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = 788BF76E8D742799D2B005E2 /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -757,7 +761,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 268F883F00340D6E5C89020D /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = 927F5AFB6C3894E17B1F6D0B /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -32,18 +32,6 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
     return await _liquidSdk.instance!.payOnchain(req: req);
   }
 
-  Future<PrepareReceiveOnchainResponse> prepareReceiveOnchain({
-    required PrepareReceiveOnchainRequest req,
-  }) async {
-    return await _liquidSdk.instance!.prepareReceiveOnchain(req: req);
-  }
-
-  Future<ReceiveOnchainResponse> receiveOnchain({
-    required PrepareReceiveOnchainResponse req,
-  }) async {
-    return await _liquidSdk.instance!.receiveOnchain(req: req);
-  }
-
   Future<RefundResponse> refund({
     required RefundRequest req,
   }) async {

--- a/lib/cubit/csv_exporter.dart
+++ b/lib/cubit/csv_exporter.dart
@@ -4,7 +4,8 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:csv/csv.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:intl/intl.dart';
-import 'package:l_breez/cubit/payments/payments_state.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/utils/date.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
@@ -46,7 +47,8 @@ class CsvExporter {
       paymentItem.add(BreezDateUtils.formatYearMonthDayHourMinute(paymentInfo.paymentTime));
       paymentItem.add(paymentInfo.title);
       paymentItem.add(paymentInfo.amountSat.toString());
-      paymentItem.add(paymentInfo.preimage);
+      // TODO: Add other payment details necessary for liquid & BTC payments.
+      paymentItem.add(_getPreimage(paymentInfo));
       paymentItem.add(paymentInfo.id);
       paymentItem.add(paymentInfo.feeSat.toString());
       return paymentItem;
@@ -105,5 +107,13 @@ class CsvExporter {
     }
     _log.info("add filter information to path finished");
     return filePath;
+  }
+
+  String _getPreimage(PaymentData paymentInfo) {
+    return paymentInfo.details?.maybeMap(
+          lightning: (details) => details.preimage,
+          orElse: () => "",
+        ) ??
+        "";
   }
 }

--- a/lib/cubit/input/input_cubit.dart
+++ b/lib/cubit/input/input_cubit.dart
@@ -7,7 +7,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/invoice.dart';
-import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:lightning_links/lightning_links.dart';
 import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
@@ -40,33 +39,24 @@ class InputCubit extends Cubit<InputState> {
     _decodeInvoiceController.add(InputData(data: input, source: source));
   }
 
-  Future trackPayment(String? trackedPaymentId) async {
-    _log.info("Tracking incoming payment: $trackedPaymentId");
-    await ServiceInjector().liquidSDK.paymentResultStream.firstWhere(
-      (payment) {
-        if (trackedPaymentId != null && trackedPaymentId.isNotEmpty) {
-          // TODO: Question: Which payment details fields correlate to  ReceivePaymentResponse.destination?
-          // Does PaymentDetails_Lightning.bolt11 correlate to ReceivePaymentResponse.destination?
-          // Does PaymentDetails_Bitcoin.swapId correlate to ReceivePaymentResponse.destination?
-          final receivedPaymentId = payment.details?.maybeMap(
-                bitcoin: (details) => details.swapId,
-                lightning: (details) => details.bolt11,
-                // TODO: liquid: is unused as Liquid payments are not integrated yet
-                liquid: (details) => details.destination,
-                orElse: () => "",
-              ) ??
-              "";
-          if (receivedPaymentId.isNotEmpty) {
-            if (receivedPaymentId == trackedPaymentId &&
-                (payment.status == PaymentState.pending || payment.status == PaymentState.complete)) {
-              _log.info("Payment Received! Id: $trackedPaymentId");
-              return true;
-            }
-          }
-        }
-        return false;
-      },
-    );
+  Future<void> trackPayment(String? paymentDestination) async {
+    if (paymentDestination == null || paymentDestination.isEmpty) {
+      _log.warning("Payment can't be tracked. Payment destination is empty.");
+      return;
+    }
+    _log.info("Tracking incoming payment: $paymentDestination");
+    await ServiceInjector().liquidSDK.paymentResultStream.firstWhere((payment) {
+      final receivedPaymentDestination = payment.destination ?? "";
+      final doesDestinationMatch = receivedPaymentDestination == paymentDestination;
+      final isPaymentReceived =
+          payment.status == PaymentState.pending || payment.status == PaymentState.complete;
+
+      if (doesDestinationMatch && isPaymentReceived) {
+        _log.info("Payment Received! Destination: ${payment.destination}, Status: ${payment.status}");
+        return true;
+      }
+      return false;
+    });
   }
 
   Stream<InputState?> _watchIncomingInvoices() {

--- a/lib/cubit/input/input_cubit.dart
+++ b/lib/cubit/input/input_cubit.dart
@@ -52,7 +52,7 @@ class InputCubit extends Cubit<InputState> {
                 bitcoin: (details) => details.swapId,
                 lightning: (details) => details.bolt11,
                 // TODO: liquid: is unused as Liquid payments are not integrated yet
-                liquid: (details) => details.address,
+                liquid: (details) => details.destination,
                 orElse: () => "",
               ) ??
               "";

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -9,34 +9,28 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 class PaymentData {
   final String id;
   final String title;
-  final String description;
-  final String preimage;
-  final String bolt11;
-  final String swapId;
+  final String destination;
   final String txId;
-  final String refundTxId;
-  final PaymentType paymentType;
   final DateTime paymentTime;
-  final int feeSat;
   final int amountSat;
-  final int refundTxAmountSat;
+  final int feeSat;
+  final String description;
+  final PaymentType paymentType;
   final PaymentState status;
+  final PaymentDetails? details;
 
   const PaymentData({
     required this.id,
     required this.title,
-    required this.description,
-    required this.preimage,
-    required this.bolt11,
-    required this.swapId,
+    required this.destination,
     required this.txId,
-    required this.refundTxId,
-    required this.paymentType,
     required this.paymentTime,
-    required this.feeSat,
     required this.amountSat,
-    required this.refundTxAmountSat,
+    required this.feeSat,
+    required this.description,
+    required this.paymentType,
     required this.status,
+    this.details,
   });
 
   factory PaymentData.fromPayment(Payment payment, BreezTranslations texts) {
@@ -45,18 +39,15 @@ class PaymentData {
     return PaymentData(
       id: payment.txId ?? "",
       title: factory._title(),
-      description: payment.description,
-      preimage: payment.preimage ?? "",
-      bolt11: payment.bolt11 ?? "",
-      swapId: payment.swapId ?? "",
+      destination: payment.destination ?? "",
       txId: payment.txId ?? "",
-      refundTxId: payment.refundTxId ?? "",
-      paymentType: payment.paymentType,
       paymentTime: factory._paymentTime(),
-      feeSat: payment.feesSat.toInt(),
       amountSat: payment.amountSat.toInt(),
-      refundTxAmountSat: payment.refundTxAmountSat?.toInt() ?? 0,
+      feeSat: payment.feesSat.toInt(),
+      description: payment.description,
+      paymentType: payment.paymentType,
       status: payment.status,
+      details: payment.details,
     );
   }
 
@@ -64,37 +55,34 @@ class PaymentData {
     return {
       'id': id,
       'title': title,
-      'description': description,
-      'preimage': preimage,
-      'bolt11': bolt11,
-      'swapId': swapId,
+      'destination': destination,
       'txId': txId,
-      'refundTxId': refundTxId,
-      'paymentType': paymentType.name,
       'paymentTime': paymentTime.toIso8601String(),
-      'feeSat': feeSat,
       'amountSat': amountSat,
-      'refundTxAmountSat': refundTxAmountSat,
+      'feeSat': feeSat,
+      'description': description,
+      'paymentType': paymentType.name,
       'status': status.name,
+      // TODO: Deserialize PaymentDetails
+      'details': details,
     };
   }
 
   factory PaymentData.fromJson(Map<String, dynamic> json) {
     return PaymentData(
-        id: json['id'],
-        title: json['title'],
-        description: json['description'],
-        preimage: json['preimage'],
-        bolt11: json['bolt11'],
-        swapId: json['swapId'],
-        txId: json['txId'],
-        refundTxId: json['refundTxId'],
-        paymentType: PaymentType.values.byName(json['paymentType']),
-        paymentTime: DateTime.parse(json['paymentTime']),
-        feeSat: json['feeSat'],
-        amountSat: json['amountSat'],
-        refundTxAmountSat: json['refundTxAmountSat'],
-        status: PaymentState.values.byName(json['status']));
+      id: json['id'],
+      title: json['title'],
+      destination: json['destination'],
+      txId: json['txId'],
+      paymentTime: DateTime.parse(json['paymentTime']),
+      amountSat: json['amountSat'],
+      feeSat: json['feeSat'],
+      description: json['description'],
+      paymentType: PaymentType.values.byName(json['paymentType']),
+      status: PaymentState.values.byName(json['status']),
+      // TODO: Serialize PaymentDetails
+      details: json['details'],
+    );
   }
 
   @override

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -148,10 +148,6 @@ class _PaymentDataFactory {
   String _title() {
     var title = "${_texts.wallet_dashboard_payment_item_no_title} Payment";
     if (_payment.description.isNotEmpty) return _payment.description;
-    // TODO: Liquid SDK - Following matchers are kind of made obsolete with description not being empty
-    if (_payment.bolt11 != null) return "Lightning Payment";
-    if (_payment.refundTxId != null) return "Refund Transaction";
-    if (_payment.swapId != null) return "Chain Swap Transaction";
     return title;
   }
 

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -86,18 +86,14 @@ class PaymentData {
   int get hashCode => Object.hash(
         id,
         title,
-        description,
-        preimage,
-        bolt11,
-        swapId,
+        destination,
         txId,
-        refundTxId,
-        paymentType,
         paymentTime,
-        feeSat,
         amountSat,
-        refundTxAmountSat,
+        feeSat,
+        paymentType,
         status,
+        details.calculateHashCode(),
       );
 
   @override
@@ -106,18 +102,14 @@ class PaymentData {
         other is PaymentData &&
             id == other.id &&
             title == other.title &&
-            description == other.description &&
-            preimage == other.preimage &&
-            bolt11 == other.bolt11 &&
-            swapId == other.swapId &&
+            destination == other.destination &&
             txId == other.txId &&
-            refundTxId == other.refundTxId &&
-            paymentType == other.paymentType &&
             paymentTime == other.paymentTime &&
-            feeSat == other.feeSat &&
+            paymentType == other.paymentType &&
             amountSat == other.amountSat &&
-            refundTxAmountSat == other.refundTxAmountSat &&
-            status == other.status;
+            feeSat == other.feeSat &&
+            status == other.status &&
+            details.equals(other.details);
   }
 }
 

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 
 // TODO: Liquid - Remove if having PaymentData is not necessary with Liquid SDK
 /// Hold formatted data from Payment to be displayed in the UI, using the minutiae noun instead of details or
@@ -14,7 +15,6 @@ class PaymentData {
   final DateTime paymentTime;
   final int amountSat;
   final int feeSat;
-  final String description;
   final PaymentType paymentType;
   final PaymentState status;
   final PaymentDetails? details;
@@ -27,7 +27,6 @@ class PaymentData {
     required this.paymentTime,
     required this.amountSat,
     required this.feeSat,
-    required this.description,
     required this.paymentType,
     required this.status,
     this.details,
@@ -44,7 +43,6 @@ class PaymentData {
       paymentTime: factory._paymentTime(),
       amountSat: payment.amountSat.toInt(),
       feeSat: payment.feesSat.toInt(),
-      description: payment.description,
       paymentType: payment.paymentType,
       status: payment.status,
       details: payment.details,
@@ -60,7 +58,6 @@ class PaymentData {
       'paymentTime': paymentTime.toIso8601String(),
       'amountSat': amountSat,
       'feeSat': feeSat,
-      'description': description,
       'paymentType': paymentType.name,
       'status': status.name,
       // TODO: Deserialize PaymentDetails
@@ -77,7 +74,6 @@ class PaymentData {
       paymentTime: DateTime.parse(json['paymentTime']),
       amountSat: json['amountSat'],
       feeSat: json['feeSat'],
-      description: json['description'],
       paymentType: PaymentType.values.byName(json['paymentType']),
       status: PaymentState.values.byName(json['status']),
       // TODO: Serialize PaymentDetails
@@ -135,7 +131,14 @@ class _PaymentDataFactory {
 
   String _title() {
     var title = "${_texts.wallet_dashboard_payment_item_no_title} Payment";
-    if (_payment.description.isNotEmpty) return _payment.description;
+    final description = _payment.details?.maybeMap(
+          lightning: (details) => details.description,
+          bitcoin: (details) => details.description,
+          liquid: (details) => details.description,
+          orElse: () => "",
+        ) ??
+        "";
+    if (description.isNotEmpty) return description;
     return title;
   }
 

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -60,8 +60,7 @@ class PaymentData {
       'feeSat': feeSat,
       'paymentType': paymentType.name,
       'status': status.name,
-      // TODO: Deserialize PaymentDetails
-      'details': details,
+      'details': details.toJson(),
     };
   }
 
@@ -76,8 +75,7 @@ class PaymentData {
       feeSat: json['feeSat'],
       paymentType: PaymentType.values.byName(json['paymentType']),
       status: PaymentState.values.byName(json['status']),
-      // TODO: Serialize PaymentDetails
-      details: json['details'],
+      details: PaymentDetailsFromJson.fromJson(json['details']),
     );
   }
 

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -78,13 +78,13 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
 
   Future<PrepareReceiveResponse> prepareReceivePayment({
     required PaymentMethod paymentMethod,
-    BigInt? amountSat,
+    BigInt? payerAmountSat,
   }) async {
-    _log.info("prepareReceivePayment\nPreparing receive payment for $amountSat sats");
+    _log.info("prepareReceivePayment\nPreparing receive payment for $payerAmountSat sats");
     try {
       final req = PrepareReceiveRequest(
         paymentMethod: paymentMethod,
-        amountSat: amountSat,
+        payerAmountSat: payerAmountSat,
       );
       return _liquidSdk.instance!.prepareReceivePayment(req: req);
     } catch (e) {
@@ -99,7 +99,7 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
   }) async {
     _log.info(
       "receivePayment\nReceive ${prepareResponse.paymentMethod.name} payment for amount: "
-      "${prepareResponse.amountSat} (sats), fees: ${prepareResponse.feesSat} (sats), description: $description",
+      "${prepareResponse.payerAmountSat} (sats), fees: ${prepareResponse.feesSat} (sats), description: $description",
     );
     try {
       final req = ReceivePaymentRequest(prepareResponse: prepareResponse, description: description);

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -51,10 +51,13 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
     ).distinct().listen((newState) => emit(newState));
   }
 
-  Future<PrepareSendResponse> prepareSendPayment(String invoice) async {
-    _log.info("prepareSendPayment\nPreparing send payment for invoice: $invoice");
+  Future<PrepareSendResponse> prepareSendPayment({
+    required String destination,
+    BigInt? amountSat,
+  }) async {
+    _log.info("prepareSendPayment\nPreparing send payment for destination: $destination");
     try {
-      final req = PrepareSendRequest(invoice: invoice);
+      final req = PrepareSendRequest(destination: destination, amountSat: amountSat);
       return await _liquidSdk.instance!.prepareSendPayment(req: req);
     } catch (e) {
       _log.severe("prepareSendPayment\nError preparing send payment", e);
@@ -62,9 +65,10 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
     }
   }
 
-  Future<SendPaymentResponse> sendPayment(PrepareSendResponse req) async {
-    _log.info("sendPayment\nSending payment for $req");
+  Future<SendPaymentResponse> sendPayment(PrepareSendResponse prepareResponse) async {
+    _log.info("sendPayment\nSending payment for $prepareResponse");
     try {
+      final req = SendPaymentRequest(prepareResponse: prepareResponse);
       return await _liquidSdk.instance!.sendPayment(req: req);
     } catch (e) {
       _log.severe("sendPayment\nError sending payment", e);
@@ -72,10 +76,16 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
     }
   }
 
-  Future<PrepareReceivePaymentResponse> prepareReceivePayment(int payerAmountSat) async {
-    _log.info("prepareReceivePayment\nPreparing receive payment for $payerAmountSat sats");
+  Future<PrepareReceiveResponse> prepareReceivePayment({
+    required PaymentMethod paymentMethod,
+    BigInt? amountSat,
+  }) async {
+    _log.info("prepareReceivePayment\nPreparing receive payment for $amountSat sats");
     try {
-      final req = PrepareReceivePaymentRequest(payerAmountSat: BigInt.from(payerAmountSat));
+      final req = PrepareReceiveRequest(
+        paymentMethod: paymentMethod,
+        amountSat: amountSat,
+      );
       return _liquidSdk.instance!.prepareReceivePayment(req: req);
     } catch (e) {
       _log.severe("prepareSendPayment\nError preparing receive payment", e);
@@ -83,11 +93,16 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
     }
   }
 
-  Future<ReceivePaymentResponse> receivePayment(ReceivePaymentRequest req) async {
+  Future<ReceivePaymentResponse> receivePayment({
+    required PrepareReceiveResponse prepareResponse,
+    String? description,
+  }) async {
     _log.info(
-      "receivePayment\nReceive payment for amount: ${req.prepareRes.payerAmountSat} (sats), fees: ${req.prepareRes.feesSat} (sats), description: ${req.description}",
+      "receivePayment\nReceive ${prepareResponse.paymentMethod.name} payment for amount: "
+      "${prepareResponse.amountSat} (sats), fees: ${prepareResponse.feesSat} (sats), description: $description",
     );
     try {
+      final req = ReceivePaymentRequest(prepareResponse: prepareResponse, description: description);
       return _liquidSdk.instance!.receivePayment(req: req);
     } catch (e) {
       _log.severe("receivePayment\nError receiving payment", e);

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -18,3 +18,64 @@ extension PaymentDetailsMaybeMapExtension on PaymentDetails? {
     }
   }
 }
+
+extension PaymentDetailsToJson on PaymentDetails? {
+  Map<String, dynamic>? toJson() {
+    return this?.maybeMap(
+      lightning: (details) => {
+        'type': 'lightning',
+        'swapId': details.swapId,
+        'description': details.description,
+        'preimage': details.preimage,
+        'bolt11': details.bolt11,
+        'refundTxId': details.refundTxId,
+        'refundTxAmountSat': details.refundTxAmountSat?.toString(),
+      },
+      liquid: (details) => {
+        'type': 'liquid',
+        'destination': details.destination,
+        'description': details.description,
+      },
+      bitcoin: (details) => {
+        'type': 'bitcoin',
+        'swapId': details.swapId,
+        'description': details.description,
+        'refundTxId': details.refundTxId,
+        'refundTxAmountSat': details.refundTxAmountSat?.toString(),
+      },
+      orElse: () => null,
+    );
+  }
+}
+
+extension PaymentDetailsFromJson on PaymentDetails? {
+  static PaymentDetails? fromJson(Map<String, dynamic> json) {
+    switch (json['type']) {
+      case 'lightning':
+        return PaymentDetails.lightning(
+          swapId: json['swapId'] as String,
+          description: json['description'] as String,
+          preimage: json['preimage'] as String?,
+          bolt11: json['bolt11'] as String?,
+          refundTxId: json['refundTxId'] as String?,
+          refundTxAmountSat:
+              json['refundTxAmountSat'] != null ? BigInt.parse(json['refundTxAmountSat'] as String) : null,
+        );
+      case 'liquid':
+        return PaymentDetails.liquid(
+          destination: json['destination'] as String,
+          description: json['description'] as String,
+        );
+      case 'bitcoin':
+        return PaymentDetails.bitcoin(
+          swapId: json['swapId'] as String,
+          description: json['description'] as String,
+          refundTxId: json['refundTxId'] as String?,
+          refundTxAmountSat:
+              json['refundTxAmountSat'] != null ? BigInt.parse(json['refundTxAmountSat'] as String) : null,
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
+// TODO: Ensure that any changes to [PaymentDetails] are reflected here on each extension.
 extension PaymentDetailsMaybeMapExtension on PaymentDetails? {
   T maybeMap<T>({
     T Function(PaymentDetails_Bitcoin details)? bitcoin,
@@ -82,27 +83,26 @@ extension PaymentDetailsFromJson on PaymentDetails? {
 
 extension PaymentDetailsExtension on PaymentDetails? {
   bool equals(PaymentDetails? other) {
-    if (identical(this, other)) return true;
-
-    return other.runtimeType == runtimeType &&
-        other.maybeMap(
-          lightning: (o) =>
-              o.swapId == (this as PaymentDetails_Lightning).swapId &&
-              o.description == (this as PaymentDetails_Lightning).description &&
-              o.preimage == (this as PaymentDetails_Lightning).preimage &&
-              o.bolt11 == (this as PaymentDetails_Lightning).bolt11 &&
-              o.refundTxId == (this as PaymentDetails_Lightning).refundTxId &&
-              o.refundTxAmountSat == (this as PaymentDetails_Lightning).refundTxAmountSat,
-          liquid: (o) =>
-              o.destination == (this as PaymentDetails_Liquid).destination &&
-              o.description == (this as PaymentDetails_Liquid).description,
-          bitcoin: (o) =>
-              o.swapId == (this as PaymentDetails_Bitcoin).swapId &&
-              o.description == (this as PaymentDetails_Bitcoin).description &&
-              o.refundTxId == (this as PaymentDetails_Bitcoin).refundTxId &&
-              o.refundTxAmountSat == (this as PaymentDetails_Bitcoin).refundTxAmountSat,
-          orElse: () => this == other,
-        );
+    return (identical(this, other)) ||
+        other.runtimeType == runtimeType &&
+            other.maybeMap(
+              lightning: (o) =>
+                  o.swapId == (this as PaymentDetails_Lightning).swapId &&
+                  o.description == (this as PaymentDetails_Lightning).description &&
+                  o.preimage == (this as PaymentDetails_Lightning).preimage &&
+                  o.bolt11 == (this as PaymentDetails_Lightning).bolt11 &&
+                  o.refundTxId == (this as PaymentDetails_Lightning).refundTxId &&
+                  o.refundTxAmountSat == (this as PaymentDetails_Lightning).refundTxAmountSat,
+              liquid: (o) =>
+                  o.destination == (this as PaymentDetails_Liquid).destination &&
+                  o.description == (this as PaymentDetails_Liquid).description,
+              bitcoin: (o) =>
+                  o.swapId == (this as PaymentDetails_Bitcoin).swapId &&
+                  o.description == (this as PaymentDetails_Bitcoin).description &&
+                  o.refundTxId == (this as PaymentDetails_Bitcoin).refundTxId &&
+                  o.refundTxAmountSat == (this as PaymentDetails_Bitcoin).refundTxAmountSat,
+              orElse: () => this == other,
+            );
   }
 }
 

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+
+extension PaymentDetailsMaybeMapExtension on PaymentDetails? {
+  T maybeMap<T>({
+    T Function(PaymentDetails_Bitcoin details)? bitcoin,
+    T Function(PaymentDetails_Lightning details)? lightning,
+    T Function(PaymentDetails_Liquid details)? liquid,
+    required T Function() orElse,
+  }) {
+    if (this is PaymentDetails_Bitcoin) {
+      return bitcoin != null ? bitcoin(this as PaymentDetails_Bitcoin) : orElse();
+    } else if (this is PaymentDetails_Lightning) {
+      return lightning != null ? lightning(this as PaymentDetails_Lightning) : orElse();
+    } else if (this is PaymentDetails_Liquid) {
+      return liquid != null ? liquid(this as PaymentDetails_Liquid) : orElse();
+    } else {
+      return orElse();
+    }
+  }
+}

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -79,3 +79,41 @@ extension PaymentDetailsFromJson on PaymentDetails? {
     }
   }
 }
+
+extension PaymentDetailsExtension on PaymentDetails? {
+  bool equals(PaymentDetails? other) {
+    if (identical(this, other)) return true;
+
+    return other.runtimeType == runtimeType &&
+        other.maybeMap(
+          lightning: (o) =>
+              o.swapId == (this as PaymentDetails_Lightning).swapId &&
+              o.description == (this as PaymentDetails_Lightning).description &&
+              o.preimage == (this as PaymentDetails_Lightning).preimage &&
+              o.bolt11 == (this as PaymentDetails_Lightning).bolt11 &&
+              o.refundTxId == (this as PaymentDetails_Lightning).refundTxId &&
+              o.refundTxAmountSat == (this as PaymentDetails_Lightning).refundTxAmountSat,
+          liquid: (o) =>
+              o.destination == (this as PaymentDetails_Liquid).destination &&
+              o.description == (this as PaymentDetails_Liquid).description,
+          bitcoin: (o) =>
+              o.swapId == (this as PaymentDetails_Bitcoin).swapId &&
+              o.description == (this as PaymentDetails_Bitcoin).description &&
+              o.refundTxId == (this as PaymentDetails_Bitcoin).refundTxId &&
+              o.refundTxAmountSat == (this as PaymentDetails_Bitcoin).refundTxAmountSat,
+          orElse: () => this == other,
+        );
+  }
+}
+
+extension PaymentDetailsHashCode on PaymentDetails? {
+  int calculateHashCode() {
+    return maybeMap(
+      lightning: (o) =>
+          Object.hash(o.swapId, o.description, o.preimage, o.bolt11, o.refundTxId, o.refundTxAmountSat),
+      liquid: (o) => Object.hash(o.destination, o.description),
+      bitcoin: (o) => Object.hash(o.swapId, o.description, o.refundTxId, o.refundTxAmountSat),
+      orElse: () => 0,
+    );
+  }
+}

--- a/lib/routes/chainswap/receive/chainswap_qr_dialog.dart
+++ b/lib/routes/chainswap/receive/chainswap_qr_dialog.dart
@@ -19,14 +19,14 @@ import 'package:share_plus/share_plus.dart';
 final _log = Logger("QrCodeDialog");
 
 class ChainSwapQrDialog extends StatefulWidget {
-  final PrepareReceiveOnchainResponse prepareReceiveOnchainResponse;
-  final ReceiveOnchainResponse? receiveOnchainResponse;
+  final PrepareReceiveResponse prepareReceiveResponse;
+  final ReceivePaymentResponse? receivePaymentResponse;
   final Object? error;
   final Function(dynamic result) _onFinish;
 
   const ChainSwapQrDialog(
-    this.prepareReceiveOnchainResponse,
-    this.receiveOnchainResponse,
+    this.prepareReceiveResponse,
+    this.receivePaymentResponse,
     this.error,
     this._onFinish,
   );
@@ -64,9 +64,9 @@ class ChainSwapQrDialogState extends State<ChainSwapQrDialog> with SingleTickerP
   @override
   void didUpdateWidget(covariant ChainSwapQrDialog oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.receiveOnchainResponse?.address != oldWidget.receiveOnchainResponse?.address) {
+    if (widget.receivePaymentResponse?.destination != oldWidget.receivePaymentResponse?.destination) {
       var inputCubit = context.read<InputCubit>();
-      inputCubit.trackPayment(widget.receiveOnchainResponse!.bip21).then((value) {
+      inputCubit.trackPayment(widget.receivePaymentResponse!.destination).then((value) {
         Timer(const Duration(milliseconds: 1000), () {
           if (mounted) {
             _controller!.reverse();
@@ -108,7 +108,7 @@ class ChainSwapQrDialogState extends State<ChainSwapQrDialog> with SingleTickerP
                         icon: const Icon(IconData(0xe917, fontFamily: 'icomoon')),
                         color: themeData.primaryTextTheme.labelLarge!.color!,
                         onPressed: () {
-                          Share.share(widget.receiveOnchainResponse!.bip21);
+                          Share.share(widget.receivePaymentResponse!.destination);
                         },
                       ),
                     ),
@@ -123,7 +123,7 @@ class ChainSwapQrDialogState extends State<ChainSwapQrDialog> with SingleTickerP
                         onPressed: () {
                           ServiceInjector()
                               .deviceClient
-                              .setClipboardText(widget.receiveOnchainResponse!.bip21);
+                              .setClipboardText(widget.receivePaymentResponse!.destination);
                           showFlushbar(
                             context,
                             message: texts.qr_code_dialog_copied,
@@ -146,23 +146,23 @@ class ChainSwapQrDialogState extends State<ChainSwapQrDialog> with SingleTickerP
                       ? extractExceptionMessage(error, texts)
                       : texts.qr_code_dialog_warning_message_error,
                 ),
-                secondChild: widget.receiveOnchainResponse == null
+                secondChild: widget.receivePaymentResponse == null
                     ? const SizedBox()
                     : Column(
                         children: [
-                          InvoiceQR(bolt11: widget.receiveOnchainResponse!.bip21, bip21: true),
+                          InvoiceQR(bolt11: widget.receivePaymentResponse!.destination, bip21: true),
                           const Padding(padding: EdgeInsets.only(top: 16.0)),
                           SizedBox(
                             width: MediaQuery.of(context).size.width,
                             child: ExpiryAndFeeMessage(
-                              feesSat: widget.prepareReceiveOnchainResponse.feesSat.toInt(),
+                              feesSat: widget.prepareReceiveResponse.feesSat.toInt(),
                             ),
                           ),
                           const Padding(padding: EdgeInsets.only(top: 16.0)),
                         ],
                       ),
                 duration: const Duration(seconds: 1),
-                crossFadeState: widget.receiveOnchainResponse == null
+                crossFadeState: widget.receivePaymentResponse == null
                     ? CrossFadeState.showFirst
                     : CrossFadeState.showSecond,
               ),

--- a/lib/routes/chainswap/receive/receive_chainswap_page.dart
+++ b/lib/routes/chainswap/receive/receive_chainswap_page.dart
@@ -179,10 +179,10 @@ class _ReceiveChainSwapPageState extends State<ReceiveChainSwapPage> {
     final paymentsCubit = context.read<PaymentsCubit>();
     final currencyCubit = context.read<CurrencyCubit>();
 
-    final amountMsat = currencyCubit.state.bitcoinCurrency.parse(_amountController.text);
+    final payerAmountSat = currencyCubit.state.bitcoinCurrency.parse(_amountController.text);
     final prepareResponse = await paymentsCubit.prepareReceivePayment(
       paymentMethod: PaymentMethod.bitcoinAddress,
-      amountSat: BigInt.from(amountMsat),
+      payerAmountSat: BigInt.from(payerAmountSat),
     );
     final receivePaymentResponse = paymentsCubit.receivePayment(
       prepareResponse: prepareResponse,

--- a/lib/routes/chainswap/send/send_chainswap_button.dart
+++ b/lib/routes/chainswap/send/send_chainswap_button.dart
@@ -38,7 +38,7 @@ class SendChainSwapButton extends StatelessWidget {
     var loaderRoute = createLoaderRoute(context);
     navigator.push(loaderRoute);
     try {
-      final req = PayOnchainRequest(address: recipientAddress, prepareRes: preparePayOnchainResponse);
+      final req = PayOnchainRequest(address: recipientAddress, prepareResponse: preparePayOnchainResponse);
       await chainSwapCubit.payOnchain(req: req);
       navigator.pushNamedAndRemoveUntil(Home.routeName, (Route<dynamic> route) => false);
     } catch (e) {

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -244,10 +244,10 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     final paymentsCubit = context.read<PaymentsCubit>();
     final currencyCubit = context.read<CurrencyCubit>();
 
-    final amountMsat = BigInt.from(currencyCubit.state.bitcoinCurrency.parse(_amountController.text));
+    final payerAmountSat = BigInt.from(currencyCubit.state.bitcoinCurrency.parse(_amountController.text));
     final prepareReceiveResponse = await paymentsCubit.prepareReceivePayment(
       paymentMethod: PaymentMethod.lightning,
-      amountSat: amountMsat,
+      payerAmountSat: payerAmountSat,
     );
     final receivePaymentResponse = paymentsCubit.receivePayment(
       prepareResponse: prepareReceiveResponse,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -244,13 +244,15 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     final paymentsCubit = context.read<PaymentsCubit>();
     final currencyCubit = context.read<CurrencyCubit>();
 
-    final amountMsat = currencyCubit.state.bitcoinCurrency.parse(_amountController.text);
-    final prepareReceiveResponse = await paymentsCubit.prepareReceivePayment(amountMsat);
-    final receivePaymentRequest = ReceivePaymentRequest(
-      prepareRes: prepareReceiveResponse,
+    final amountMsat = BigInt.from(currencyCubit.state.bitcoinCurrency.parse(_amountController.text));
+    final prepareReceiveResponse = await paymentsCubit.prepareReceivePayment(
+      paymentMethod: PaymentMethod.lightning,
+      amountSat: amountMsat,
+    );
+    final receivePaymentResponse = paymentsCubit.receivePayment(
+      prepareResponse: prepareReceiveResponse,
       description: _descriptionController.text,
     );
-    final receivePaymentResponse = paymentsCubit.receivePayment(receivePaymentRequest);
 
     navigator.pop();
     Widget dialog = FutureBuilder(

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -19,13 +19,13 @@ import 'package:share_plus/share_plus.dart';
 final _log = Logger("QrCodeDialog");
 
 class QrCodeDialog extends StatefulWidget {
-  final PrepareReceivePaymentResponse prepareReceivePaymentResponse;
+  final PrepareReceiveResponse prepareReceiveResponse;
   final ReceivePaymentResponse? receivePaymentResponse;
   final Object? error;
   final Function(dynamic result) _onFinish;
 
   const QrCodeDialog(
-    this.prepareReceivePaymentResponse,
+    this.prepareReceiveResponse,
     this.receivePaymentResponse,
     this.error,
     this._onFinish,
@@ -64,9 +64,9 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
   @override
   void didUpdateWidget(covariant QrCodeDialog oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.receivePaymentResponse?.id != oldWidget.receivePaymentResponse?.id) {
+    if (widget.receivePaymentResponse?.destination != oldWidget.receivePaymentResponse?.destination) {
       final inputCubit = context.read<InputCubit>();
-      inputCubit.trackPayment(widget.receivePaymentResponse!.id).then((value) {
+      inputCubit.trackPayment(widget.receivePaymentResponse!.destination).then((value) {
         Timer(const Duration(milliseconds: 1000), () {
           if (mounted) {
             _controller!.reverse();
@@ -108,7 +108,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                         icon: const Icon(IconData(0xe917, fontFamily: 'icomoon')),
                         color: themeData.primaryTextTheme.labelLarge!.color!,
                         onPressed: () {
-                          Share.share(widget.receivePaymentResponse!.invoice);
+                          Share.share(widget.receivePaymentResponse!.destination);
                         },
                       ),
                     ),
@@ -123,7 +123,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                         onPressed: () {
                           ServiceInjector()
                               .deviceClient
-                              .setClipboardText(widget.receivePaymentResponse!.invoice);
+                              .setClipboardText(widget.receivePaymentResponse!.destination);
                           showFlushbar(
                             context,
                             message: texts.qr_code_dialog_copied,
@@ -150,12 +150,12 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                     ? const SizedBox()
                     : Column(
                         children: [
-                          InvoiceQR(bolt11: widget.receivePaymentResponse!.invoice),
+                          InvoiceQR(bolt11: widget.receivePaymentResponse!.destination),
                           const Padding(padding: EdgeInsets.only(top: 16.0)),
                           SizedBox(
                             width: MediaQuery.of(context).size.width,
                             child: ExpiryAndFeeMessage(
-                              feesSat: widget.prepareReceivePaymentResponse.feesSat.toInt(),
+                              feesSat: widget.prepareReceiveResponse.feesSat.toInt(),
                             ),
                           ),
                           const Padding(padding: EdgeInsets.only(top: 16.0)),

--- a/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_bolt11.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_bolt11.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:l_breez/cubit/payments/models/models.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/widgets/shareable_payment_row.dart';
 
 class PaymentDetailsBolt11 extends StatelessWidget {
@@ -9,14 +10,17 @@ class PaymentDetailsBolt11 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bolt11 = paymentData.bolt11;
-    if (bolt11.isNotEmpty) {
-      return ShareablePaymentRow(
-        title: "Invoice",
-        sharedValue: bolt11,
-      );
-    } else {
-      return Container();
-    }
+    final bolt11 = paymentData.details?.maybeMap(
+          lightning: (details) => details.bolt11,
+          orElse: () => "",
+        ) ??
+        "";
+
+    if (bolt11.isEmpty) return const SizedBox.shrink();
+
+    return ShareablePaymentRow(
+      title: "Invoice",
+      sharedValue: bolt11,
+    );
   }
 }

--- a/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_description.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_description.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/cubit/payments/models/models.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 
 class PaymentDetailsDialogDescription extends StatelessWidget {
   final PaymentData paymentData;
@@ -12,7 +13,13 @@ class PaymentDetailsDialogDescription extends StatelessWidget {
     final themeData = Theme.of(context);
 
     final title = paymentData.title;
-    final description = paymentData.description;
+    final description = paymentData.details?.maybeMap(
+          lightning: (details) => details.description,
+          bitcoin: (details) => details.description,
+          liquid: (details) => details.description,
+          orElse: () => "",
+        ) ??
+        "";
     if (description.isEmpty || title == description) {
       return const SizedBox.shrink();
     }

--- a/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_preimage.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_preimage.dart
@@ -1,6 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/cubit/payments/models/models.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/widgets/shareable_payment_row.dart';
 
 class PaymentDetailsPreimage extends StatelessWidget {
@@ -10,16 +11,18 @@ class PaymentDetailsPreimage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final texts = context.texts();
+    final paymentPreimage = paymentData.details?.maybeMap(
+          lightning: (details) => details.preimage,
+          orElse: () => "",
+        ) ??
+        "";
 
-    final paymentPreimage = paymentData.preimage;
-    if (paymentPreimage.isNotEmpty) {
-      return ShareablePaymentRow(
-        title: texts.payment_details_dialog_single_info_pre_image,
-        sharedValue: paymentPreimage,
-      );
-    } else {
-      return Container();
-    }
+    if (paymentPreimage.isEmpty) return const SizedBox.shrink();
+
+    final texts = context.texts();
+    return ShareablePaymentRow(
+      title: texts.payment_details_dialog_single_info_pre_image,
+      sharedValue: paymentPreimage,
+    );
   }
 }

--- a/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_refund_tx_fee_amount.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 
 class PaymentDetailsDialogRefundTxAmount extends StatelessWidget {
   final PaymentData paymentData;
@@ -20,10 +21,16 @@ class PaymentDetailsDialogRefundTxAmount extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final refundTxAmountSat = paymentData.details.maybeMap(
+      bitcoin: (details) => details.refundTxAmountSat?.toInt() ?? 0,
+      lightning: (details) => details.refundTxAmountSat?.toInt() ?? 0,
+      orElse: () => 0,
+    );
+
+    if (refundTxAmountSat == 0) return const SizedBox.shrink();
+
     final texts = context.texts();
     final themeData = Theme.of(context);
-
-    if (paymentData.refundTxAmountSat == 0) return const SizedBox.shrink();
 
     return Container(
       height: 36.0,
@@ -48,7 +55,7 @@ class PaymentDetailsDialogRefundTxAmount extends StatelessWidget {
               child: BlocBuilder<CurrencyCubit, CurrencyState>(builder: (context, state) {
                 final amountSats = BitcoinCurrency.fromTickerSymbol(
                   state.bitcoinTicker,
-                ).format(paymentData.refundTxAmountSat);
+                ).format(refundTxAmountSat);
                 return AutoSizeText(
                   paymentData.paymentType == PaymentType.receive
                       ? texts.payment_details_dialog_amount_positive(amountSats)

--- a/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_swap_id.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/src/payment_details_dialog_swap_id.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
-import 'package:l_breez/cubit/payments/models/models.dart';
+import 'package:l_breez/cubit/payments/models/payment/payment_data.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/widgets/shareable_payment_row.dart';
 
 class PaymentDetailsSwapId extends StatelessWidget {
@@ -9,13 +10,19 @@ class PaymentDetailsSwapId extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final swapId = paymentData.swapId;
-    return swapId.isNotEmpty
-        ? ShareablePaymentRow(
-            // TODO: Move this message to Breez-Translations
-            title: "Swap ID",
-            sharedValue: swapId,
-          )
-        : const SizedBox.shrink();
+    final swapId = paymentData.details?.maybeMap(
+          bitcoin: (details) => details.swapId,
+          lightning: (details) => details.swapId,
+          orElse: () => "",
+        ) ??
+        "";
+
+    if (swapId.isEmpty) return const SizedBox.shrink();
+
+    return ShareablePaymentRow(
+      // TODO: Move this message to Breez-Translations
+      title: "Swap ID",
+      sharedValue: swapId,
+    );
   }
 }

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -81,7 +81,10 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
         minHeight: minHeight,
         paymentFunc: () async {
           try {
-            final prepareSendResponse = await paymentsCubit.prepareSendPayment(widget.invoice.bolt11);
+            final prepareSendResponse = await paymentsCubit.prepareSendPayment(
+              destination: widget.invoice.bolt11,
+              amountSat: BigInt.from(_amountToPay!),
+            );
             return await paymentsCubit.sendPayment(prepareSendResponse);
           } catch (e) {
             rethrow;

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -106,37 +106,37 @@ class BreezSDKLiquid {
       (event) async {
         if (event is liquid_sdk.SdkEvent_PaymentFailed) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Payment Failed. ${event.details.swapId}", level: "WARN"),
+            liquid_sdk.LogEntry(line: "Payment Failed. ${event.details}", level: "WARN"),
           );
           _paymentResultStream.addError(PaymentException(event.details));
         }
         if (event is liquid_sdk.SdkEvent_PaymentPending) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Payment Pending. ${event.details.swapId}", level: "INFO"),
+            liquid_sdk.LogEntry(line: "Payment Pending. ${event.details}", level: "INFO"),
           );
           _paymentResultStream.add(event.details);
         }
         if (event is liquid_sdk.SdkEvent_PaymentRefunded) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Payment Refunded. ${event.details.swapId}", level: "INFO"),
+            liquid_sdk.LogEntry(line: "Payment Refunded. ${event.details}", level: "INFO"),
           );
           _paymentResultStream.add(event.details);
         }
         if (event is liquid_sdk.SdkEvent_PaymentRefundPending) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Pending Payment Refund. ${event.details.swapId}", level: "INFO"),
+            liquid_sdk.LogEntry(line: "Pending Payment Refund. ${event.details}", level: "INFO"),
           );
           _paymentResultStream.add(event.details);
         }
         if (event is liquid_sdk.SdkEvent_PaymentSucceeded) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Payment Succeeded. ${event.details.swapId}", level: "INFO"),
+            liquid_sdk.LogEntry(line: "Payment Succeeded. ${event.details}", level: "INFO"),
           );
           _paymentResultStream.add(event.details);
         }
         if (event is liquid_sdk.SdkEvent_PaymentWaitingConfirmation) {
           _logStreamController.add(
-            liquid_sdk.LogEntry(line: "Payment Waiting Confirmation. ${event.details.swapId}", level: "INFO"),
+            liquid_sdk.LogEntry(line: "Payment Waiting Confirmation. ${event.details}", level: "INFO"),
           );
           _paymentResultStream.add(event.details);
         }

--- a/packages/service_injector/pubspec.lock
+++ b/packages/service_injector/pubspec.lock
@@ -54,10 +54,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: f323bc8b900e59ab16e8a0b1bdd196ffa8997a0d
+      resolved-ref: "9353761f3d8824e2d85733b078da2145be3534e9"
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.2.2-dev8"
+    version: "0.2.2-dev10"
   breez_logger:
     dependency: "direct main"
     description:
@@ -301,10 +301,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: a7c0328f9fe8dfea760986dae18ccce0370f393d
+      resolved-ref: "96e8a30294100a386d362b00e17ce2cf5f627970"
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.2.1"
+    version: "0.2.2-dev10"
   flutter_rust_bridge:
     dependency: transitive
     description:

--- a/packages/service_injector/pubspec.lock
+++ b/packages/service_injector/pubspec.lock
@@ -54,10 +54,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: c9e564d78147b49d615bc7b2577c8451082254c8
+      resolved-ref: f323bc8b900e59ab16e8a0b1bdd196ffa8997a0d
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.2.1"
+    version: "0.2.2-dev8"
   breez_logger:
     dependency: "direct main"
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: f703c4b50e253e53efc604d50281bbaefe82d615856f8ae1e7625518ae252e98
+      sha256: "7beb9cb4690916a6c4fd151d91dba53555ea258dbc029dd5f1bfba2e7bd32b86"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   flutter_secure_storage:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1059,18 +1059,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1154,10 +1154,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   melos:
     dependency: "direct main"
     description:
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1869,10 +1869,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -416,10 +416,10 @@ packages:
     dependency: "direct main"
     description:
       name: duration
-      sha256: "0548a12d235dab185c677ef660995f23fdc06a02a2b984aa23805f6a03d82815"
+      sha256: "8b9020df63d2894f29fe250b60ca5b7f9e943d4a3cf766c2b161efeb617a0ea3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.13"
+    version: "3.0.15"
   email_validator:
     dependency: "direct main"
     description:
@@ -1059,18 +1059,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1154,10 +1154,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   melos:
     dependency: "direct main"
     description:
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1186,10 +1186,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: b8c0e9afcfd52534f85ec666f3d52156f560b5e6c25b1e3d4fe2087763607926
+      sha256: "6ac2913ad98c83f558d2c8a55bc8f511bdcf28b86639701c04b04c16da1e9ee1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.2.1"
   mockito:
     dependency: "direct main"
     description:
@@ -1597,10 +1597,10 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -1869,10 +1869,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR applies breaking changes from
- https://github.com/breez/breez-sdk-liquid/pull/414

Full integration will be in scope of another PR:
- https://github.com/breez/misty-breez/issues/156

### Breaking changes:
* `PrepareReceivePaymentResponse`, `PrepareReceiveOnchainResponse` consolidated into `PrepareReceiveResponse`
* `ReceiveOnchainResponse` consolidated into `ReceivePaymentResponse`
* `PrepareSendRequest` now has `destination` & an optional `amountSat`
* `prepareRes` fields on structs got renamed to `prepareResponse`
* `PrepareReceiveResponse` now has `paymentMethod`

### Changelist:
- Apply "Send/Receive: Add BIP21 support" changes 
- Log `PaymentData` itself on SDK event listener  4334f6a
- Remove obsolete matchers on payment title e9b55ad
- Update `PaymentData` fields  e314fea
    - Added `toJson` & `fromJson` extensions on `PaymentDetails` 5d197737f2ff44f08fcf6e1943d638c7578908a2
- Create a `maybeMap` extension of `PaymentDetails` 380be17
- Reflect `PaymentData` changes and rely on `maybeMap` extension for matching values by details type 2fcc825
- Update payment tracking logic ee80686
- Get payment description from payment details 4106fcb
- Apply rename changes 92b08058c06432ba501aaa6dfac2aabd9e5f521e
  - `amountSat` -> `payerAmountSat`
  - `PaymentDetails_Liquid.address` -> `PaymentDetails_Liquid.destination`
- Update dependencies to latest & embed breez-sdk-liquid framework d77acdd8b17de78ffc6fe19a63a0c0010ef1e9c6


### Other changes:
* Re-enabled `description` on `ReceiveChainSwapPage`