### PR TITLE
Track newly received payments when on "Receive via Lightning Address" page

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -344,7 +344,7 @@ jobs:
 
       - name: 🚀 Build app
         working-directory: lbreez
-        run: flutter build ios --target=lib/main/main.dart --release --split-debug-info=./obsfucated/debug --obfuscate --config-only --no-pub --no-codesign --dart-define-from-file=config.json
+        run: flutter build ios --target=lib/main/main.dart --release --split-debug-info=./obsfucated/debug --obfuscate --no-config-only --no-pub --no-codesign --dart-define-from-file=config.json
 
       - name: 📦 Resolve Swift package dependencies
         working-directory: lbreez

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '14.0'
+platform :ios, '15.6'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,49 +8,49 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - Flutter
-  - Firebase/CoreOnly (10.29.0):
-    - FirebaseCore (= 10.29.0)
-  - Firebase/DynamicLinks (10.29.0):
+  - Firebase/CoreOnly (11.2.0):
+    - FirebaseCore (= 11.2.0)
+  - Firebase/DynamicLinks (11.2.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.29.0)
-  - Firebase/Messaging (10.29.0):
+    - FirebaseDynamicLinks (~> 11.2.0)
+  - Firebase/Messaging (11.2.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.29.0)
-  - firebase_core (3.3.0):
-    - Firebase/CoreOnly (= 10.29.0)
+    - FirebaseMessaging (~> 11.2.0)
+  - firebase_core (3.6.0):
+    - Firebase/CoreOnly (= 11.2.0)
     - Flutter
