### PR TITLE
Flutter 3.24 linter warnings

### DIFF
--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "748c7837511d0e6a507737353af268484e1745e2",
+        "version" : "1.2024011601.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "076b241a625e25eac22f8849be256dfb960fcdfe",
+        "version" : "10.19.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "9d17b500cd98d9a7009751ad62f802e152e97021",
+        "version" : "10.26.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "16244d177c4e989f87b25e9db1012b382cfedc55",
+        "version" : "10.25.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "0382ca27f22fb3494cf657d8dc356dc282cd1193",
+        "version" : "3.4.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -67,7 +67,7 @@ class InputHandler extends Handler {
       _setLoading(false);
       if (error != null) {
         final context = contextProvider?.getBuildContext();
-        if (context != null) {
+        if (context != null && context.mounted) {
           showFlushbar(context, message: extractExceptionMessage(error, context.texts()));
         } else {
           _log.info("Skipping handling of error: $error because context is null");
@@ -110,7 +110,7 @@ class InputHandler extends Handler {
         firstPaymentItemKey,
       ),
     ).then((message) {
-      if (message != null) {
+      if (message != null && context.mounted) {
         showFlushbar(context, message: message);
       }
     });

--- a/lib/routes/chainswap/receive/chainswap_qr_dialog.dart
+++ b/lib/routes/chainswap/receive/chainswap_qr_dialog.dart
@@ -74,7 +74,9 @@ class ChainSwapQrDialogState extends State<ChainSwapQrDialog> with SingleTickerP
         });
       }).catchError((e) {
         _log.warning("Failed to track payment", e);
-        showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        if (mounted) {
+          showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        }
         onFinish(false);
       });
     }

