### PR TITLE
Refactor `HomeDrawer`

### DIFF
--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -26,7 +26,6 @@ class Home extends StatefulWidget {
 
 class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final GlobalKey<HomeDrawerState> _drawerKey = GlobalKey<HomeDrawerState>();
   final GlobalKey firstPaymentItemKey = GlobalKey();
   final ScrollController scrollController = ScrollController();
   final handlers = <Handler>[];
@@ -95,18 +94,15 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
             child: Scaffold(
               resizeToAvoidBottomInset: false,
               key: _scaffoldKey,
-              appBar: HomeAppBar(
-                themeData: themeData,
-                scaffoldKey: _scaffoldKey,
-              ),
+              appBar: HomeAppBar(themeData: themeData, scaffoldKey: _scaffoldKey),
               drawerEnableOpenDragGesture: true,
               drawerDragStartBehavior: DragStartBehavior.down,
               drawerEdgeDragWidth: mediaSize.width,
-              drawer: HomeDrawer(key: _drawerKey),
+              drawer: const HomeDrawer(),
               bottomNavigationBar: BottomActionsBar(firstPaymentItemKey),
               floatingActionButton: QrActionButton(firstPaymentItemKey),
               floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-              body: _drawerKey.currentState?.screen() ?? AccountPage(firstPaymentItemKey, scrollController),
+              body: AccountPage(firstPaymentItemKey, scrollController),
             ),
           ),
         ),

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -9,114 +9,64 @@ import 'package:l_breez/routes/home/widgets/drawer/breez_navigation_drawer.dart'
 import 'package:l_breez/routes/security/security_page.dart';
 import 'package:l_breez/widgets/flushbar.dart';
 
-class HomeDrawer extends StatefulWidget {
+class HomeDrawer extends StatelessWidget {
   const HomeDrawer({super.key});
 
   @override
-  State<HomeDrawer> createState() => HomeDrawerState();
-}
-
-class HomeDrawerState extends State<HomeDrawer> {
-  final Set<String> _hiddenRoutes = {''};
-  final List<DrawerItemConfig> _screens = [
-    const DrawerItemConfig("breezHome", "Misty Breez", ""),
-  ];
-  final Map<String, Widget> _screenBuilders = {};
-
-  String _activeScreen = "breezHome";
-
-  @override
   Widget build(BuildContext context) {
+    final texts = context.texts();
+
     return BlocBuilder<UserProfileCubit, UserProfileState>(
       builder: (context, user) {
         final settings = user.profileSettings;
 
         return BreezNavigationDrawer(
-          _drawerGroupedItems(settings),
-          (screenName) => _handleNavigation(context, screenName),
+          [
+            DrawerItemConfigGroup([
+              DrawerItemConfig(
+                "",
+                texts.home_drawer_item_title_balance,
+                "src/icon/balance.png",
+                isSelected: settings.appMode == AppMode.balance,
+                onItemSelected: (_) {
+                  // TODO add protectAdminAction
+                },
+              )
+            ]),
+            DrawerItemConfigGroup(
+              [
+                DrawerItemConfig(
+                  FiatCurrencySettings.routeName,
+                  texts.home_drawer_item_title_fiat_currencies,
+                  "src/icon/fiat_currencies.png",
+                ),
+                DrawerItemConfig(
+                  SecurityPage.routeName,
+                  texts.home_drawer_item_title_security_and_backup,
+                  "src/icon/security.png",
+                ),
+                DrawerItemConfig(
+                  DevelopersView.routeName,
+                  texts.home_drawer_item_title_developers,
+                  "src/icon/developers.png",
+                ),
+              ],
+              groupTitle: texts.home_drawer_item_title_preferences,
+              groupAssetImage: "",
+              isExpanded: settings.expandPreferences,
+            ),
+          ],
+          (routeName) {
+            Navigator.of(context).pushNamed(routeName).then(
+              (message) {
+                if (message != null && message is String && context.mounted) {
+                  showFlushbar(context, message: message);
+                }
+              },
+            );
+          },
         );
       },
     );
-  }
-
-  List<DrawerItemConfigGroup> _drawerGroupedItems(UserProfileSettings settings) {
-    final texts = context.texts();
-
-    return [
-      ...[
-        DrawerItemConfigGroup([
-          DrawerItemConfig(
-            "",
-            texts.home_drawer_item_title_balance,
-            "src/icon/balance.png",
-            isSelected: settings.appMode == AppMode.balance,
-            onItemSelected: (_) {
-              // TODO add protectAdminAction
-            },
-          )
-        ]),
-      ],
-      DrawerItemConfigGroup(
-        _filterItems(_drawerConfigToFilter()),
-        groupTitle: texts.home_drawer_item_title_preferences,
-        groupAssetImage: "",
-        isExpanded: settings.expandPreferences,
-      ),
-    ];
-  }
-
-  void _handleNavigation(
-    BuildContext context,
-    String screenName,
-  ) {
-    if (_screens.map((sc) => sc.name).contains(screenName)) {
-      setState(() {
-        _activeScreen = screenName;
-      });
-    } else {
-      Navigator.of(context).pushNamed(screenName).then((message) {
-        if (message != null && message is String) {
-          showFlushbar(context, message: message);
-        }
-      });
-    }
-  }
-
-  List<DrawerItemConfig> _drawerConfigToFilter() {
-    final texts = context.texts();
-
-    return [
-      DrawerItemConfig(
-        FiatCurrencySettings.routeName,
-        texts.home_drawer_item_title_fiat_currencies,
-        "src/icon/fiat_currencies.png",
-      ),
-      DrawerItemConfig(
-        SecurityPage.routeName,
-        texts.home_drawer_item_title_security_and_backup,
-        "src/icon/security.png",
-      ),
-      ..._drawerConfigAdvancedFlavorItems(),
-    ];
-  }
-
-  List<DrawerItemConfig> _drawerConfigAdvancedFlavorItems() {
-    final texts = context.texts();
-
-    return [
-      DrawerItemConfig(
-        DevelopersView.routeName,
-        texts.home_drawer_item_title_developers,
-        "src/icon/developers.png",
-      ),
-    ];
-  }
-
-  List<DrawerItemConfig> _filterItems(List<DrawerItemConfig> items) {
-    return items.where((c) => !_hiddenRoutes.contains(c.name)).toList();
-  }
-
-  Widget? screen() {
-    return _screenBuilders[_activeScreen];
   }
 }


### PR DESCRIPTION
This PR has refactoring changes on `HomeDrawer` widget.

### Changelist:
* Convert `HomeDrawer` into a `StatelessWidget`
* Build the widget tree directly without relying on helper methods
* Remove unused parts
  - `_hiddenRoutes`,
  - `_drawerKey` &
  - everything related to screens.