### PR TITLE
Do not emit payment state changes unless there's been a change

### DIFF
--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -99,6 +99,44 @@ class PaymentData {
 
   @override
   String toString() => jsonEncode(toJson());
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        title,
+        description,
+        preimage,
+        bolt11,
+        swapId,
+        txId,
+        refundTxId,
+        paymentType,
+        paymentTime,
+        feeSat,
+        amountSat,
+        refundTxAmountSat,
+        status,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is PaymentData &&
+            id == other.id &&
+            title == other.title &&
+            description == other.description &&
+            preimage == other.preimage &&
+            bolt11 == other.bolt11 &&
+            swapId == other.swapId &&
+            txId == other.txId &&
+            refundTxId == other.refundTxId &&
+            paymentType == other.paymentType &&
+            paymentTime == other.paymentTime &&
+            feeSat == other.feeSat &&
+            amountSat == other.amountSat &&
+            refundTxAmountSat == other.refundTxAmountSat &&
+            status == other.status;
+  }
 }
 
 class _PaymentDataFactory {

--- a/lib/cubit/payments/models/payment/payment_filters.dart
+++ b/lib/cubit/payments/models/payment/payment_filters.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
 class PaymentFilters implements Exception {
@@ -49,4 +50,20 @@ class PaymentFilters implements Exception {
 
   @override
   String toString() => jsonEncode(toJson());
+
+  @override
+  int get hashCode => Object.hash(
+        filters?.map((type) => type.hashCode).toList() ?? [],
+        fromTimestamp,
+        toTimestamp,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is PaymentFilters &&
+            listEquals(filters, other.filters) &&
+            fromTimestamp == other.fromTimestamp &&
+            toTimestamp == other.toTimestamp;
+  }
 }

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -43,17 +43,12 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin {
       _liquidSdk.paymentsStream,
       paymentFiltersStream,
       (payments, paymentFilters) {
-        return PaymentsState(
+        return state.copyWith(
           payments: payments.map((e) => PaymentData.fromPayment(e, texts)).toList(),
           paymentFilters: paymentFilters,
         );
       },
-    ).distinct().listen(_updatePaymentsState);
-  }
-
-  void _updatePaymentsState(newState) {
-    _log.info("_updatePaymentsState\nPaymentsState changed: $newState");
-    emit(newState);
+    ).distinct().listen((newState) => emit(newState));
   }
 
   Future<PrepareSendResponse> prepareSendPayment(String invoice) async {

--- a/lib/cubit/payments/payments_state.dart
+++ b/lib/cubit/payments/payments_state.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:l_breez/cubit/payments/models/models.dart';
 
 class PaymentsState {
@@ -56,4 +57,18 @@ class PaymentsState {
 
   @override
   String toString() => jsonEncode(toJson());
+
+  @override
+  int get hashCode => Object.hash(
+        payments.map((payment) => payment.hashCode).toList(),
+        paymentFilters.hashCode,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is PaymentsState &&
+            listEquals(payments, other.payments) &&
+            paymentFilters == other.paymentFilters;
+  }
 }


### PR DESCRIPTION
Added equality operators to `PaymentsState` items, `PaymentData` & `PaymentFilters` so the state is updated on distinct `PaymentsState` events on `PaymentCubit`.