--- a/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
@@ -90,13 +90,15 @@ class _SendChainSwapConfirmationPageState extends State<SendChainSwapConfirmatio
       amountSat: widget.amountSat,
     );
     _fetchFeeOptionsFuture.then((feeOptions) {
-      final accountState = context.read<AccountCubit>().state;
-      setState(() {
-        affordableFees = feeOptions
-            .where((f) => f.isAffordable(balanceSat: accountState.balance, amountSat: widget.amountSat))
-            .toList();
-        selectedFeeIndex = (affordableFees.length / 2).floor();
-      });
+      if (mounted) {
+        final accountState = context.read<AccountCubit>().state;
+        setState(() {
+          affordableFees = feeOptions
+              .where((f) => f.isAffordable(balanceSat: accountState.balance, amountSat: widget.amountSat))
+              .toList();
+          selectedFeeIndex = (affordableFees.length / 2).floor();
+        });
+      }
     }, onError: (error, stackTrace) {
       setState(() {
         affordableFees = <SendChainSwapFeeOption>[];

--- a/lib/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/chainswap/send/widgets/bitcoin_address_text_form_field.dart
@@ -32,19 +32,21 @@ class BitcoinAddressTextFormField extends TextFormField {
               onPressed: () async {
                 Navigator.pushNamed<String>(context, QRScan.routeName).then(
                   (barcode) {
-                    _log.info("Scanned string: '$barcode'");
-                    final address = BitcoinAddressInfo.fromScannedString(barcode).address;
-                    _log.info("BitcoinAddressInfoFromScannedString: '$address'");
-                    if (address == null) return;
-                    if (address.isEmpty) {
-                      showFlushbar(
-                        context,
-                        message: context.texts().withdraw_funds_error_qr_code_not_detected,
-                      );
-                      return;
+                    if (context.mounted) {
+                      _log.info("Scanned string: '$barcode'");
+                      final address = BitcoinAddressInfo.fromScannedString(barcode).address;
+                      _log.info("BitcoinAddressInfoFromScannedString: '$address'");
+                      if (address == null) return;
+                      if (address.isEmpty) {
+                        showFlushbar(
+                          context,
+                          message: context.texts().withdraw_funds_error_qr_code_not_detected,
+                        );
+                        return;
+                      }
+                      controller.text = address;
+                      _onAddressChanged(context, validatorHolder, address);
                     }
-                    controller.text = address;
-                    _onAddressChanged(context, validatorHolder, address);
                   },
                 );
               },

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -74,7 +74,9 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
         });
       }).catchError((e) {
         _log.warning("Failed to track payment", e);
-        showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        if (mounted) {
+          showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        }
         onFinish(false);
       });
     }

--- a/lib/routes/create_invoice/widgets/successful_payment.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment.dart
@@ -26,7 +26,11 @@ class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute> with Wid
           builder: (context) => SuccessfulPaymentDialog(
             onPrint: widget.onPrint,
           ),
-        ).whenComplete(() => Navigator.of(context).pop());
+        ).whenComplete(() {
+          if (mounted) {
+            Navigator.of(context).pop();
+          }
+        });
       });
     }
   }

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -26,7 +26,6 @@ class Home extends StatefulWidget {
 
 class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final GlobalKey<HomeDrawerState> _drawerKey = GlobalKey<HomeDrawerState>();
   final GlobalKey firstPaymentItemKey = GlobalKey();
   final ScrollController scrollController = ScrollController();
   final handlers = <Handler>[];
@@ -95,18 +94,15 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
             child: Scaffold(
               resizeToAvoidBottomInset: false,
               key: _scaffoldKey,
-              appBar: HomeAppBar(
-                themeData: themeData,
-                scaffoldKey: _scaffoldKey,
-              ),
+              appBar: HomeAppBar(themeData: themeData, scaffoldKey: _scaffoldKey),
               drawerEnableOpenDragGesture: true,
               drawerDragStartBehavior: DragStartBehavior.down,
               drawerEdgeDragWidth: mediaSize.width,
-              drawer: HomeDrawer(key: _drawerKey),
+              drawer: const HomeDrawer(),
               bottomNavigationBar: BottomActionsBar(firstPaymentItemKey),
               floatingActionButton: QrActionButton(firstPaymentItemKey),
               floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-              body: _drawerKey.currentState?.screen() ?? AccountPage(firstPaymentItemKey, scrollController),
+              body: AccountPage(firstPaymentItemKey, scrollController),
             ),
           ),
         ),

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -66,7 +66,7 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
           ),
       child: PopScope(
         canPop: false,
-        onPopInvoked: (bool didPop) async {
+        onPopInvokedWithResult: (bool didPop, Object? result) async {
           if (didPop) {
             return;
           }

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -31,12 +31,16 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
                   onTap: () async {
                     // TODO - Handle the case accountMnemonic is null as restoreMnemonic is now nullable
                     await ServiceInjector().credentialsManager.restoreMnemonic().then(
-                          (accountMnemonic) => Navigator.pushNamed(
+                      (accountMnemonic) {
+                        if (context.mounted) {
+                          return Navigator.pushNamed(
                             context,
                             MnemonicsConfirmationPage.routeName,
                             arguments: accountMnemonic,
-                          ),
-                        );
+                          );
+                        }
+                      },
+                    );
                   },
                 ),
               );

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -9,114 +9,64 @@ import 'package:l_breez/routes/home/widgets/drawer/breez_navigation_drawer.dart'
 import 'package:l_breez/routes/security/security_page.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 
