### PR TITLE
Use the latest notification plugin release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:23.4.1'
     // Import breez_sdk_liquid for notifications
     implementation("net.java.dev.jna:jna:5.14.0@aar")
-    implementation("com.github.breez:breez-sdk-liquid:0.2.2-dev14") {
+    implementation("com.github.breez:breez-sdk-liquid:latest.release") {
         exclude group:"net.java.dev.jna"
     }
     // Logging

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,7 +40,7 @@ end
 target 'NotificationService' do
   use_frameworks!
 
-  pod 'BreezSDKLiquid', '= 0.2.2-dev15'
+  pod 'BreezSDKLiquid'
   pod 'KeychainAccess'
   pod 'XCGLogger'
 end


### PR DESCRIPTION
This PR changes the podfile/gradle (BreezSDKLiquid/breez-sdk-liquid) notification plugin dependencies to use the latest release

(To be merged post 0.2.2 release)