### PR TITLE
Insufficient funds error

### DIFF
--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -25,6 +25,9 @@ String extractExceptionMessage(
     message = _localizedExceptionMessage(texts, message);
     return message;
   }
+  if (exception is PaymentError_InsufficientFunds) {
+    return texts.invoice_payment_validator_error_insufficient_local_balance;
+  }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
 }
 


### PR DESCRIPTION
Closes #175

This PR does not address the core issue but displays a more user friendly error message after user approves a payment they have no sufficient funds for, which they didn't know as the fees were not shown correctly.
See https://github.com/breez/misty-breez/issues/175#issuecomment-2343278728 for more information.

### Changes:
- Translate `PaymentError.InsufficientFunds()` errors to a human readable error message
