### PR TITLE
Fix `storage.sql` file path

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -23,6 +23,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     _liquidSdk.walletInfoStream.distinct().listen((walletInfo) {
       final newState = state.copyWith(
         id: walletInfo.pubkey,
+        fingerprint: walletInfo.fingerprint,
         initial: false,
         balance: walletInfo.balanceSat.toInt(),
         pendingReceive: walletInfo.pendingReceiveSat.toInt(),

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 class AccountState {
   final String? id;
+  final String? fingerprint;
   final bool initial;
   final int balance;
   final int pendingSend;
@@ -10,6 +11,7 @@ class AccountState {
 
   const AccountState({
     required this.id,
+    required this.fingerprint,
     required this.initial,
     required this.balance,
     required this.pendingSend,
@@ -20,6 +22,7 @@ class AccountState {
   AccountState.initial()
       : this(
           id: null,
+          fingerprint: null,
           initial: true,
           balance: 0,
           walletBalance: 0,
@@ -29,6 +32,7 @@ class AccountState {
 
   AccountState copyWith({
     String? id,
+    String? fingerprint,
     bool? initial,
     int? balance,
     int? pendingSend,
@@ -37,6 +41,7 @@ class AccountState {
   }) {
     return AccountState(
       id: id ?? this.id,
+      fingerprint: fingerprint ?? this.fingerprint,
       initial: initial ?? this.initial,
       balance: balance ?? this.balance,
       pendingSend: pendingSend ?? this.pendingSend,
@@ -50,6 +55,7 @@ class AccountState {
   Map<String, dynamic>? toJson() {
     return {
       "id": id,
+      "fingerprint": fingerprint,
       "initial": initial,
       "balance": balance,
       "pendingSend": pendingSend,
@@ -61,6 +67,7 @@ class AccountState {
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
       id: json["id"],
+      fingerprint: json["fingerprint"],
       initial: json["initial"],
       balance: json["balance"],
       pendingSend: json["pendingSend"],

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -3,11 +3,12 @@ import 'dart:io';
 import 'package:archive/archive_io.dart';
 import 'package:breez_logger/breez_logger.dart';
 import 'package:breez_preferences/breez_preferences.dart';
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:l_breez/cubit/chain_swap/chain_swap_cubit.dart';
+import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/dev/command_line_interface.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -130,6 +131,9 @@ class _DevelopersViewState extends State<DevelopersView> {
   }
 
   void _exportKeys(BuildContext context) async {
+    final accountCubit = context.read<AccountCubit>();
+    final accountState = accountCubit.state;
+
     final credentialsManager = ServiceInjector().credentialsManager;
     final appDir = await getApplicationDocumentsDirectory();
     final encoder = ZipFileEncoder();
@@ -142,7 +146,11 @@ class _DevelopersViewState extends State<DevelopersView> {
         ArchiveFile(basename(credentialFile.path), bytes.length, bytes),
       );
     }
-    final storageFilePath = "${appDir.path}/storage.sql";
+
+    final config = await AppConfig.instance();
+    final sdkDir = Directory(config.sdkConfig.workingDir);
+    final walletStoragePath = "${sdkDir.path}/${config.sdkConfig.network.name}/${accountState.fingerprint}";
+    final storageFilePath = "$walletStoragePath/storage.sql";
     final storageFile = File(storageFilePath);
     encoder.addFile(storageFile);
     encoder.close();


### PR DESCRIPTION
Fixes the path of `storage.sql` file after the SDK changes that split based on network & per seed.

Cons: Since fingerprint is retrieved via `getInfo`, wallet needs to have been successfully connected at least once during session to retrieve `storage.sql` file.