-class HomeDrawer extends StatefulWidget {
+class HomeDrawer extends StatelessWidget {
   const HomeDrawer({super.key});
 
   @override
-  State<HomeDrawer> createState() => HomeDrawerState();
-}
-
-class HomeDrawerState extends State<HomeDrawer> {
-  final Set<String> _hiddenRoutes = {''};
-  final List<DrawerItemConfig> _screens = [
-    const DrawerItemConfig("breezHome", "Misty Breez", ""),
-  ];
-  final Map<String, Widget> _screenBuilders = {};
-
-  String _activeScreen = "breezHome";
-
-  @override
   Widget build(BuildContext context) {
+    final texts = context.texts();
+
     return BlocBuilder<UserProfileCubit, UserProfileState>(
       builder: (context, user) {
         final settings = user.profileSettings;
 
         return BreezNavigationDrawer(
-          _drawerGroupedItems(settings),
-          (screenName) => _handleNavigation(context, screenName),
+          [
+            DrawerItemConfigGroup([
+              DrawerItemConfig(
+                "",
+                texts.home_drawer_item_title_balance,
+                "src/icon/balance.png",
+                isSelected: settings.appMode == AppMode.balance,
+                onItemSelected: (_) {
+                  // TODO add protectAdminAction
+                },
+              )
+            ]),
+            DrawerItemConfigGroup(
+              [
+                DrawerItemConfig(
+                  FiatCurrencySettings.routeName,
+                  texts.home_drawer_item_title_fiat_currencies,
+                  "src/icon/fiat_currencies.png",
+                ),
+                DrawerItemConfig(
+                  SecurityPage.routeName,
+                  texts.home_drawer_item_title_security_and_backup,
+                  "src/icon/security.png",
+                ),
+                DrawerItemConfig(
+                  DevelopersView.routeName,
+                  texts.home_drawer_item_title_developers,
+                  "src/icon/developers.png",
+                ),
+              ],
+              groupTitle: texts.home_drawer_item_title_preferences,
+              groupAssetImage: "",
+              isExpanded: settings.expandPreferences,
+            ),
+          ],
+          (routeName) {
+            Navigator.of(context).pushNamed(routeName).then(
+              (message) {
+                if (message != null && message is String && context.mounted) {
+                  showFlushbar(context, message: message);
+                }
+              },
+            );
+          },
         );
       },
     );
-  }
-
-  List<DrawerItemConfigGroup> _drawerGroupedItems(UserProfileSettings settings) {
-    final texts = context.texts();
-
-    return [
-      ...[
-        DrawerItemConfigGroup([
-          DrawerItemConfig(
-            "",
-            texts.home_drawer_item_title_balance,
-            "src/icon/balance.png",
-            isSelected: settings.appMode == AppMode.balance,
-            onItemSelected: (_) {
-              // TODO add protectAdminAction
-            },
-          )
-        ]),
-      ],
-      DrawerItemConfigGroup(
-        _filterItems(_drawerConfigToFilter()),
-        groupTitle: texts.home_drawer_item_title_preferences,
-        groupAssetImage: "",
-        isExpanded: settings.expandPreferences,
-      ),
-    ];
-  }
-
-  void _handleNavigation(
-    BuildContext context,
-    String screenName,
-  ) {
-    if (_screens.map((sc) => sc.name).contains(screenName)) {
-      setState(() {
-        _activeScreen = screenName;
-      });
-    } else {
-      Navigator.of(context).pushNamed(screenName).then((message) {
-        if (message != null && message is String) {
-          showFlushbar(context, message: message);
-        }
-      });
-    }
-  }
-
-  List<DrawerItemConfig> _drawerConfigToFilter() {
-    final texts = context.texts();
-
-    return [
-      DrawerItemConfig(
-        FiatCurrencySettings.routeName,
-        texts.home_drawer_item_title_fiat_currencies,
-        "src/icon/fiat_currencies.png",
-      ),
-      DrawerItemConfig(
-        SecurityPage.routeName,
-        texts.home_drawer_item_title_security_and_backup,
-        "src/icon/security.png",
-      ),
-      ..._drawerConfigAdvancedFlavorItems(),
-    ];
-  }
-
-  List<DrawerItemConfig> _drawerConfigAdvancedFlavorItems() {
-    final texts = context.texts();
-
-    return [
-      DrawerItemConfig(
-        DevelopersView.routeName,
-        texts.home_drawer_item_title_developers,
-        "src/icon/developers.png",
-      ),
-    ];
-  }
-
-  List<DrawerItemConfig> _filterItems(List<DrawerItemConfig> items) {
-    return items.where((c) => !_hiddenRoutes.contains(c.name)).toList();
-  }
-
-  Widget? screen() {
-    return _screenBuilders[_activeScreen];
   }
 }

--- a/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
@@ -43,13 +43,15 @@ class PaymentsFilterCalendar extends StatelessWidget {
                     context: context,
                     builder: (_) => CalendarDialog(firstDate!),
                   ).then((result) {
-                    final paymentsCubit = context.read<PaymentsCubit>();
-                    if (result != null) {
-                      paymentsCubit.changePaymentFilter(
-                        filters: filter,
-                        fromTimestamp: result[0].millisecondsSinceEpoch,
-                        toTimestamp: result[1].millisecondsSinceEpoch,
-                      );
+                    if (context.mounted) {
+                      final paymentsCubit = context.read<PaymentsCubit>();
+                      if (result != null) {
+                        paymentsCubit.changePaymentFilter(
+                          filters: filter,
+                          fromTimestamp: result[0].millisecondsSinceEpoch,
+                          toTimestamp: result[1].millisecondsSinceEpoch,
+                        );
+                      }
                     }
                   })
                 : ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -44,7 +44,7 @@ class QrActionButton extends StatelessWidget {
       (barcode) {
         _log.info("Scanned string: '$barcode'");
         if (barcode == null) return;
-        if (barcode.isEmpty) {
+        if (barcode.isEmpty && context.mounted) {
           showFlushbar(
             context,
             message: texts.qr_action_button_error_code_not_detected,

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -25,7 +25,7 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
 
     return PopScope(
       canPop: _currentPage == 1,
-      onPopInvoked: (_) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
         if (_currentPage > 1) {
           FocusScope.of(context).requestFocus(FocusNode());
           setState(() {

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -17,7 +17,7 @@ Future<LNURLPageResult?> handleAuthRequest(
 ) async {
   return promptAreYouSure(context, null, LoginText(domain: reqData.domain)).then(
     (permitted) async {
-      if (permitted == true) {
+      if (permitted == true && context.mounted) {
         final texts = context.texts();
         final navigator = Navigator.of(context);
         final loaderRoute = createLoaderRoute(context);

--- a/lib/routes/security/auto_lock_mixin.dart
+++ b/lib/routes/security/auto_lock_mixin.dart
@@ -11,13 +11,15 @@ mixin AutoLockMixin<T extends StatefulWidget> on State<T> {
     final securityCubit = context.read<cubit.SecurityCubit>();
     securityCubit.stream.distinct().where((state) => state.lockState == cubit.LockState.locked).listen(
       (_) {
-        Navigator.of(context, rootNavigator: true).push(
-          FadeInRoute(
-            builder: (_) => const LockScreen(
-              authorizedAction: AuthorizedAction.popPage,
+        if (mounted) {
+          Navigator.of(context, rootNavigator: true).push(
+            FadeInRoute(
+              builder: (_) => const LockScreen(
+                authorizedAction: AuthorizedAction.popPage,
+              ),
             ),
-          ),
-        );
+          );
+        }
       },
     );
   }

--- a/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
+++ b/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
@@ -38,22 +38,24 @@ class SecurityMnemonicsManagement extends StatelessWidget {
             // TODO - Handle the case accountMnemonic is null as restoreMnemonic is now nullable
             await ServiceInjector().credentialsManager.restoreMnemonic().then(
               (accountMnemonic) {
-                if (securityState.verificationStatus == VerificationStatus.unverified) {
-                  Navigator.pushNamed(
-                    context,
-                    MnemonicsConfirmationPage.routeName,
-                    arguments: accountMnemonic,
-                  );
-                } else {
-                  Navigator.push(
-                    context,
-                    FadeInRoute(
-                      builder: (context) => MnemonicsPage(
-                        mnemonics: accountMnemonic!,
-                        viewMode: true,
+                if (context.mounted) {
+                  if (securityState.verificationStatus == VerificationStatus.unverified) {
+                    Navigator.pushNamed(
+                      context,
+                      MnemonicsConfirmationPage.routeName,
+                      arguments: accountMnemonic,
+                    );
+                  } else {
+                    Navigator.push(
+                      context,
+                      FadeInRoute(
+                        builder: (context) => MnemonicsPage(
+                          mnemonics: accountMnemonic!,
+                          viewMode: true,
+                        ),
                       ),
-                    ),
-                  );
+                    );
+                  }
                 }
               },
             );

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -54,8 +54,8 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
     });
 
     widget._currencyCubit.fetchExchangeRates().catchError((value) {
-      final texts = context.texts();
       if (mounted) {
+        final texts = context.texts();
         setState(() {
           Navigator.pop(context);
           showFlushbar(

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -56,7 +56,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (_) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
         if (_state == PaymentRequestState.processingPayment) {
           return;
         } else {

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -110,7 +110,9 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
         if (_currentRoute != null && _currentRoute!.isActive) {
           navigator.removeRoute(_currentRoute!);
         }
-        showFlushbar(context, message: extractExceptionMessage(err, texts));
+        if (mounted) {
+          showFlushbar(context, message: extractExceptionMessage(err, texts));
+        }
       }
     });
   }


### PR DESCRIPTION
This PR addresses linter warning and deprecations that came with Flutter 3.24

- Addressed [use_build_context_synchronously](https://dart.dev/tools/linter-rules/use_build_context_synchronously) linter warnings 38eeb14bc951c81cc8487a48811d835b21b30cfa
  - #132
- Replace `onPopInvoked` with `onPopInvokedWithResult` e32db7b6d5c4b08a1f66637a2acc51cf6517380a
  - [Generic types in PopScope](https://docs.flutter.dev/release/breaking-changes/popscope-with-result)