### PR TITLE
Use production .podspec of breez-sdk-liquid on CI workflow

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -157,6 +157,11 @@ jobs:
           path: 'breez-sdk-liquid'
           ref: ${{ needs.setup.outputs.liquid-sdk-ref }}
 
+      - name: Use production .podspec
+        if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
+        working-directory: breez-sdk-liquid/packages/flutter/ios/
+        run: mv flutter_breez_liquid.podspec.production flutter_breez_liquid.podspec
+
       - name: 🏗️ Rust cache
         if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Production `.podspec` of `breez-sdk-liquid` is used when building the SDK from git repository, this change allows devs to work locally against a locally built library without additional steps.