### PR TITLE
Address iOS online build issues

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -99,6 +99,13 @@ jobs:
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal
 
+      - name: Install Protoc
+        if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: 🏗️ Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -202,9 +202,11 @@ jobs:
       - name: 🔨 Build Android binaries
         if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
         working-directory: breez-sdk-liquid/lib/bindings/langs/flutter/
-        run: |
-          just build-android
-          just link
+        run: just build-android
+
+      - name: Copy the binaries to the needed location
+        working-directory: breez-sdk-liquid/lib/bindings/langs/flutter/
+        run: just copy-android
 
       - name: 🗂️ Populate Flutter tool's cache of binary artifacts.
         working-directory: lbreez

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -65,7 +65,7 @@ jobs:
   build-ios:
     needs: setup
     name: Build iOS
-    runs-on: macOS-latest
+    runs-on: macos-14
     env:
       SCHEME: Runner
       BUILD_CONFIGURATION: Release

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -207,9 +207,11 @@ jobs:
       - name: 🔨 Build iOS binaries
         if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
         working-directory: breez-sdk-liquid/lib/bindings/langs/flutter/
-        run: |
-          just build-apple
-          just link
+        run: just build-apple
+
+      - name: Copy the XCFramework to the needed location
+        working-directory: breez-sdk-liquid/lib/bindings/langs/flutter/
+        run: just copy-apple
 
       - name: 🗂️ Populate Flutter tool's cache of binary artifacts.
         working-directory: lbreez

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -96,6 +96,13 @@ jobs:
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal
 
+      - name: Install Protoc
+        if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: 🏗️ Setup Java
         uses: actions/setup-java@v4
         with:

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>export</string>
+	<key>method</key>
+	<string>app-store</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.breez.liquid.lBreez</key>
+		<string>mistybreez-dist-profile</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>teamID</key>
+	<string>F7R2LZH3W5</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -9,7 +9,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.breez.liquid.lBreez</key>
-		<string>mistybreez-dist-profile</string>
+		<string>Misty Breez Dist Profile</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution</string>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -779,7 +779,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.breez.liquid.lBreez;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "mistybreez-dist-profile";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Misty Breez Dist Profile";
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -289,7 +289,6 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				E8F7D4EE2C0737FE0018DB5D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -821,17 +820,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		E8F7D4EE2C0737FE0018DB5D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.26.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Flutter
-import UIKit
+import SwiftUI
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -13,7 +13,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(TeamIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<string>group.F7R2LZH3W5.com.breez.liquid.lBreez</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -9,6 +9,7 @@
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>
+		<string>NDEF</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/lib/main/bootstrap.dart
+++ b/lib/main/bootstrap.dart
@@ -49,7 +49,7 @@ Future<void> bootstrap(AppBuilder builder) async {
     // iOS Extension requirement
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       SharedPreferenceAppGroup.setAppGroup(
-        "group.${const String.fromEnvironment("APP_ID_PREFIX")}.com.breez.liquid.lBreez",
+        "group.F7R2LZH3W5.com.breez.liquid.lBreez",
       );
     }
 

--- a/packages/breez_sdk_liquid/lib/src/model/config.dart
+++ b/packages/breez_sdk_liquid/lib/src/model/config.dart
@@ -54,7 +54,7 @@ class AppConfig {
       path = workingDir.path;
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       final sharedDirectory = await AppGroupDirectory.getAppGroupDirectory(
-        "group.${const String.fromEnvironment("APP_ID_PREFIX")}.com.breez.liquid.lBreez",
+        "group.F7R2LZH3W5.com.breez.liquid.lBreez",
       );
       if (sharedDirectory == null) {
         throw Exception("Could not get shared directory");

--- a/packages/keychain/lib/src/keychain.dart
+++ b/packages/keychain/lib/src/keychain.dart
@@ -1,7 +1,12 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class KeyChain {
-  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+  final FlutterSecureStorage _storage = const FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock,
+      groupId: "group.${const String.fromEnvironment("APP_ID_PREFIX")}.com.breez.liquid.lBreez",
+    ),
+  );
 
   Future<String?> read(String key) {
     return _storage.read(key: key);

--- a/packages/keychain/lib/src/keychain.dart
+++ b/packages/keychain/lib/src/keychain.dart
@@ -4,7 +4,7 @@ class KeyChain {
   final FlutterSecureStorage _storage = const FlutterSecureStorage(
     iOptions: IOSOptions(
       accessibility: KeychainAccessibility.first_unlock,
-      groupId: "group.${const String.fromEnvironment("APP_ID_PREFIX")}.com.breez.liquid.lBreez",
+      groupId: "group.F7R2LZH3W5.com.breez.liquid.lBreez",
     ),
   );
 


### PR DESCRIPTION
Depends on:
- https://github.com/breez/breez-sdk-liquid/pull/447

This PR addresses build issues that prevented us from deploying to TestFlight and other required changes for the app to function as expected.

- Use "macos-14" runner which targets XCode 15.4 by default 
  - It is suggested to use XCode >= 15.3 to address this build error:
  ```
  Could not resolve package dependencies: Package.resolved file is corrupted or malformed; fix or delete the 
  file to continue: unknown 'PinsStorage' version '3' at '/Users/runner/work/l-***/l- 
  ***/l***/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'.
  ```
- Create `ExportOptions.plist`
- Install Protoc when building the library
- Add `NDEF` to `NFC` tag reader session formats
- Use shared keychain on iOS