### PR TITLE
Breez Liquid SDK API Key integration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,6 +25,23 @@ if (flutterVersionName == null) {
     flutterVersionName = "1.0"
 }
 
+def dartDefines = [:]
+if (project.hasProperty('dart-defines')) {
+    // Decode dart-defines, which are comma-separated and encoded in Base64, and store them in a variable.
+    dartDefines = dartDefines + project.property('dart-defines')
+            .split(',')
+            .collectEntries { entry ->
+                def pair = new String(entry.decodeBase64(), 'UTF-8').split('=', 2)
+                [(pair.first()): pair.last()]
+            }
+}
+
+def envVariables = [
+        API_KEY: project.hasProperty('API_KEY')
+                ? API_KEY
+                : "${dartDefines.API_KEY}",
+]
+
 android {
     namespace = "com.breez.liquid.l_breez"
     compileSdkVersion 34
@@ -105,6 +122,7 @@ android {
         debug {
             signingConfig = signingConfigs.debug
             manifestPlaceholders = [appName: "Misty Breez - Debug"]
+            resValue "string", "breezApiKey", envVariables.API_KEY
             minifyEnabled = false
             shrinkResources = false
             applicationIdSuffix = ".debug"
@@ -113,6 +131,7 @@ android {
         release {
             signingConfig = signingConfigs.release
             manifestPlaceholders = [appName: "Misty Breez"]
+            resValue "string", "breezApiKey", envVariables.API_KEY
             // Enables code shrinking, obfuscation, and optimization for only
             // your project's release build type. Make sure to use a build
             // variant with `debuggable false`.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -151,6 +151,10 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
             android:resource="@color/breez_notification_color" />
+        <!-- Compile-time Variables -->
+        <meta-data
+            android:name="com.breez.liquid.l_breez.API_KEY"
+            android:value="@string/breezApiKey" />
     </application>
     <!-- Required to query activities that can process text, see:
     https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/breez/liquid/l_breez/BreezForegroundService.kt
+++ b/android/app/src/main/kotlin/com/breez/liquid/l_breez/BreezForegroundService.kt
@@ -34,9 +34,12 @@ class BreezForegroundService : SdkLogger, ForegroundService() {
     }
 
     override fun getConnectRequest(): ConnectRequest? {
+        val apiKey = applicationContext.getString(R.string.breezApiKey)
+        Logger.tag(TAG).trace { "API_KEY: $apiKey" }
         val config = defaultConfig(LiquidNetwork.MAINNET)
 
         config.workingDir = PathUtils.getDataDirectory(applicationContext)
+        config.breezApiKey = apiKey
 
         return readSecuredValue(
             applicationContext,

--- a/ios/NotificationService/NotificationService.swift
+++ b/ios/NotificationService/NotificationService.swift
@@ -8,6 +8,7 @@ class NotificationService: SDKNotificationService {
     fileprivate let TAG = "NotificationService"
     
     private let accountMnemonic: String = "account_mnemonic"
+    private let accountApiKey: String = "account_api_key"
     
     override init() {
         let logsDir = FileManager
@@ -33,10 +34,16 @@ class NotificationService: SDKNotificationService {
     }
     
     override func getConnectRequest() -> ConnectRequest? {
+        guard let apiKey = KeychainHelper.shared.getFlutterString(accessGroup: accessGroup, key: accountApiKey) else {
+            self.logger.log(tag: TAG, line: "API key not found", level: "ERROR")
+            return nil
+        }
+        self.logger.log(tag: TAG, line: "API_KEY: \(apiKey)", level: "TRACE")
         var config = defaultConfig(network: LiquidNetwork.mainnet)
         config.workingDir = FileManager
             .default.containerURL(forSecurityApplicationGroupIdentifier: accessGroup)!
             .path
+        config.breezApiKey = apiKey
         
         // Construct the ConnectRequest 
         guard let mnemonic = KeychainHelper.shared.getFlutterString(accessGroup: accessGroup, key: accountMnemonic) else {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,8 +1,7 @@
 PODS:
   - app_group_directory (1.0.0):
     - Flutter
-  - BreezSDKLiquid (0.2.1):
-    - Flutter
+  - BreezSDKLiquid (0.2.1)
   - clipboard_watcher (0.0.1):
     - Flutter
   - connectivity_plus (0.0.1):
@@ -279,7 +278,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_group_directory: 7bf9f8f9819ead554de29da7c25fb7a680d6a9a0
-  BreezSDKLiquid: 937e553b4a081dc76c5a6cba9837e299354aedca
+  BreezSDKLiquid: 251f19328069eb73b8653c159f12196fa1cbe22f
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
@@ -293,7 +292,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
   FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_breez_liquid: c673b43b14c33cf9ce4b24d40d344dd0f10960fa
+  flutter_breez_liquid: 25615dbdf0dd058755f23d1b97202090fa0f49bc
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
@@ -327,6 +326,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   XCGLogger: 399c5885210b4e2ad79d9f7a29b105d672ef724f
 
-PODFILE CHECKSUM: 27d8d9df63feebbe29f412c244d89619e2d05ec1
+PODFILE CHECKSUM: c7e3aa05d64d03b1e96041369ae57f6584015526
 
 COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1412023D6C2DB5D2F4D233CA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B0583BD90A340B2CE4C3A7A /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		26E7AAF972C857A33EEA6115 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47D8F857BBF9A73C1F96B7B /* Pods_NotificationService.framework */; };
+		2C986B8F63C6AB416D0B2558 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21B0AFF006FA07EAA875429D /* Pods_NotificationService.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		4F8AB4D00129C23EA869D3FE /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA8CE8067C7D9FE0A27B7C /* Pods_RunnerTests.framework */; };
 		732A3D282C6CCF13007563A8 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D272C6CCF13007563A8 /* NotificationService.swift */; };
 		732A3D2C2C6CCF13007563A8 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 732A3D252C6CCF13007563A8 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		732A3D362C6CD974007563A8 /* SdkLogListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D332C6CD974007563A8 /* SdkLogListener.swift */; };
@@ -22,10 +22,10 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
-		C7887C7872FE42A94F158AB0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28F619239C7B46C732A8B226 /* Pods_Runner.framework */; };
 		D60FB850C4C30FEAB3325F5C /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		E88FB9F52C7756900037463D /* breez_sdk_liquid.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */; };
 		E88FB9F62C7756900037463D /* breez_sdk_liquid.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FFC771EFFE804E43DEFB0BB3 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C7F97C84ECEB66AB63470D4 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,22 +71,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		01BCAB1C5CA855A3D5FC238B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		15FBC21547B00E119F1FE42E /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPay.swift"; sourceTree = "<group>"; };
-		28F619239C7B46C732A8B226 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3272D1A44D7DFE2336B7833F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		1716C2BF6131162D390D93A5 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
+		1C08D7501EA08FEEA635C1B5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		21B0AFF006FA07EAA875429D /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		307656AD6C1928A220DF8A3D /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		35A24BAB75F2CA5EA46A6317 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		36136CA437BFC850907F553A /* ServiceLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceLogger.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ServiceLogger.swift"; sourceTree = "<group>"; };
 		36D0B41A3417E9CC03930119 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPayInvoice.swift"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3BA62FF80BBC75AD80E016C8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3FCE86AB511842FD78C29C16 /* BreezSDKConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKConnector.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/BreezSDKConnector.swift"; sourceTree = "<group>"; };
 		44631C1F894000A1C00B4B41 /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/SDKNotificationService.swift"; sourceTree = "<group>"; };
-		65A51DEA57D1EB087B32A610 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
-		718FF436C43B2E9D9CF35A08 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		732A3D252C6CCF13007563A8 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		732A3D272C6CCF13007563A8 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		732A3D292C6CCF13007563A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -97,6 +96,7 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7C7F97C84ECEB66AB63470D4 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		941FBF81DE56E38CB9B607EF /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/TaskProtocol.swift"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -105,20 +105,20 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9C6421985206DB8B1A06D9B3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		A1FDFA8B9020AE5593CFF020 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9B0583BD90A340B2CE4C3A7A /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C2A04A44FDB19A00EE94C39 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		A54E869D93DD243818730EC5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		A91886188D7722C76D07717B /* LnurlPayInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInfo.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/LnurlPayInfo.swift"; sourceTree = "<group>"; };
 		ACD7135B1733C7A905A92BC5 /* ReceivePayment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceivePayment.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/ReceivePayment.swift"; sourceTree = "<group>"; };
+		BA1800BC5214E8D55214D607 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		BCD162BC443C0AE50AE693BF /* RedeemSwap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RedeemSwap.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Task/RedeemSwap.swift"; sourceTree = "<group>"; };
 		BE49C1F5DD1913DD5BEAA00F /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/Constants.swift"; sourceTree = "<group>"; };
+		C2E61D892244B37FD730BBE4 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		D8AA8CE8067C7D9FE0A27B7C /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DDA2D3DEE5D16A7FBF7EE020 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		E47D8F857BBF9A73C1F96B7B /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = breez_sdk_liquid.xcframework; path = ".symlinks/plugins/flutter_breez_liquid/ios/../../../../../../breez-sdk-liquid/packages/flutter/ios/Frameworks/breez_sdk_liquid.xcframework"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		F10B8BD13646D7188373EBFA /* ServiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceConfig.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ServiceConfig.swift"; sourceTree = "<group>"; };
-		F2B6CB12B4D00E23C3B6A6B3 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
+		F3CDA02A2B9516E892C91FF1 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
 		F937E02F522B34DA0603EE0C /* BreezSDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDK.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/BreezSDK.swift"; sourceTree = "<group>"; };
 		FF2B4C3B077B63A01FF73FC6 /* ResourceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResourceHelper.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/ResourceHelper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -129,7 +129,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D60FB850C4C30FEAB3325F5C /* BuildFile in Frameworks */,
-				4F8AB4D00129C23EA869D3FE /* Pods_RunnerTests.framework in Frameworks */,
+				FFC771EFFE804E43DEFB0BB3 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -137,7 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26E7AAF972C857A33EEA6115 /* Pods_NotificationService.framework in Frameworks */,
+				2C986B8F63C6AB416D0B2558 /* Pods_NotificationService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,7 +146,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E88FB9F52C7756900037463D /* breez_sdk_liquid.xcframework in Frameworks */,
-				C7887C7872FE42A94F158AB0 /* Pods_Runner.framework in Frameworks */,
+				1412023D6C2DB5D2F4D233CA /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,9 +157,9 @@
 			isa = PBXGroup;
 			children = (
 				E88FB9F42C7756900037463D /* breez_sdk_liquid.xcframework */,
-				E47D8F857BBF9A73C1F96B7B /* Pods_NotificationService.framework */,
-				28F619239C7B46C732A8B226 /* Pods_Runner.framework */,
-				D8AA8CE8067C7D9FE0A27B7C /* Pods_RunnerTests.framework */,
+				21B0AFF006FA07EAA875429D /* Pods_NotificationService.framework */,
+				9B0583BD90A340B2CE4C3A7A /* Pods_Runner.framework */,
+				7C7F97C84ECEB66AB63470D4 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -268,15 +268,15 @@
 			isa = PBXGroup;
 			children = (
 				6ED43DD1619018FCC51A7E28 /* breez_sdk-OnDemandResources */,
-				65A51DEA57D1EB087B32A610 /* Pods-NotificationService.debug.xcconfig */,
-				718FF436C43B2E9D9CF35A08 /* Pods-NotificationService.release.xcconfig */,
-				F2B6CB12B4D00E23C3B6A6B3 /* Pods-NotificationService.profile.xcconfig */,
-				9C6421985206DB8B1A06D9B3 /* Pods-Runner.debug.xcconfig */,
-				DDA2D3DEE5D16A7FBF7EE020 /* Pods-Runner.release.xcconfig */,
-				3272D1A44D7DFE2336B7833F /* Pods-Runner.profile.xcconfig */,
-				A1FDFA8B9020AE5593CFF020 /* Pods-RunnerTests.debug.xcconfig */,
-				01BCAB1C5CA855A3D5FC238B /* Pods-RunnerTests.release.xcconfig */,
-				35A24BAB75F2CA5EA46A6317 /* Pods-RunnerTests.profile.xcconfig */,
+				C2E61D892244B37FD730BBE4 /* Pods-NotificationService.debug.xcconfig */,
+				1716C2BF6131162D390D93A5 /* Pods-NotificationService.release.xcconfig */,
+				F3CDA02A2B9516E892C91FF1 /* Pods-NotificationService.profile.xcconfig */,
+				3BA62FF80BBC75AD80E016C8 /* Pods-Runner.debug.xcconfig */,
+				BA1800BC5214E8D55214D607 /* Pods-Runner.release.xcconfig */,
+				9C2A04A44FDB19A00EE94C39 /* Pods-Runner.profile.xcconfig */,
+				307656AD6C1928A220DF8A3D /* Pods-RunnerTests.debug.xcconfig */,
+				A54E869D93DD243818730EC5 /* Pods-RunnerTests.release.xcconfig */,
+				1C08D7501EA08FEEA635C1B5 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -288,7 +288,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				4CB4141D830652178CAC44B9 /* [CP] Check Pods Manifest.lock */,
+				3D810D9C8E07A0B389AEE2AA /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -307,7 +307,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732A3D312C6CCF13007563A8 /* Build configuration list for PBXNativeTarget "NotificationService" */;
 			buildPhases = (
-				B837CCCC148A35B4D06B325B /* [CP] Check Pods Manifest.lock */,
+				098A740DF07CCF8A6B00A2F0 /* [CP] Check Pods Manifest.lock */,
 				732A3D212C6CCF13007563A8 /* Sources */,
 				732A3D222C6CCF13007563A8 /* Frameworks */,
 				732A3D232C6CCF13007563A8 /* Resources */,
@@ -325,7 +325,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				77580E8F05651E000E7F9230 /* [CP] Check Pods Manifest.lock */,
+				C06796464B1FA798D170315F /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				732A3D2D2C6CCF13007563A8 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
@@ -333,8 +333,8 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				5F288F96D58ED544CAC10E2F /* [CP] Embed Pods Frameworks */,
-				BC73CB54432B423C322430F7 /* [CP] Copy Pods Resources */,
+				2116D48551372B4566A629D0 /* [CP] Embed Pods Frameworks */,
+				B664D544DB004045CD9C3B74 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -423,99 +423,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
-		};
-		4CB4141D830652178CAC44B9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5F288F96D58ED544CAC10E2F /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		77580E8F05651E000E7F9230 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		B837CCCC148A35B4D06B325B /* [CP] Check Pods Manifest.lock */ = {
+		098A740DF07CCF8A6B00A2F0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -537,7 +445,77 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BC73CB54432B423C322430F7 /* [CP] Copy Pods Resources */ = {
+		2116D48551372B4566A629D0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
+		};
+		3D810D9C8E07A0B389AEE2AA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		B664D544DB004045CD9C3B74 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -552,6 +530,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C06796464B1FA798D170315F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -676,7 +676,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3272D1A44D7DFE2336B7833F /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = 9C2A04A44FDB19A00EE94C39 /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -706,7 +706,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1FDFA8B9020AE5593CFF020 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 307656AD6C1928A220DF8A3D /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -724,7 +724,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 01BCAB1C5CA855A3D5FC238B /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = A54E869D93DD243818730EC5 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -740,7 +740,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 35A24BAB75F2CA5EA46A6317 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 1C08D7501EA08FEEA635C1B5 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -756,7 +756,7 @@
 		};
 		732A3D2E2C6CCF13007563A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65A51DEA57D1EB087B32A610 /* Pods-NotificationService.debug.xcconfig */;
+			baseConfigurationReference = C2E61D892244B37FD730BBE4 /* Pods-NotificationService.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -798,7 +798,7 @@
 		};
 		732A3D2F2C6CCF13007563A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 718FF436C43B2E9D9CF35A08 /* Pods-NotificationService.release.xcconfig */;
+			baseConfigurationReference = 1716C2BF6131162D390D93A5 /* Pods-NotificationService.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -837,7 +837,7 @@
 		};
 		732A3D302C6CCF13007563A8 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2B6CB12B4D00E23C3B6A6B3 /* Pods-NotificationService.profile.xcconfig */;
+			baseConfigurationReference = F3CDA02A2B9516E892C91FF1 /* Pods-NotificationService.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -990,7 +990,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9C6421985206DB8B1A06D9B3 /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = 3BA62FF80BBC75AD80E016C8 /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1021,7 +1021,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DDA2D3DEE5D16A7FBF7EE020 /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = BA1800BC5214E8D55214D607 /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/lib/main/bootstrap.dart
+++ b/lib/main/bootstrap.dart
@@ -63,7 +63,7 @@ Future<void> bootstrap(AppBuilder builder) async {
     _log.info("Reconnect if secure storage has mnemonic.");
     String? mnemonic = await injector.credentialsManager.restoreMnemonic();
     if (mnemonic != null) {
-      await sdkConnectivityCubit.reconnect();
+      await sdkConnectivityCubit.reconnect(mnemonic: mnemonic);
     }
     runApp(builder(injector, sdkConnectivityCubit));
   }, (error, stackTrace) async {

--- a/packages/breez_sdk_liquid/lib/src/model/config.dart
+++ b/packages/breez_sdk_liquid/lib/src/model/config.dart
@@ -42,8 +42,10 @@ class AppConfig {
     liquid_sdk.Config defaultConf,
   ) async {
     _log.info("Getting SDK config");
+    const breezApiKey = String.fromEnvironment("API_KEY");
     return defaultConf.copyWith(
       workingDir: await _workingDir(),
+      breezApiKey: breezApiKey,
     );
   }
 

--- a/packages/breez_sdk_liquid/lib/src/model/config.dart
+++ b/packages/breez_sdk_liquid/lib/src/model/config.dart
@@ -43,6 +43,9 @@ class AppConfig {
   ) async {
     _log.info("Getting SDK config");
     const breezApiKey = String.fromEnvironment("API_KEY");
+    if (breezApiKey.isEmpty) {
+      throw Exception("API_KEY is not set in environment variables");
+    }
     return defaultConf.copyWith(
       workingDir: await _workingDir(),
       breezApiKey: breezApiKey,

--- a/packages/credentials_manager/lib/src/credentials_manager.dart
+++ b/packages/credentials_manager/lib/src/credentials_manager.dart
@@ -14,6 +14,34 @@ class CredentialsManager {
 
   CredentialsManager({required this.keyChain});
 
+  Future storeBreezApiKey({
+    required String breezApiKey,
+  }) async {
+    try {
+      await _storeBreezApiKey(breezApiKey);
+    } catch (err) {
+      throw Exception(err.toString());
+    }
+  }
+
+  Future<String?> restoreBreezApiKey() async {
+    try {
+      String? mnemonicStr = await keyChain.read(accountApiKey);
+      return mnemonicStr;
+    } catch (err) {
+      throw Exception(err.toString());
+    }
+  }
+
+  Future deleteBreezApiKey() async {
+    try {
+      await keyChain.delete(accountApiKey);
+      _log.info("Deleted Breez API key successfully");
+    } catch (err) {
+      throw Exception(err.toString());
+    }
+  }
+
   Future storeMnemonic({
     required String mnemonic,
   }) async {
@@ -49,6 +77,10 @@ class CredentialsManager {
   }
 
   // Helper methods
+  Future<void> _storeBreezApiKey(String breezApiKey) async {
+    await keyChain.write(accountApiKey, breezApiKey);
+  }
+
   Future<void> _storeMnemonic(String mnemonic) async {
     await keyChain.write(accountMnemonic, mnemonic);
   }

--- a/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
+++ b/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
@@ -26,11 +26,11 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
     await _connect(mnemonic, storeMnemonic: true);
   }
 
-  Future<void> reconnect() async {
+  Future<void> reconnect({String? mnemonic}) async {
     try {
-      final mnemonic = await credentialsManager.restoreMnemonic();
-      if (mnemonic != null) {
-        await _connect(mnemonic);
+      final restoredMnemonic = mnemonic ?? await credentialsManager.restoreMnemonic();
+      if (restoredMnemonic != null) {
+        await _connect(restoredMnemonic);
       } else {
         throw Exception("No mnemonics");
       }

--- a/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
+++ b/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
@@ -66,12 +66,8 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
 
   Future<void> _storeBreezApiKey(String? breezApiKey) async {
     final storedBreezApiKey = await credentialsManager.restoreBreezApiKey();
-
-    // Store the API key from AppConfig if it's not stored yet or if it has changed
-    if (breezApiKey != null && breezApiKey.isNotEmpty) {
-      if (storedBreezApiKey == null || storedBreezApiKey.isEmpty || storedBreezApiKey != breezApiKey) {
-        await credentialsManager.storeBreezApiKey(breezApiKey: breezApiKey);
-      }
+    if (breezApiKey != null && breezApiKey.isNotEmpty && storedBreezApiKey != breezApiKey) {
+      await credentialsManager.storeBreezApiKey(breezApiKey: breezApiKey);
     }
   }
 

--- a/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
+++ b/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
@@ -19,11 +19,11 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
 
   Future<void> register() async {
     final mnemonic = generateMnemonic(strength: 128);
-    await _connect(mnemonic, storeCredentials: true);
+    await _connect(mnemonic, storeMnemonic: true);
   }
 
   Future<void> restore({required String mnemonic}) async {
-    await _connect(mnemonic, storeCredentials: true);
+    await _connect(mnemonic, storeMnemonic: true);
   }
 
   Future<void> reconnect({String? mnemonic}) async {
@@ -39,7 +39,7 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
     }
   }
 
-  Future<void> _connect(String mnemonic, {bool storeCredentials = false}) async {
+  Future<void> _connect(String mnemonic, {bool storeMnemonic = false}) async {
     try {
       emit(SdkConnectivityState.connecting);
 
@@ -49,23 +49,19 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
 
       _startSyncing();
 
-      if (storeCredentials) {
-        _storeCredentials(breezApiKey: config.sdkConfig.breezApiKey, mnemonic: mnemonic);
+      await _storeBreezApiKey(config.sdkConfig.breezApiKey);
+      if (storeMnemonic) {
+        await credentialsManager.storeMnemonic(mnemonic: mnemonic);
       }
 
       emit(SdkConnectivityState.connected);
     } catch (e) {
-      if (storeCredentials) {
+      if (storeMnemonic) {
         _clearStoredCredentials();
       }
       emit(SdkConnectivityState.disconnected);
       rethrow;
     }
-  }
-
-  Future<void> _storeCredentials({required String mnemonic, String? breezApiKey}) async {
-    await _storeBreezApiKey(breezApiKey);
-    await credentialsManager.storeMnemonic(mnemonic: mnemonic);
   }
 
   Future<void> _storeBreezApiKey(String? breezApiKey) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -488,10 +488,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: f42eacb83b318e183b1ae24eead1373ab1334084404c8c16e0354f9a3e55d385
+      sha256: cb284e267f8e2a45a904b5c094d2ba51d0aabfc20b1538ab786d9ef7dc2bf75c
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.9.4+1"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -1797,10 +1797,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,9 @@
+# Troubleshooting
+
+If you're using `--dart-define-from-file` & `config.json` to define environment variables:
+- Make sure you have `config.json` file at the root of Misty Breez project
+- Make sure you have `API_KEY` (upper case) with a valid key at your `config.json` file
+- Make sure you are running flutter run with the following args `--dart-define-from-file=config.json`
+
+If you're using `--dart-define` to define environment variables:
+- Make sure you are running flutter run with the following args `--dart-define=API_KEY=<YOUR_API_KEY> --dart-define=APP_ID_PREFIX=<IOS_APP_ID_PREFIX>`


### PR DESCRIPTION
This PR improves API key handling, ensure secure storage across platforms and streamline the reconnection process.

### Changelog:
- **Android:** Get `API_KEY` from compile-time variables on Android f849bd7
- Set SDK Config's `breezApiKey` to `API_KEY` from environment variables 5240097
- Throw an exception if `API_KEY` is not set in environment variables 83d304a
- Add readme on how to define environment variables b6a4595
- Remove redundant secure storage access when reconnecting on launch  5f1c7b0
- Store `breezApiKey` to secure storage b44a052
- **iOS:** Access `API_KEY` from shared secure storage on iOS notification service app extension a511e42