### PR TITLE
Address `No space left on device` issues faced online build runners

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -47,6 +47,24 @@ jobs:
 
       - run: echo "set pre-setup output variables"
 
+      - name: Disk Cleanup
+        run: |
+          echo "::group::Free space before cleanup"
+          df -h --total
+          echo "::endgroup::"
+          echo "::group::Cleaned Files"
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "::endgroup::"
+          echo "::group::Free space after cleanup"
+          df -h --total
+          echo "::endgroup::"
+
   setup:
     name: Setup
     needs: pre-setup
@@ -76,6 +94,22 @@ jobs:
       FIREBASE_PLACEHOLDER_APP_ID: com.breez.liquid.lBreez
       GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
     steps:
+      - name: Disk Cleanup
+        run: |
+          echo "::group::Free space before cleanup"
+          df -hI
+          echo "::endgroup::"
+          echo "::group::Cleaned Files"
+          sudo rm -rf /Applications/Xcode_14.3.1.app
+          sudo rm -rf /Applications/Xcode_15.0.1.app
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          echo "::endgroup::"
+          echo "::group::Free space after cleanup"
+          df -hI
+          echo "::endgroup::"
+
       - name: 🏗️ Setup l-breez repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -283,5 +283,7 @@ jobs:
 
       - name: Remove Google Application Credentials file
         if: success() || failure()
-        working-directory: lbreez
-        run: rm -f google-application-credentials.json
+        run: |
+          if [ -d "lbreez" ] && [ -f "lbreez/google-application-credentials.json" ]; then
+            rm lbreez/google-application-credentials.json
+          fi

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -46,6 +46,24 @@ jobs:
 
       - run: echo "set pre-setup output variables"
 
+      - name: Disk Cleanup
+        run: |
+          echo "::group::Free space before cleanup"
+          df -h --total
+          echo "::endgroup::"
+          echo "::group::Cleaned Files"
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "::endgroup::"
+          echo "::group::Free space after cleanup"
+          df -h --total
+          echo "::endgroup::"
+
   setup:
     name: Setup
     needs: pre-setup
@@ -84,6 +102,23 @@ jobs:
       FIREBASE_PLACEHOLDER_APP_ID: com.breez.liquid.lBreez
       GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
     steps:
+      - name: Disk Cleanup
+        run: |
+          echo "::group::Free space before cleanup"
+          df -hI
+          echo "::endgroup::"
+          echo "::group::Cleaned Files"
+          sudo rm -rf /Users/runner/Library/Android/sdk
+          sudo rm -rf /Applications/Xcode_14.3.1.app
+          sudo rm -rf /Applications/Xcode_15.0.1.app
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          echo "::endgroup::"
+          echo "::group::Free space after cleanup"
+          df -hI
+          echo "::endgroup::"
+
       - name: 🏗️ Setup l-breez repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -322,5 +322,7 @@ jobs:
 
       - name: Remove Google Application Credentials file
         if: success() || failure()
-        working-directory: lbreez
-        run: rm -f google-application-credentials.json
+        run: |
+          if [ -d "lbreez" ] && [ -f "lbreez/google-application-credentials.json" ]; then
+            rm lbreez/google-application-credentials.json
+          fi


### PR DESCRIPTION
This PR addresses the `System.IO.IOException: No space left on device` issues encountered on online builds, which is caused by macOS runner image having ~40GB less available space with the latest update.

### Changelist:
- Cleanup runner disks on build workflows
  - Removes older XCode versions on Android & iOS workflows
  - Removes Android SDK on iOS workflow
  
### Other changelist:
- Remove Google Application credentials file only if it exists