-  - firebase_dynamic_links (6.0.4):
-    - Firebase/DynamicLinks (= 10.29.0)
+  - firebase_dynamic_links (6.0.8):
+    - Firebase/DynamicLinks (= 11.2.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (15.0.4):
-    - Firebase/Messaging (= 10.29.0)
+  - firebase_messaging (15.1.3):
+    - Firebase/Messaging (= 11.2.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (10.29.0):
-    - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.12)
-    - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.29.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDynamicLinks (10.29.0):
-    - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.29.0):
-    - FirebaseCore (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.29.0):
-    - FirebaseCore (~> 10.0)
-    - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.3)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Reachability (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseCore (11.2.0):
+    - FirebaseCoreInternal (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Logger (~> 8.0)
+  - FirebaseCoreInternal (11.4.2):
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+  - FirebaseDynamicLinks (11.2.0):
+    - FirebaseCore (~> 11.0)
+  - FirebaseInstallations (11.4.0):
+    - FirebaseCore (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (11.2.0):
+    - FirebaseCore (~> 11.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Reachability (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
-  - flutter_breez_liquid (0.3.4):
+  - flutter_breez_liquid (0.4.0-rc3):
     - Flutter
   - flutter_fgbg (0.0.1):
     - Flutter
@@ -65,47 +65,43 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMLKit/BarcodeScanning (6.0.0):
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleMLKit/BarcodeScanning (7.0.0):
     - GoogleMLKit/MLKitCore
-    - MLKitBarcodeScanning (~> 5.0.0)
-  - GoogleMLKit/MLKitCore (6.0.0):
-    - MLKitCommon (~> 11.0.0)
+    - MLKitBarcodeScanning (~> 6.0.0)
+  - GoogleMLKit/MLKitCore (7.0.0):
+    - MLKitCommon (~> 12.0.0)
   - GoogleToolboxForMac/Defines (4.2.1)
   - GoogleToolboxForMac/Logger (4.2.1):
     - GoogleToolboxForMac/Defines (= 4.2.1)
   - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
     - GoogleToolboxForMac/Defines (= 4.2.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
+  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.3):
+  - GoogleUtilities/Environment (8.0.2):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.3):
+  - GoogleUtilities/Network (8.0.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.3)":
+  - "GoogleUtilities/NSData+zlib (8.0.2)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/Reachability (7.13.3):
+  - GoogleUtilities/Privacy (8.0.2)
+  - GoogleUtilities/Reachability (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilitiesComponents (1.1.0):
-    - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (3.5.0)
   - image_cropper (0.0.4):
     - Flutter
@@ -116,31 +112,31 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - MLImage (1.0.0-beta5)
-  - MLKitBarcodeScanning (5.0.0):
-    - MLKitCommon (~> 11.0)
-    - MLKitVision (~> 7.0)
-  - MLKitCommon (11.0.0):
-    - GoogleDataTransport (< 10.0, >= 9.4.1)
+  - MLImage (1.0.0-beta6)
+  - MLKitBarcodeScanning (6.0.0):
+    - MLKitCommon (~> 12.0)
+    - MLKitVision (~> 8.0)
+  - MLKitCommon (12.0.0):
+    - GoogleDataTransport (~> 10.0)
     - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
     - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
-    - GoogleUtilities/UserDefaults (< 8.0, >= 7.13.0)
-    - GoogleUtilitiesComponents (~> 1.0)
+    - GoogleUtilities/Logger (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
     - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-  - MLKitVision (7.0.0):
+  - MLKitVision (8.0.0):
     - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
     - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
     - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-    - MLImage (= 1.0.0-beta5)
-    - MLKitCommon (~> 11.0)
-  - mobile_scanner (5.1.1):
+    - MLImage (= 1.0.0-beta6)
+    - MLKitCommon (~> 12.0)
+  - mobile_scanner (6.0.2):
     - Flutter
-    - GoogleMLKit/BarcodeScanning (~> 6.0.0)
-  - nanopb (2.30910.0):
-    - nanopb/decode (= 2.30910.0)
-    - nanopb/encode (= 2.30910.0)
-  - nanopb/decode (2.30910.0)
-  - nanopb/encode (2.30910.0)
+    - GoogleMLKit/BarcodeScanning (~> 7.0.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - ObjcExceptionBridging (7.1.5):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 7.1.5)
   - ObjcExceptionBridging/ObjcExceptionBridging (7.1.5)
@@ -212,7 +208,6 @@ SPEC REPOS:
     - GoogleMLKit
     - GoogleToolboxForMac
     - GoogleUtilities
-    - GoogleUtilitiesComponents
     - GTMSessionFetcher
     - KeychainAccess
     - MLImage
@@ -281,45 +276,44 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_group_directory: 7bf9f8f9819ead554de29da7c25fb7a680d6a9a0
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
-  connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
-  Firebase: cec914dab6fd7b1bd8ab56ea07ce4e03dd251c2d
-  firebase_core: 57aeb91680e5d5e6df6b888064be7c785f146efb
-  firebase_dynamic_links: 550e8cefbdee7b6e74adfebb3cc4d340fa72f6c8
-  firebase_messaging: c862b3d2b973ecc769194dc8de09bd22c77ae757
-  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
-  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
-  FirebaseDynamicLinks: 83c278fcae48ac2cf8c3fb10f64f3d469dadcf9b
-  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
-  FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
+  connectivity_plus: 4c41c08fc6d7c91f63bc7aec70ffe3730b04f563
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  Firebase: 98e6bf5278170668a7983e12971a66b2cd57fc8c
+  firebase_core: 2bedc3136ec7c7b8561c6123ed0239387b53f2af
+  firebase_dynamic_links: 31addc071dc0e3ebd7a8f969b5e592636200b7c1
+  firebase_messaging: 15d114e1a41fc31e4fbabcd48d765a19eec94a38
+  FirebaseCore: a282032ae9295c795714ded2ec9c522fc237f8da
+  FirebaseCoreInternal: 35731192cab10797b88411be84940d2beb33a238
+  FirebaseDynamicLinks: 4fa5589f3d0c59b00235025a36690edf97559409
+  FirebaseInstallations: 6ef4a1c7eb2a61ee1f74727d7f6ce2e72acf1414
+  FirebaseMessaging: c9ec7b90c399c7a6100297e9d16f8a27fc7f7152
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_breez_liquid: c7014d3406171ecfc6a9deac8d378f9b39dbef06
+  flutter_breez_liquid: 8306e7e1867337fbecadf2b0f538270dc282ea94
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleMLKit: 97ac7af399057e99182ee8edfa8249e3226a4065
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
   GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
-  GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
+  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
-  MLImage: 1824212150da33ef225fbd3dc49f184cf611046c
-  MLKitBarcodeScanning: 10ca0845a6d15f2f6e911f682a1998b68b973e8b
-  MLKitCommon: afec63980417d29ffbb4790529a1b0a2291699e1
-  MLKitVision: e858c5f125ecc288e4a31127928301eaba9ae0c1
-  mobile_scanner: 8564358885a9253c43f822435b70f9345c87224f
-  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
+  MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
+  MLKitCommon: 07c2c33ae5640e5380beaaa6e4b9c249a205542d
+  MLKitVision: 45e79d68845a2de77e2dd4d7f07947f0ed157b0e
+  mobile_scanner: fd0054c52ede661e80bf5a4dea477a2467356bee
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   ObjcExceptionBridging: d3d37d62981bb7f252ecb31b62d7e23a96bbfb8a
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
-  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preference_app_group: 46aee3873e1da581d4904bece9876596d7f66725
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
@@ -328,6 +322,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   XCGLogger: 399c5885210b4e2ad79d9f7a29b105d672ef724f
 
-PODFILE CHECKSUM: bce0f66a635de639805b89b3b01316f8e9f5a71d
+PODFILE CHECKSUM: 0ce493dcb0f7bebb017b9d87555c839c9685fa8b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		442AE910DC3589D0BD9C3F38 /* BreezSDKLiquid.swift in Resources */ = {isa = PBXBuildFile; fileRef = 3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		5A1B8E788210285CFD84BDA9 /* TaskProtocol.swift in Resources */ = {isa = PBXBuildFile; fileRef = 94B64D07DB5A75CA4E5809DF /* TaskProtocol.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		5EA264694B3772E5372313B9 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F91DF349ADFED3844B75AC98 /* Pods_RunnerTests.framework */; };
 		619399E2500DF1F47AC77393 /* LnurlPayInfo.swift in Resources */ = {isa = PBXBuildFile; fileRef = 8BD8A8F87E52CF59156EC5B7 /* LnurlPayInfo.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		709E41899AB4AF301DA51392 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2366EDF24777593206A12AB /* Pods_NotificationService.framework */; };
 		71047A5D4902C8ED77D1A08E /* ResourceHelper.swift in Resources */ = {isa = PBXBuildFile; fileRef = 68C3549E54F158E6F1BF215E /* ResourceHelper.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		732A3D282C6CCF13007563A8 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D272C6CCF13007563A8 /* NotificationService.swift */; };
 		732A3D2C2C6CCF13007563A8 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 732A3D252C6CCF13007563A8 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -28,12 +28,12 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A09F2C75439FD441CCB45C4B /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		A5B7FE775C5DE85F5BA030AA /* SwapUpdated.swift in Resources */ = {isa = PBXBuildFile; fileRef = 6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		AB78FD82BFA3940FC6C860C5 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 696661FE737F1E384C84F29A /* Pods_RunnerTests.framework */; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
+		BB71B106A54928909D07002A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A431CB94F64ACEF1D2F2001E /* Pods_Runner.framework */; };
+		BEB278255207A594FD379756 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15092D723490CD165FF561C9 /* Pods_NotificationService.framework */; };
 		BEFD2B173AD9A8F75F4C4E70 /* Constants.swift in Resources */ = {isa = PBXBuildFile; fileRef = B5E5724CB2BA100C10032AF2 /* Constants.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		C20CE275E425F859C7E6DE4C /* String+SHA256.swift in Resources */ = {isa = PBXBuildFile; fileRef = A9EEF592AC15F5122FE4839C /* String+SHA256.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		C3850D9DB1F37D4536E0023E /* ServiceLogger.swift in Resources */ = {isa = PBXBuildFile; fileRef = 1A928177C42305FC6DA768BE /* ServiceLogger.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		C88B3F9A868A4512A851A47F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 448D80E5E03100EC5323B1F1 /* Pods_Runner.framework */; };
 		E2882E44B007EB2A2A3DA08E /* LnurlPay.swift in Resources */ = {isa = PBXBuildFile; fileRef = B820DCA0F1919C03D6BA3896 /* LnurlPay.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		E81E0B282CA33D3400B1C606 /* BreezSDKLiquid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */; };
 		E81E0B292CA33D3400B1C606 /* BreezSDKLiquidConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */; };
@@ -92,20 +92,23 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		03E2A3806D8270A61245EC01 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		15092D723490CD165FF561C9 /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A928177C42305FC6DA768BE /* ServiceLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceLogger.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ServiceLogger.swift; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		36A7CF263E5E34CFA7EA8767 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquid.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquid.swift; sourceTree = "<group>"; };
-		448D80E5E03100EC5323B1F1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		456FA4180E4D6C7AB064C943 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
+		4CA05FAD82404E98DDF9A284 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		56F0F63213FB8C78EDF753A4 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		61BCE1845227F6ABBBAF606D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquidConnector.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquidConnector.swift; sourceTree = "<group>"; };
+		651F1D52552E655AC759F715 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
 		68C3549E54F158E6F1BF215E /* ResourceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResourceHelper.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ResourceHelper.swift; sourceTree = "<group>"; };
-		696661FE737F1E384C84F29A /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6AC92D74B4BFFA1F94D9A6B7 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwapUpdated.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/SwapUpdated.swift; sourceTree = "<group>"; };
 		732A3D252C6CCF13007563A8 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		732A3D272C6CCF13007563A8 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -117,10 +120,8 @@
 		733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = breez_sdk_liquidFFI.xcframework; path = .symlinks/plugins/flutter_breez_liquid/ios/Frameworks/breez_sdk_liquidFFI.xcframework; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		761CD90B9FD0BEFBD6A49AB4 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8BD8A8F87E52CF59156EC5B7 /* LnurlPayInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInfo.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPayInfo.swift; sourceTree = "<group>"; };
-		8D826DDBBDAC671F94F9661C /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		94B64D07DB5A75CA4E5809DF /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/TaskProtocol.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -129,18 +130,17 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A431CB94F64ACEF1D2F2001E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9EEF592AC15F5122FE4839C /* String+SHA256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SHA256.swift"; path = "../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/String+SHA256.swift"; sourceTree = "<group>"; };
 		B05FDB7E07CF3107D1D2C0CB /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/SDKNotificationService.swift; sourceTree = "<group>"; };
 		B5E5724CB2BA100C10032AF2 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Constants.swift; sourceTree = "<group>"; };
 		B820DCA0F1919C03D6BA3896 /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPay.swift; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		E0FB3B69AAB0675A6F3DC053 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
-		E1624E3243E4E84221864DEB /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
-		E2366EDF24777593206A12AB /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2DE30F377D8FE1C5AFCFAB3 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		DA1498A9CB224F702189F9B2 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		E7CE5A6DC237972BB00127A7 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		F987B2F921BFE73062422495 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		FD154D249BCA1F9376073FE1 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
-		FF2176479498D72136D5B07D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F91DF349ADFED3844B75AC98 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,7 +148,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB78FD82BFA3940FC6C860C5 /* Pods_RunnerTests.framework in Frameworks */,
+				5EA264694B3772E5372313B9 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,7 +157,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				733E91342CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework in Frameworks */,
-				709E41899AB4AF301DA51392 /* Pods_NotificationService.framework in Frameworks */,
+				BEB278255207A594FD379756 /* Pods_NotificationService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,7 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C88B3F9A868A4512A851A47F /* Pods_Runner.framework in Frameworks */,
+				BB71B106A54928909D07002A /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,9 +216,9 @@
 			isa = PBXGroup;
 			children = (
 				733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */,
-				E2366EDF24777593206A12AB /* Pods_NotificationService.framework */,
-				448D80E5E03100EC5323B1F1 /* Pods_Runner.framework */,
-				696661FE737F1E384C84F29A /* Pods_RunnerTests.framework */,
+				15092D723490CD165FF561C9 /* Pods_NotificationService.framework */,
+				A431CB94F64ACEF1D2F2001E /* Pods_Runner.framework */,
+				F91DF349ADFED3844B75AC98 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -286,15 +286,15 @@
 			isa = PBXGroup;
 			children = (
 				859CF8DB9DF068928BF5B359 /* flutter_breez_liquid-OnDemandResources */,
-				761CD90B9FD0BEFBD6A49AB4 /* Pods-NotificationService.debug.xcconfig */,
-				456FA4180E4D6C7AB064C943 /* Pods-NotificationService.release.xcconfig */,
-				FD154D249BCA1F9376073FE1 /* Pods-NotificationService.profile.xcconfig */,
-				F987B2F921BFE73062422495 /* Pods-Runner.debug.xcconfig */,
-				FF2176479498D72136D5B07D /* Pods-Runner.release.xcconfig */,
-				36A7CF263E5E34CFA7EA8767 /* Pods-Runner.profile.xcconfig */,
-				8D826DDBBDAC671F94F9661C /* Pods-RunnerTests.debug.xcconfig */,
-				E1624E3243E4E84221864DEB /* Pods-RunnerTests.release.xcconfig */,
-				E0FB3B69AAB0675A6F3DC053 /* Pods-RunnerTests.profile.xcconfig */,
+				6AC92D74B4BFFA1F94D9A6B7 /* Pods-NotificationService.debug.xcconfig */,
+				E7CE5A6DC237972BB00127A7 /* Pods-NotificationService.release.xcconfig */,
+				651F1D52552E655AC759F715 /* Pods-NotificationService.profile.xcconfig */,
+				56F0F63213FB8C78EDF753A4 /* Pods-Runner.debug.xcconfig */,
+				61BCE1845227F6ABBBAF606D /* Pods-Runner.release.xcconfig */,
+				DA1498A9CB224F702189F9B2 /* Pods-Runner.profile.xcconfig */,
+				4CA05FAD82404E98DDF9A284 /* Pods-RunnerTests.debug.xcconfig */,
+				03E2A3806D8270A61245EC01 /* Pods-RunnerTests.release.xcconfig */,
+				D2DE30F377D8FE1C5AFCFAB3 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -306,7 +306,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				9A718C6B593BD4F8A84A0D2D /* [CP] Check Pods Manifest.lock */,
+				74F4F6040C9B48481C8539BA /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -325,7 +325,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732A3D312C6CCF13007563A8 /* Build configuration list for PBXNativeTarget "NotificationService" */;
 			buildPhases = (
-				70B26BF5CB348C91271D1BFF /* [CP] Check Pods Manifest.lock */,
+				962A8027B2071047A85ACD49 /* [CP] Check Pods Manifest.lock */,
 				732A3D212C6CCF13007563A8 /* Sources */,
 				732A3D222C6CCF13007563A8 /* Frameworks */,
 				732A3D232C6CCF13007563A8 /* Resources */,
@@ -343,7 +343,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				8072A47F9F2A24C4C88FD501 /* [CP] Check Pods Manifest.lock */,
+				2244A012D720EED44F1FD3E1 /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				732A3D2D2C6CCF13007563A8 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
@@ -351,8 +351,8 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				83617F1ED0E3307F4D78D86B /* [CP] Embed Pods Frameworks */,
-				DE2DA4CEFFFE838D45600287 /* [CP] Copy Pods Resources */,
+				C724E3F620A5E7D073192470 /* [CP] Embed Pods Frameworks */,
+				E9F7B6AC3FC2FDDFEED02816 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -454,45 +454,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
-		};
-		70B26BF5CB348C91271D1BFF /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8072A47F9F2A24C4C88FD501 /* [CP] Check Pods Manifest.lock */ = {
+		2244A012D720EED44F1FD3E1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -514,39 +476,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		83617F1ED0E3307F4D78D86B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
-			name = "Run Script";
+			name = "Thin Binary";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		9A718C6B593BD4F8A84A0D2D /* [CP] Check Pods Manifest.lock */ = {
+		74F4F6040C9B48481C8539BA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -568,7 +514,61 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DE2DA4CEFFFE838D45600287 /* [CP] Copy Pods Resources */ = {
+		962A8027B2071047A85ACD49 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C724E3F620A5E7D073192470 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E9F7B6AC3FC2FDDFEED02816 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -719,7 +719,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36A7CF263E5E34CFA7EA8767 /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = DA1498A9CB224F702189F9B2 /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -732,7 +732,7 @@
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/main/main.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -749,7 +749,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8D826DDBBDAC671F94F9661C /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 4CA05FAD82404E98DDF9A284 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -767,7 +767,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E1624E3243E4E84221864DEB /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 03E2A3806D8270A61245EC01 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -783,7 +783,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0FB3B69AAB0675A6F3DC053 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = D2DE30F377D8FE1C5AFCFAB3 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -799,7 +799,7 @@
 		};
 		732A3D2E2C6CCF13007563A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 761CD90B9FD0BEFBD6A49AB4 /* Pods-NotificationService.debug.xcconfig */;
+			baseConfigurationReference = 6AC92D74B4BFFA1F94D9A6B7 /* Pods-NotificationService.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -841,7 +841,7 @@
 		};
 		732A3D2F2C6CCF13007563A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 456FA4180E4D6C7AB064C943 /* Pods-NotificationService.release.xcconfig */;
+			baseConfigurationReference = E7CE5A6DC237972BB00127A7 /* Pods-NotificationService.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -884,7 +884,7 @@
 		};
 		732A3D302C6CCF13007563A8 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD154D249BCA1F9376073FE1 /* Pods-NotificationService.profile.xcconfig */;
+			baseConfigurationReference = 651F1D52552E655AC759F715 /* Pods-NotificationService.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1038,7 +1038,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F987B2F921BFE73062422495 /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = 56F0F63213FB8C78EDF753A4 /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1051,7 +1051,7 @@
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/main/main.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1069,7 +1069,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF2176479498D72136D5B07D /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = 61BCE1845227F6ABBBAF606D /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1084,7 +1084,7 @@
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/main/main.dart;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -12,15 +12,23 @@ import 'package:theme_provider/theme_provider.dart';
 
 class App extends StatelessWidget {
   final ServiceInjector injector;
+  final AccountCubit accountCubit;
   final SdkConnectivityCubit sdkConnectivityCubit;
-  const App({super.key, required this.injector, required this.sdkConnectivityCubit});
+
+  const App({
+    super.key,
+    required this.injector,
+    required this.accountCubit,
+    required this.sdkConnectivityCubit,
+  });
 
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
         BlocProvider<AccountCubit>(
-          create: (BuildContext context) => AccountCubit(injector.liquidSDK),
+          lazy: false,
+          create: (BuildContext context) => accountCubit,
         ),
         BlocProvider<PaymentsCubit>(
           create: (BuildContext context) => PaymentsCubit(injector.liquidSDK),
@@ -105,7 +113,7 @@ class _AppViewState extends State<AppView> {
               },
               initialRoute: securityState.pinStatus == PinStatus.enabled
                   ? LockScreen.routeName
-                  : accountState.initial
+                  : !accountState.isOnboardingComplete
                       ? SplashPage.routeName
                       : Home.routeName,
               onGenerateRoute: (RouteSettings settings) => onGenerateRoute(

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -10,25 +10,19 @@ export 'account_state.dart';
 final _log = Logger("AccountCubit");
 
 class AccountCubit extends Cubit<AccountState> with HydratedMixin {
-  final BreezSDKLiquid _liquidSdk;
+  final BreezSDKLiquid liquidSDK;
 
-  AccountCubit(this._liquidSdk) : super(AccountState.initial()) {
+  AccountCubit({
+    required this.liquidSDK,
+  }) : super(AccountState.initial()) {
     hydrate();
-
     _listenAccountChanges();
   }
 
   void _listenAccountChanges() {
     _log.info("Listening to account changes");
-    _liquidSdk.walletInfoStream.distinct().listen((walletInfo) {
-      final newState = state.copyWith(
-        id: walletInfo.pubkey,
-        fingerprint: walletInfo.fingerprint,
-        initial: false,
-        balance: walletInfo.balanceSat.toInt(),
-        pendingReceive: walletInfo.pendingReceiveSat.toInt(),
-        pendingSend: walletInfo.pendingSendSat.toInt(),
-      );
+    liquidSDK.walletInfoStream.distinct().listen((walletInfo) {
+      final newState = state.copyWith(walletInfo: walletInfo);
       _log.info("AccountState changed: $newState");
       emit(newState);
     });
@@ -42,5 +36,9 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
   @override
   Map<String, dynamic>? toJson(AccountState state) {
     return state.toJson();
+  }
+
+  void setOnboardingComplete(bool isComplete) {
+    emit(state.copyWith(isOnboardingComplete: isComplete));
   }
 }

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -1,81 +1,82 @@
 import 'dart:convert';
 
+import 'package:breez_liquid/breez_liquid.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger("AccountState");
+
 class AccountState {
-  final String? id;
-  final String? fingerprint;
-  final bool initial;
-  final int balance;
-  final int pendingSend;
-  final int pendingReceive;
-  final int walletBalance;
+  final bool isOnboardingComplete;
+  final GetInfoResponse? walletInfo;
 
-  const AccountState({
-    required this.id,
-    required this.fingerprint,
-    required this.initial,
-    required this.balance,
-    required this.pendingSend,
-    required this.pendingReceive,
-    required this.walletBalance,
-  });
+  const AccountState({required this.isOnboardingComplete, required this.walletInfo});
 
-  AccountState.initial()
-      : this(
-          id: null,
-          fingerprint: null,
-          initial: true,
-          balance: 0,
-          walletBalance: 0,
-          pendingReceive: 0,
-          pendingSend: 0,
-        );
+  AccountState.initial() : this(isOnboardingComplete: false, walletInfo: null);
 
   AccountState copyWith({
-    String? id,
-    String? fingerprint,
-    bool? initial,
-    int? balance,
-    int? pendingSend,
-    int? pendingReceive,
-    int? walletBalance,
+    bool? isOnboardingComplete,
+    GetInfoResponse? walletInfo,
   }) {
     return AccountState(
-      id: id ?? this.id,
-      fingerprint: fingerprint ?? this.fingerprint,
-      initial: initial ?? this.initial,
-      balance: balance ?? this.balance,
-      pendingSend: pendingSend ?? this.pendingSend,
-      pendingReceive: pendingReceive ?? this.pendingReceive,
-      walletBalance: walletBalance ?? this.walletBalance,
+      isOnboardingComplete: isOnboardingComplete ?? this.isOnboardingComplete,
+      walletInfo: walletInfo ?? this.walletInfo,
     );
   }
 
-  bool get hasBalance => balance > 0;
+  bool get hasBalance => walletInfo != null && walletInfo!.balanceSat > BigInt.zero;
 
   Map<String, dynamic>? toJson() {
     return {
-      "id": id,
-      "fingerprint": fingerprint,
-      "initial": initial,
-      "balance": balance,
-      "pendingSend": pendingSend,
-      "pendingReceive": pendingReceive,
-      "walletBalance": walletBalance,
+      "isOnboardingComplete": isOnboardingComplete,
+      "walletInfo": walletInfo?.toJson(),
     };
   }
 
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
-      id: json["id"],
-      fingerprint: json["fingerprint"],
-      initial: json["initial"],
-      balance: json["balance"],
-      pendingSend: json["pendingSend"],
-      pendingReceive: json["pendingReceive"],
-      walletBalance: json["walletBalance"],
+      isOnboardingComplete: json["isOnboardingComplete"] ?? false,
+      walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),
     );
   }
 
   @override
   String toString() => jsonEncode(toJson());
+}
+
+extension GetInfoResponseToJson on GetInfoResponse {
+  Map<String, dynamic> toJson() {
+    return {
+      'balanceSat': balanceSat.toString(),
+      'pendingSendSat': pendingSendSat.toString(),
+      'pendingReceiveSat': pendingReceiveSat.toString(),
+      'fingerprint': fingerprint,
+      'pubkey': pubkey,
+    };
+  }
+}
+
+extension GetInfoResponseFromJson on GetInfoResponse {
+  static GetInfoResponse? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _log.info("walletInfo is missing from AccountState JSON.");
+      return null;
+    }
+
+    if (json['balanceSat'] == null ||
+        json['pendingSendSat'] == null ||
+        json['pendingReceiveSat'] == null ||
+        json['fingerprint'] == null ||
+        json['pubkey'] == null) {
+      _log.warning("GetInfoResponse has missing fields on AccountState JSON.");
+      return null;
+    }
+
+    return GetInfoResponse(
+      balanceSat: BigInt.parse(json['balanceSat'] as String),
+      pendingSendSat: BigInt.parse(json['pendingSendSat'] as String),
+      pendingReceiveSat: BigInt.parse(json['pendingReceiveSat'] as String),
+      fingerprint: json['fingerprint'] as String,
+      pubkey: json['pubkey'] as String,
+    );
+  }
 }

--- a/lib/cubit/input/input_cubit.dart
+++ b/lib/cubit/input/input_cubit.dart
@@ -38,8 +38,8 @@ class InputCubit extends Cubit<InputState> {
     _decodeInvoiceController.add(InputData(data: input, source: source));
   }
 
-  Future<void> trackPayment(String? paymentDestination) async {
-    _log.info("Tracking incoming payment: $paymentDestination");
+  Future<void> trackPaymentEvents(String? paymentDestination) async {
+    _log.info("Tracking incoming payment events for: $paymentDestination");
     final paymentDestinationIsEmpty = paymentDestination == null || paymentDestination.isEmpty;
     await ServiceInjector().liquidSDK.paymentEventStream.firstWhere((paymentEvent) {
       final payment = paymentEvent.payment;

--- a/lib/cubit/user_profile/user_profile_cubit.dart
+++ b/lib/cubit/user_profile/user_profile_cubit.dart
@@ -68,7 +68,6 @@ class UserProfileCubit extends Cubit<UserProfileState> with HydratedMixin {
     String? color,
     String? animal,
     String? image,
-    bool? registrationRequested,
     bool? hideBalance,
     AppMode? appMode,
     bool? expandPreferences,

--- a/lib/main/main.dart
+++ b/lib/main/main.dart
@@ -3,8 +3,9 @@ import 'package:l_breez/main/bootstrap.dart';
 
 void main() {
   bootstrap(
-    (injector, sdkConnectivityCubit) => App(
+    (injector, accountCubit, sdkConnectivityCubit) => App(
       injector: injector,
+      accountCubit: accountCubit,
       sdkConnectivityCubit: sdkConnectivityCubit,
     ),
   );

--- a/lib/routes/chainswap/send/fee/fee_chooser/widgets/fee_chooser_header.dart
+++ b/lib/routes/chainswap/send/fee/fee_chooser/widgets/fee_chooser_header.dart
@@ -44,8 +44,7 @@ class _FeeChooserHeaderState extends State<FeeChooserHeader> {
                 index: index,
                 text: feeOption.getDisplayName(texts),
                 isAffordable: feeOption.isAffordable(
-                  balanceSat: accountState.balance,
-                  walletBalanceSat: accountState.walletBalance,
+                  balanceSat: accountState.walletInfo!.balanceSat.toInt(),
                   amountSat: widget.amountSat,
                 ),
                 isSelected: widget.selectedFeeIndex == index,

--- a/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
+++ b/lib/routes/chainswap/send/send_chainswap_confirmation_page.dart
@@ -95,7 +95,8 @@ class _SendChainSwapConfirmationPageState extends State<SendChainSwapConfirmatio
         final accountState = accountCubit.state;
         setState(() {
           affordableFees = feeOptions
-              .where((f) => f.isAffordable(balanceSat: accountState.balance, amountSat: widget.amountSat))
+              .where((f) => f.isAffordable(
+                  balanceSat: accountState.walletInfo!.balanceSat.toInt(), amountSat: widget.amountSat))
               .toList();
           selectedFeeIndex = (affordableFees.length / 2).floor();
         });

--- a/lib/routes/chainswap/send/send_chainswap_form.dart
+++ b/lib/routes/chainswap/send/send_chainswap_form.dart
@@ -108,7 +108,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
                     if (value) {
                       final accountCubit = context.read<AccountCubit>();
                       final accountState = accountCubit.state;
-                      _setAmount(accountState.balance);
+                      _setAmount(accountState.walletInfo!.balanceSat.toInt());
                     } else {
                       widget.amountController.text = "";
                     }

--- a/lib/routes/chainswap/send/widgets/chainswap_available_btc.dart
+++ b/lib/routes/chainswap/send/widgets/chainswap_available_btc.dart
@@ -25,7 +25,7 @@ class WithdrawFundsAvailableBtc extends StatelessWidget {
               child: BlocBuilder<CurrencyCubit, CurrencyState>(
                 builder: (context, currencyState) {
                   return Text(
-                    currencyState.bitcoinCurrency.format(account.balance),
+                    currencyState.bitcoinCurrency.format(account.walletInfo!.balanceSat.toInt()),
                     style: textStyle,
                   );
                 },

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -148,8 +148,10 @@ class _DevelopersViewState extends State<DevelopersView> {
     }
 
     final config = await AppConfig.instance();
-    final sdkDir = Directory(config.sdkConfig.workingDir);
-    final walletStoragePath = "${sdkDir.path}/${config.sdkConfig.network.name}/${accountState.fingerprint}";
+    final sdkDirPath = Directory(config.sdkConfig.workingDir).path;
+    final networkName = config.sdkConfig.network.name;
+    final fingerprint = accountState.walletInfo!.fingerprint;
+    final walletStoragePath = "$sdkDirPath/$networkName/$fingerprint";
     final storageFilePath = "$walletStoragePath/storage.sql";
     final storageFile = File(storageFilePath);
     encoder.addFile(storageFile);

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -89,7 +89,7 @@ class AccountPage extends StatelessWidget {
                   ),
                 ),
               );
-            } else if (!accountState.initial && nonFilteredPayments.isEmpty) {
+            } else if (accountState.isOnboardingComplete && nonFilteredPayments.isEmpty) {
               slivers.add(
                 SliverPersistentHeader(
                   delegate: FixedSliverDelegate(

--- a/lib/routes/home/widgets/dashboard/balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/balance_text.dart
@@ -45,7 +45,7 @@ class _BalanceTextState extends State<BalanceText> {
                 fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
               ),
               text: widget.currencyState.bitcoinCurrency.format(
-                widget.accountState.balance,
+                widget.accountState.walletInfo!.balanceSat.toInt(),
                 removeTrailingZeros: true,
                 includeDisplayName: false,
               ),

--- a/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
@@ -39,7 +39,7 @@ class FiatBalanceText extends StatelessWidget {
       ),
       onPressed: () => _changeFiatCurrency(context),
       child: Text(
-        currencyState.fiatConversion()?.format(accountState.balance) ?? "",
+        currencyState.fiatConversion()?.format(accountState.walletInfo!.balanceSat.toInt()) ?? "",
         style: balanceFiatConversionTextStyle.copyWith(
           color: themeData.colorScheme.onSecondary.withOpacity(pow(1.00 - offsetFactor, 2).toDouble()),
         ),
@@ -83,7 +83,7 @@ class FiatBalanceText extends StatelessWidget {
     final fiatConversion = currencyState.fiatConversion();
     if (fiatConversion == null) return false;
 
-    double fiatValue = fiatConversion.satToFiat(accountState.balance);
+    double fiatValue = fiatConversion.satToFiat(accountState.walletInfo!.balanceSat.toInt());
     int fractionSize = fiatConversion.currencyData.info.fractionSize;
     double minimumAmount = 1 / pow(10, fractionSize);
 

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -48,7 +48,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
                         color: themeData.customData.dashboardBgColor,
                       ),
                     ),
-                    if (!accountState.initial) ...[
+                    if (accountState.isOnboardingComplete) ...[
                       Positioned(
                         top: 60 - _kBalanceOffsetTransition * widget.offsetFactor,
                         child: Center(

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -168,6 +168,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
   void connect({String? mnemonic}) async {
     final connectionService = context.read<SdkConnectivityCubit>();
     final securityCubit = context.read<SecurityCubit>();
+    final accountCubit = context.read<AccountCubit>();
 
     final isRestore = mnemonic != null;
     _log.info("${isRestore ? "Restore" : "Starting new"} wallet");
@@ -184,6 +185,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       } else {
         await connectionService.register();
       }
+      accountCubit.setOnboardingComplete(true);
       themeProvider.setTheme('dark');
       navigator.pushReplacementNamed('/');
     } catch (error) {

--- a/lib/routes/ln_invoice/ln_invoice_payment_page.dart
+++ b/lib/routes/ln_invoice/ln_invoice_payment_page.dart
@@ -242,7 +242,7 @@ class LNInvoicePaymentPageState extends State<LNInvoicePaymentPage> {
   void _validateLnUrlPayment(int amount, bool outgoing) {
     final accountCubit = context.read<AccountCubit>();
     final accountState = accountCubit.state;
-    final balance = accountState.balance;
+    final balance = accountState.walletInfo!.balanceSat.toInt();
     final lnUrlCubit = context.read<LnUrlCubit>();
     return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits!, balance);
   }

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -404,7 +404,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
   void _validateLnUrlPayment(int amount, bool outgoing) {
     final accountCubit = context.read<AccountCubit>();
     final accountState = accountCubit.state;
-    final balance = accountState.balance;
+    final balance = accountState.walletInfo!.balanceSat.toInt();
     final lnUrlCubit = context.read<LnUrlCubit>();
     return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits!, balance);
   }

--- a/lib/routes/receive_payment/lightning/receive_lightning_page.dart
+++ b/lib/routes/receive_payment/lightning/receive_lightning_page.dart
@@ -225,7 +225,7 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
 
   void _validatePayment(int amount, bool outgoing) {
     final accountState = context.read<AccountCubit>().state;
-    final balance = accountState.balance;
+    final balance = accountState.walletInfo!.balanceSat.toInt();
     final lnUrlCubit = context.read<LnUrlCubit>();
     return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits, balance);
   }

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -49,6 +49,7 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                       children: [
                         if (webhookState.lnurlPayUrl != null)
                           DestinationWidget(
+                            isLnAddress: true,
                             destination: webhookState.lnurlPayUrl!,
                             title: texts.receive_payment_method_lightning_address,
                             infoWidget: const PaymentLimitsMessageBox(),

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -323,7 +323,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
 
   void _validatePayment(int amount, bool outgoing) {
     final accountState = context.read<AccountCubit>().state;
-    final balance = accountState.balance;
+    final balance = accountState.walletInfo!.balanceSat.toInt();
     final lnUrlCubit = context.read<LnUrlCubit>();
     return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits!, balance);
   }

--- a/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
+++ b/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
@@ -211,7 +211,7 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
 
   void _validateSwap(int amount, bool outgoing) {
     final accountState = context.read<AccountCubit>().state;
-    final balance = accountState.balance;
+    final balance = accountState.walletInfo!.balanceSat.toInt();
     final chainSwapCubit = context.read<ChainSwapCubit>();
     return chainSwapCubit.validateSwap(BigInt.from(amount), outgoing, _onchainPaymentLimits, balance);
   }

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -113,16 +113,18 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   void _onPaymentFinished(bool isSuccess) {
     Timer(const Duration(milliseconds: 1000), () {
       if (!mounted) return;
-      if (isSuccess == true) {
-        // Close the page and show successful payment route
-        Navigator.of(context)
-          ..pop()
-          ..push(
-            PageRouteBuilder(
-              opaque: false,
-              pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
-            ),
-          );
+      if (isSuccess) {
+        final navigator = Navigator.of(context);
+        if (!widget.isLnAddress) {
+          navigator.pop(); // Only pop if destination is not an LN Address
+        }
+        // Show successful payment route
+        navigator.push(
+          PageRouteBuilder(
+            opaque: false,
+            pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+          ),
+        );
       } else {
         if (widget.isLnAddress) _paymentStateSubscription?.cancel();
         showFlushbar(context, title: "", message: "Payment failed.");

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -130,7 +130,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
       navigator.push(
         PageRouteBuilder(
           opaque: false,
-          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(particlesEnabled: false),
         ),
       );
     } else {

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -78,6 +78,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   }
 
   void _trackNewPayments() {
+    _log.info("Tracking new payments.");
     final paymentsCubit = context.read<PaymentsCubit>();
     _receivedPaymentSubscription?.cancel();
     _receivedPaymentSubscription = paymentsCubit.stream
@@ -106,7 +107,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   void _trackPaymentEvents(String? destination) {
     final inputCubit = context.read<InputCubit>();
     inputCubit
-        .trackPayment(destination)
+        .trackPaymentEvents(destination)
         .then((_) => _onPaymentFinished(true))
         .catchError((e) => _onTrackPaymentError(e));
   }

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -125,26 +125,24 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   }
 
   void _onPaymentFinished(bool isSuccess) {
-    Timer(const Duration(milliseconds: 1000), () {
-      if (!mounted) return;
-      if (isSuccess) {
-        final navigator = Navigator.of(context);
-        if (!widget.isLnAddress) {
-          navigator.pop(); // Only pop if destination is not an LN Address
-        }
-        // Show successful payment route
-        navigator.push(
-          PageRouteBuilder(
-            opaque: false,
-            pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
-          ),
-        );
-      } else {
-        if (!widget.isLnAddress) {
-          showFlushbar(context, title: "", message: "Payment failed.");
-        }
+    if (!mounted) return;
+    if (isSuccess) {
+      final navigator = Navigator.of(context);
+      if (!widget.isLnAddress) {
+        navigator.pop(); // Only pop if destination is not an LN Address
       }
-    });
+      // Show successful payment route
+      navigator.push(
+        PageRouteBuilder(
+          opaque: false,
+          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+        ),
+      );
+    } else {
+      if (!widget.isLnAddress) {
+        showFlushbar(context, title: "", message: "Payment failed.");
+      }
+    }
   }
 
   @override

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -49,8 +49,9 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   @override
   void didUpdateWidget(covariant DestinationWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-
-    /// Receive pages other than LN Address wait for user input for invoice to be created, hence they rely on didUpdateWidget and not initState
+    // For receive payment pages other than LN Address, user input is required before creating an invoice.
+    // Therefore, they rely on `didUpdateWidget` instead of `initState` to capture updates after
+    // initial widget setup.
     if (!widget.isLnAddress) {
       _trackPaymentEvents(getUpdatedDestination(oldWidget));
     }
@@ -128,10 +129,9 @@ class _DestinationWidgetState extends State<DestinationWidget> {
     if (!mounted) return;
     if (isSuccess) {
       final navigator = Navigator.of(context);
-      if (!widget.isLnAddress) {
-        navigator.pop(); // Only pop if destination is not an LN Address
-      }
-      // Show successful payment route
+      // Only pop if the destination is not an LN Address,
+      // as there's no way to 1:1 match payments on the LN Address page.
+      if (!widget.isLnAddress) navigator.pop();
       navigator.push(
         PageRouteBuilder(
           opaque: false,

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -52,11 +52,23 @@ class _DestinationWidgetState extends State<DestinationWidget> {
 
     /// Receive pages other than LN Address wait for user input for invoice to be created, hence they rely on didUpdateWidget and not initState
     if (!widget.isLnAddress) {
-      final hasUpdatedDestination = widget.destination != oldWidget.destination;
-      if (hasUpdatedDestination || _hasNewDestination(widget.snapshot, oldWidget.snapshot)) {
-        _trackPaymentEvents(widget.destination ?? widget.snapshot?.data?.destination);
-      }
+      _trackPaymentEvents(getUpdatedDestination(oldWidget));
     }
+  }
+
+  String? getUpdatedDestination(DestinationWidget oldWidget) {
+    final hasUpdatedDestination = widget.destination != oldWidget.destination;
+    if (widget.destination != null && hasUpdatedDestination) {
+      return widget.destination!;
+    }
+
+    final newSnapshotDestination = widget.snapshot?.data?.destination;
+    final oldSnapshotDestination = oldWidget.snapshot?.data?.destination;
+    if (newSnapshotDestination != null && newSnapshotDestination != oldSnapshotDestination) {
+      return newSnapshotDestination;
+    }
+
+    return null;
   }
 
   @override
@@ -94,15 +106,6 @@ class _DestinationWidgetState extends State<DestinationWidget> {
       _processedPayments.add(paymentId);
     }
     _onPaymentFinished(isPaymentReceived);
-  }
-
-  bool _hasNewDestination(
-    AsyncSnapshot<ReceivePaymentResponse>? newSnapshot,
-    AsyncSnapshot<ReceivePaymentResponse>? oldSnapshot,
-  ) {
-    return newSnapshot?.hasData == true &&
-        oldSnapshot?.hasData == true &&
-        newSnapshot!.data!.destination != oldSnapshot!.data!.destination;
   }
 
   void _trackPaymentEvents(String? destination) {

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -126,8 +126,11 @@ class _DestinationWidgetState extends State<DestinationWidget> {
           ),
         );
       } else {
-        if (widget.isLnAddress) _paymentStateSubscription?.cancel();
-        showFlushbar(context, title: "", message: "Payment failed.");
+        if (widget.isLnAddress) {
+          _paymentStateSubscription?.cancel();
+        } else {
+          showFlushbar(context, title: "", message: "Payment failed.");
+        }
       }
     });
   }

--- a/lib/routes/receive_payment/widgets/successful_payment/successful_payment.dart
+++ b/lib/routes/receive_payment/widgets/successful_payment/successful_payment.dart
@@ -3,7 +3,9 @@ import 'package:l_breez/routes/receive_payment/widgets/destination_widget/widget
 import 'package:l_breez/routes/receive_payment/widgets/successful_payment/successful_payment_message.dart';
 
 class SuccessfulPaymentRoute extends StatefulWidget {
-  const SuccessfulPaymentRoute({super.key});
+  final bool particlesEnabled;
+
+  const SuccessfulPaymentRoute({super.key, this.particlesEnabled = true});
 
   @override
   State<StatefulWidget> createState() => SuccessfulPaymentRouteState();
@@ -53,7 +55,7 @@ class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute> with Tic
       if (status == AnimationStatus.reverse) {
         Future.delayed(const Duration(milliseconds: 400), () {
           setState(() {
-            showParticles = true;
+            showParticles = widget.particlesEnabled;
           });
           _particlesController.forward();
         });

--- a/packages/breez_logger/pubspec.lock
+++ b/packages/breez_logger/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   breez_preferences:
     dependency: "direct overridden"
     description:
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clipboard_watcher:
     dependency: transitive
     description:
@@ -137,10 +137,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   deep_link_client:
     dependency: "direct overridden"
     description:
@@ -159,10 +159,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -247,10 +247,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -278,10 +278,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -293,7 +293,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -450,10 +450,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -498,10 +498,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -522,10 +522,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -570,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fec12c3c39f01e4df1ec6ad92b6e85503c5ca64ffd6e28d18c9ffe53fcc4cb11
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.3"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -806,10 +806,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:

--- a/packages/breez_logger/pubspec.yaml
+++ b/packages/breez_logger/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
   archive: ^3.6.1
-  device_info_plus: ^10.1.2
-  share_plus: ^10.0.0
-  logging: ^1.2.0
+  device_info_plus: ^11.1.0
+  share_plus: ^10.1.1
+  logging: ^1.3.0
   rxdart: ^0.28.0
 
 dependency_overrides:

--- a/packages/breez_preferences/pubspec.lock
+++ b/packages/breez_preferences/pubspec.lock
@@ -47,10 +47,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   material_color_utilities:
     dependency: transitive
     description:
@@ -71,10 +71,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/packages/breez_preferences/pubspec.yaml
+++ b/packages/breez_preferences/pubspec.yaml
@@ -9,6 +9,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  logging: ^1.2.0
-  shared_preferences: ^2.3.1
+  logging: ^1.3.0
+  shared_preferences: ^2.3.2
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences

--- a/packages/breez_sdk_liquid/pubspec.lock
+++ b/packages/breez_sdk_liquid/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   breez_logger:
     dependency: "direct overridden"
     description:
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clipboard_watcher:
     dependency: transitive
     description:
@@ -137,10 +137,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   deep_link_client:
     dependency: "direct overridden"
     description:
@@ -159,10 +159,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -247,10 +247,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -278,10 +278,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -293,7 +293,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -450,10 +450,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -498,10 +498,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -522,10 +522,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -570,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: fec12c3c39f01e4df1ec6ad92b6e85503c5ca64ffd6e28d18c9ffe53fcc4cb11
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.3"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -806,10 +806,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:

--- a/packages/breez_sdk_liquid/pubspec.yaml
+++ b/packages/breez_sdk_liquid/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
-  logging: ^1.2.0
+  logging: ^1.3.0
   rxdart: ^0.28.0
-  path_provider: ^2.1.4
+  path_provider: ^2.1.5
 
 dependency_overrides:
   # Comment-out to work with breez-sdk-liquid from git repository

--- a/packages/credentials_manager/pubspec.lock
+++ b/packages/credentials_manager/pubspec.lock
@@ -102,10 +102,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   material_color_utilities:
     dependency: transitive
     description:
@@ -126,18 +126,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -182,10 +182,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/packages/credentials_manager/pubspec.yaml
+++ b/packages/credentials_manager/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
 dependencies:
   keychain:
     path: ../keychain
-  logging: ^1.2.0
+  logging: ^1.3.0
   path_provider: ^2.1.4

--- a/packages/deep_link_client/pubspec.lock
+++ b/packages/deep_link_client/pubspec.lock
@@ -140,10 +140,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:

--- a/packages/deep_link_client/pubspec.yaml
+++ b/packages/deep_link_client/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
-  firebase_dynamic_links: ^6.0.4
-  logging: ^1.2.0
+  firebase_dynamic_links: ^6.0.8
+  logging: ^1.3.0
   rxdart: ^0.28.0

--- a/packages/device_client/pubspec.lock
+++ b/packages/device_client/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   characters:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   ffi:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -111,10 +111,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   material_color_utilities:
     dependency: transitive
     description:
@@ -143,10 +143,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -159,18 +159,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -215,10 +215,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -239,10 +239,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fec12c3c39f01e4df1ec6ad92b6e85503c5ca64ffd6e28d18c9ffe53fcc4cb11
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.3"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:

--- a/packages/device_client/pubspec.yaml
+++ b/packages/device_client/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
     sdk: flutter
 
   clipboard_watcher: ^0.2.1
-  logging: ^1.2.0
-  package_info_plus: ^8.0.2
+  logging: ^1.3.0
+  package_info_plus: ^8.1.0
   rxdart: ^0.28.0
-  share_plus: ^10.0.0
-  shared_preferences: ^2.3.1
+  share_plus: ^10.1.1
+  shared_preferences: ^2.3.2

--- a/packages/keychain/pubspec.lock
+++ b/packages/keychain/pubspec.lock
@@ -111,18 +111,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -167,10 +167,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/packages/lightning_links/pubspec.lock
+++ b/packages/lightning_links/pubspec.lock
@@ -31,10 +31,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   material_color_utilities:
     dependency: transitive
     description:

--- a/packages/lightning_links/pubspec.yaml
+++ b/packages/lightning_links/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
-  logging: ^1.2.0
+  logging: ^1.3.0
   uni_links: ^0.5.1
   rxdart: ^0.28.0

--- a/packages/notifications_client/firebase_notifications_client/pubspec.lock
+++ b/packages/notifications_client/firebase_notifications_client/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -148,10 +148,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:

--- a/packages/notifications_client/firebase_notifications_client/pubspec.yaml
+++ b/packages/notifications_client/firebase_notifications_client/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
-  firebase_messaging: <15.1.0
-  logging: ^1.2.0
+  firebase_messaging: ^15.1.3
+  logging: ^1.3.0
   rxdart: ^0.28.0

--- a/packages/sdk_connectivity_cubit/pubspec.lock
+++ b/packages/sdk_connectivity_cubit/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   breez_logger:
     dependency: transitive
     description:
@@ -113,10 +113,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clipboard_watcher:
     dependency: transitive
     description:
@@ -145,10 +145,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "2056db5241f96cdc0126bd94459fc4cdc13876753768fc7a31c425e50a7177d0"
+      sha256: "876849631b0c7dc20f8b471a2a03142841b482438e3b707955464f5ffca3e4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -161,10 +161,10 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   credentials_manager:
     dependency: "direct main"
     description:
@@ -184,10 +184,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   dbus:
     dependency: transitive
     description:
@@ -214,10 +214,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -302,10 +302,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -356,7 +356,7 @@ packages:
       path: "../../../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   flutter_fgbg:
     dependency: "direct main"
     description:
@@ -530,10 +530,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -594,10 +594,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -618,10 +618,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -674,10 +674,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: fec12c3c39f01e4df1ec6ad92b6e85503c5ca64ffd6e28d18c9ffe53fcc4cb11
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.3"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -926,10 +926,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:

--- a/packages/sdk_connectivity_cubit/pubspec.yaml
+++ b/packages/sdk_connectivity_cubit/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
   bip39: ^1.0.6
-  connectivity_plus: ^6.0.5
+  connectivity_plus: ^6.1.0
   breez_sdk_liquid:
     path: ../breez_sdk_liquid
   credentials_manager:
@@ -27,7 +27,7 @@ dependencies:
       ref: 976b28ff3c299836f215b6deb2003838c49a8001
   flutter_bloc: ^8.1.6
   flutter_secure_storage: ^9.2.2
-  logging: ^1.2.0
+  logging: ^1.3.0
 
 dependency_overrides:
   # Comment-out to work with breez-sdk-liquid from git repository

--- a/packages/service_injector/pubspec.lock
+++ b/packages/service_injector/pubspec.lock
@@ -54,10 +54,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "399a455a3618de58c97dc25380a5166239835b52"
+      resolved-ref: "64aab2a98939972ec661ddf03fe22ecc5a7e5854"
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.4.0-rc3"
+    version: "0.5.0-rc3"
   breez_logger:
     dependency: "direct main"
     description:
@@ -99,10 +99,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clipboard_watcher:
     dependency: transitive
     description:
@@ -146,10 +146,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   deep_link_client:
     dependency: "direct main"
     description:
@@ -168,10 +168,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -256,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
@@ -287,10 +287,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: transitive
     description: flutter
@@ -301,10 +301,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "7659a0ca7405247c2dbbcd94ac6aec62ddf60570"
+      resolved-ref: bed160e4cc36da3cf8f555c09fce96755995eeba
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.4.0-rc3"
+    version: "0.5.0-rc3"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -461,10 +461,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -509,10 +509,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -533,10 +533,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -581,10 +581,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -613,10 +613,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: fec12c3c39f01e4df1ec6ad92b6e85503c5ca64ffd6e28d18c9ffe53fcc4cb11
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.3"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -810,10 +810,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:

--- a/packages/service_injector/pubspec.yaml
+++ b/packages/service_injector/pubspec.yaml
@@ -26,6 +26,6 @@ dependencies:
   credentials_manager:
     path: ../credentials_manager
 
-  logging: ^1.2.0
+  logging: ^1.3.0
   rxdart: ^0.28.0
-  shared_preferences: ^2.3.1
+  shared_preferences: ^2.3.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: b1595874fbc8f7a50da90f5d8f327bb0bfd6a95dc906c390efe991540c3b54aa
+      sha256: "5534e701a2c505fed1f0799e652dd6ae23bd4d2c4cf797220e5ced5764a7c1c2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.40"
+    version: "1.3.44"
   analyzer:
     dependency: transitive
     description:
@@ -111,7 +111,7 @@ packages:
       path: "../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   breez_logger:
     dependency: "direct main"
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
   clipboard_watcher:
     dependency: "direct main"
     description:
@@ -290,10 +290,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "2056db5241f96cdc0126bd94459fc4cdc13876753768fc7a31c425e50a7177d0"
+      sha256: "876849631b0c7dc20f8b471a2a03142841b482438e3b707955464f5ffca3e4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -314,18 +314,18 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
+      sha256: "88b0fddbe4c92910fefc09cc0248f5e7f0cd23e450ded4c28f16ab8ee8f83268"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.2"
+    version: "1.10.0"
   credentials_manager:
     dependency: "direct main"
     description:
@@ -345,10 +345,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   csv:
     dependency: "direct main"
     description:
@@ -391,10 +391,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -416,10 +416,10 @@ packages:
     dependency: "direct main"
     description:
       name: duration
-      sha256: "8b9020df63d2894f29fe250b60ca5b7f9e943d4a3cf766c2b161efeb617a0ea3"
+      sha256: "13e5d20723c9c1dde8fb318cf86716d10ce294734e81e44ae1a817f3ae714501"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.15"
+    version: "4.0.3"
   email_validator:
     dependency: "direct main"
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: "direct main"
     description:
       name: extended_image
-      sha256: "69d4299043334ecece679996e47d0b0891cd8c29d8da0034868443506f1d9a78"
+      sha256: bd4d1aa63ab0816091d95fc47e8d44731bf683b03578dbc1d7a9dc3b91c7f62f
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.4"
   extended_image_library:
     dependency: transitive
     description:
@@ -512,10 +512,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "3187f4f8e49968573fd7403011dca67ba95aae419bc0d8131500fae160d94f92"
+      sha256: "51dfe2fbf3a984787a2e7b8592f2f05c986bfedd6fdacea3f9e0a7beb334de96"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.6.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -528,50 +528,50 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "362e52457ed2b7b180964769c1e04d1e0ea0259fdf7025fdfedd019d4ae2bd88"
+      sha256: f967a7138f5d2ffb1ce15950e2a382924239eaa521150a8f144af34e68b3b3e5
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.5"
+    version: "2.18.1"
   firebase_dynamic_links:
     dependency: transitive
     description:
       name: firebase_dynamic_links
-      sha256: f094b1f90951981328abdb39c4140c0b0590c8d56fe23a9ad987b654a33000d0
+      sha256: "090becd30b4cf2ba1d5d25d0162d60c32dc1a2390a0be7306e6104c3e36e1b39"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.4"
+    version: "6.0.8"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: a9af616ec8e33c739b12153c420d16d6987532e13c8d764a0f20a64031bb93f1
+      sha256: b802020cd5d3d6eed1182b743e55c3f47a11ebd57ad27adc0eb20f28375c7916
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+40"
+    version: "0.2.6+44"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
+      sha256: eb6e28a3a35deda61fe8634967c84215efc19133ba58d8e0fc6c9a2af2cba05e
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.4"
+    version: "15.1.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: c5a6443e66ae064fe186901d740ee7ce648ca2a6fd0484b8c5e963849ac0fc28
+      sha256: b316c4ee10d93d32c033644207afc282d9b2b4372f3cf9c6022f3558b3873d2d
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.42"
+    version: "4.5.46"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "232ef63b986467ae5b5577a09c2502b26e2e2aebab5b85e6c966a5ca9b038b89"
+      sha256: d7f0147a1a9fe4313168e20154a01fd5cf332898de1527d3930ff77b8c7f5387
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.12"
+    version: "3.9.2"
   firebase_notifications_client:
     dependency: "direct main"
     description:
@@ -583,10 +583,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -606,7 +606,7 @@ packages:
       path: "../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.3.4"
+    version: "0.4.0-rc3"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -809,10 +809,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
+      sha256: "1b7723a814d84fb65869ea7115cdb3ee7c3be5a27a755c1ec60e049f6b9fcbb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10+1"
+    version: "2.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -924,10 +924,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   image_cropper:
     dependency: "direct main"
     description:
@@ -972,10 +972,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "65d94623e15372c5c51bebbcb820848d7bcb323836e12dfdba60b5d3a8b39e50"
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   image_picker_ios:
     dependency: transitive
     description:
@@ -1146,10 +1146,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -1194,10 +1194,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: b8c0e9afcfd52534f85ec666f3d52156f560b5e6c25b1e3d4fe2087763607926
+      sha256: "728828a798d1a2ee506beb652ca23d974c542c96ed03dcbd5eaf97bef96cdaad"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.2"
   mockito:
     dependency: "direct main"
     description:
@@ -1250,10 +1250,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1274,18 +1274,18 @@ packages:
     dependency: transitive
     description:
       name: path_parsing
-      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      sha256: caa17e8f0b386eb190dd5b6a3b71211c76375aa8b6ffb4465b5863d019bdb334
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
@@ -1338,10 +1338,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -1472,10 +1472,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "59dfd53f497340a0c3a81909b220cfdb9b8973a91055c4e5ab9b9b9ad7c513c0"
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1845,10 +1845,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   uuid:
     dependency: transitive
     description:
@@ -1861,26 +1861,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
+      sha256: "0b9149c6ddb013818075b072b9ddc1b89a5122fff1275d4648d297086b46c4f0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.12"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
+      sha256: "2430b973a4ca3c4dbc9999b62b8c719a160100dcbae5c819bae0cacce32c9cdb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.12"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
+      sha256: f3b9b6e4591c11394d4be4806c63e72d3a41778547b2c1e2a8a04fadcfd7d173
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.12"
   vector_math:
     dependency: "direct main"
     description:
@@ -1909,10 +1909,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,27 +52,27 @@ dependencies:
       ref: 121f878dd843ea99dca371e537a063f4c9521c31
   clipboard_watcher: ^0.2.1
   csv: ^6.0.0
-  connectivity_plus: ^6.0.5
-  device_info_plus: ^10.1.2
+  connectivity_plus: ^6.1.0
+  device_info_plus: ^11.1.0
   drag_and_drop_lists:
     git:
       url: https://github.com/breez/DragAndDropLists
       ref: 38cc3155a6161730b4ec476d781873afb7ec4846
-  duration: ^3.0.13
+  duration: ^4.0.3
   email_validator: ^3.0.0
-  extended_image: ^8.2.1
+  extended_image: ^9.0.4
   ffi: ^2.1.3
-  firebase_core: <3.4.0
-  firebase_messaging: <15.1.0
+  firebase_core: ^3.6.0
+  firebase_messaging: ^15.1.3
   flutter_bloc: ^8.1.6
-  flutter_cache_manager: ^3.3.0
+  flutter_cache_manager: ^3.4.1
   flutter_fgbg:
     git:
       url: https://github.com/breez/flutter_fgbg.git
       ref: 976b28ff3c299836f215b6deb2003838c49a8001
-  flutter_inappwebview: ^6.0.0
+  flutter_inappwebview: <6.1.0
   flutter_secure_storage: ^9.2.2
-  flutter_svg: ^2.0.10+1
+  flutter_svg: ^2.0.11
   flutter_typeahead:
     git:
       url: https://github.com/breez/flutter_typeahead.git
@@ -80,7 +80,7 @@ dependencies:
   hex: ^0.2.0
   http: ^1.2.2
   hydrated_bloc: ^9.1.5
-  image: ^4.2.0
+  image: ^4.3.0
   # Doesn't support: Linux Mac Windows
   image_cropper: ^8.0.2
   # Doesn't support: Linux Mac Windows
@@ -89,21 +89,21 @@ dependencies:
   intl: ^0.19.0
   # Doesn't support: Linux Mac
   local_auth: ^2.3.0
-  local_auth_android: ^1.0.43
-  local_auth_darwin: ^1.4.0
-  logging: ^1.2.0
-  melos: ^6.1.0
+  local_auth_android: <1.0.44
+  local_auth_darwin: ^1.4.1
+  logging: ^1.3.0
+  melos: ^6.2.0
   mockito: ^5.4.4
   # Doesn't support: Linux Windows
-  mobile_scanner: <5.2.0
-  package_info_plus: ^8.0.2
+  mobile_scanner: ^6.0.2
+  package_info_plus: ^8.1.0
   path: ^1.9.0
-  path_provider: ^2.1.4
+  path_provider: ^2.1.5
   path_provider_platform_interface: ^2.1.2
   plugin_platform_interface: ^2.1.8
   qr_flutter: ^4.1.0
   rxdart: ^0.28.0
-  share_plus: ^10.0.0
+  share_plus: ^10.1.1
   shared_preferences: ^2.3.2
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences
   simple_animations: ^5.0.2
@@ -112,14 +112,14 @@ dependencies:
   timeago: ^3.7.0
   # Doesn't support: Linux Mac Windows
   uni_links: ^0.5.1
-  url_launcher: ^6.3.0
+  url_launcher: ^6.3.1
   vector_math: ^2.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.4.11
-  flutter_lints: ^4.0.0
+  build_runner: <2.4.12
+  flutter_lints: <5.0.0
   test: ^1.25.2 # test >=1.25.3 is incompatible with flutter_test from the flutter SDK
 
 dependency_overrides:


### PR DESCRIPTION
Since LN Address payments are handled by the notification extensions, by the help of LNURL services, there isn't an easy way to track LN Address payments as there are no associated `PaymentEvent`'s to listen for.

Although we cannot listen for direct payment events for LN addresses, we can still monitor the payments list. When a user is opens "Receive via Lightning Address" page, we check for new payments in the list. 

If a new incoming payment is detected, we display the successful payment route to the user.