### PR TITLE
Address miscellaneous UI feedback

### DIFF
--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -47,6 +47,7 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   }
 
   Future<LightningPaymentLimitsResponse> fetchLightningLimits() async {
+    emit(state.copyWith(errorMessage: ""));
     try {
       final lightningPaymentLimits = await _liquidSdk.instance!.fetchLightningLimits();
       emit(state.copyWith(lightningPaymentLimits: lightningPaymentLimits, errorMessage: ""));
@@ -60,6 +61,7 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
   }
 
   Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
+    emit(state.copyWith(errorMessage: ""));
     try {
       final onchainPaymentLimits = await _liquidSdk.instance!.fetchOnchainLimits();
       emit(state.copyWith(onchainPaymentLimits: onchainPaymentLimits, errorMessage: ""));

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -29,7 +29,8 @@ class WebhookCubit extends Cubit<WebhookState> {
   }
 
   Future refreshLnurlPay({GetInfoResponse? walletInfo}) async {
-    emit(state.copyWith(isLoading: true));
+    _log.info("Refreshing Lightning Address");
+    emit(WebhookState(isLoading: true));
     try {
       final getInfoResponse = walletInfo ?? await _liquidSDK.instance?.getInfo();
       if (getInfoResponse != null) {
@@ -39,7 +40,12 @@ class WebhookCubit extends Cubit<WebhookState> {
       }
     } catch (err) {
       _log.warning("Failed to refresh lnurlpay: $err");
-      emit(state.copyWith(lnurlPayError: err.toString()));
+      emit(
+        state.copyWith(
+          lnurlPayErrorTitle: "Failed to refresh Lightning Address:",
+          lnurlPayError: err.toString(),
+        ),
+      );
     } finally {
       emit(state.copyWith(isLoading: false));
     }
@@ -51,10 +57,10 @@ class WebhookCubit extends Cubit<WebhookState> {
       await _liquidSDK.instance?.registerWebhook(webhookUrl: webhookUrl);
       _log.info("SDK webhook registered: $webhookUrl");
       final lnurl = await _registerLnurlpay(walletInfo, webhookUrl);
-      emit(state.copyWith(lnurlPayUrl: lnurl));
+      emit(WebhookState(lnurlPayUrl: lnurl));
     } catch (err) {
       _log.warning("Failed to register webhooks: $err");
-      emit(state.copyWith(lnurlPayError: err.toString()));
+      emit(state.copyWith(lnurlPayErrorTitle: "Failed to register webhooks:", lnurlPayError: err.toString()));
       rethrow;
     }
   }

--- a/lib/cubit/webhook/webhook_state.dart
+++ b/lib/cubit/webhook/webhook_state.dart
@@ -1,22 +1,26 @@
 class WebhookState {
   final String? lnurlPayUrl;
   final String? lnurlPayError;
+  final String? lnurlPayErrorTitle;
   final bool isLoading;
 
   WebhookState({
     this.lnurlPayUrl,
     this.lnurlPayError,
+    this.lnurlPayErrorTitle,
     this.isLoading = false,
   });
 
   WebhookState copyWith({
     String? lnurlPayUrl,
     String? lnurlPayError,
+    String? lnurlPayErrorTitle,
     bool? isLoading,
   }) {
     return WebhookState(
       lnurlPayUrl: lnurlPayUrl ?? this.lnurlPayUrl,
       lnurlPayError: lnurlPayError ?? this.lnurlPayError,
+      lnurlPayErrorTitle: lnurlPayErrorTitle ?? this.lnurlPayErrorTitle,
       isLoading: isLoading ?? this.isLoading,
     );
   }

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
@@ -56,7 +56,7 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
                       alignment: Alignment.bottomRight,
                       icon: Image(
                         image: const AssetImage("assets/icons/qr_scan.png"),
-                        color: themeData.primaryIconTheme.color,
+                        color: themeData.iconTheme.color,
                         width: 24.0,
                         height: 24.0,
                       ),
@@ -64,7 +64,7 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
                       onPressed: () => _scanBarcode(),
                     ),
                   ),
-                  style: TextStyle(color: themeData.primaryTextTheme.headlineMedium!.color),
+                  style: FieldTextStyle.textStyle,
                   validator: (value) => errorMessage.isNotEmpty ? errorMessage : null,
                   onFieldSubmitted: (input) async {
                     if (input.isNotEmpty) {
@@ -81,7 +81,6 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
                     texts.payment_info_dialog_hint_expanded,
                     style: FieldTextStyle.labelStyle.copyWith(
                       fontSize: 13.0,
-                      color: themeData.isLightTheme ? BreezColors.grey[500] : BreezColors.white[200],
                     ),
                   ),
                 ),

--- a/lib/routes/ln_invoice/ln_invoice_payment_page.dart
+++ b/lib/routes/ln_invoice/ln_invoice_payment_page.dart
@@ -62,7 +62,7 @@ class LNInvoicePaymentPageState extends State<LNInvoicePaymentPage> {
       await _handleLightningPaymentLimitsResponse();
     } catch (error) {
       setState(() {
-        errorMessage = error.toString();
+        errorMessage = extractExceptionMessage(error, getSystemAppLocalizations());
       });
     } finally {
       setState(() {

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -68,9 +68,19 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       });
       await _handleLightningPaymentLimitsResponse();
     } catch (error) {
-      setState(() {
-        errorMessage = error.toString();
-      });
+      if (mounted) {
+        final texts = context.texts();
+        String message = extractExceptionMessage(error, texts);
+        if (error is LnUrlPayError_ServiceConnectivity) {
+          message = texts.lnurl_fetch_invoice_error_message(
+            widget.requestData.domain,
+            message,
+          );
+        }
+        setState(() {
+          errorMessage = message;
+        });
+      }
     } finally {
       setState(() {
         _loading = false;

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -68,19 +68,17 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       });
       await _handleLightningPaymentLimitsResponse();
     } catch (error) {
-      if (mounted) {
-        final texts = context.texts();
-        String message = extractExceptionMessage(error, texts);
-        if (error is LnUrlPayError_ServiceConnectivity) {
-          message = texts.lnurl_fetch_invoice_error_message(
-            widget.requestData.domain,
-            message,
-          );
-        }
-        setState(() {
-          errorMessage = message;
-        });
+      final texts = getSystemAppLocalizations();
+      String message = extractExceptionMessage(error, texts);
+      if (error is LnUrlPayError_ServiceConnectivity) {
+        message = texts.lnurl_fetch_invoice_error_message(
+          widget.requestData.domain,
+          message,
+        );
       }
+      setState(() {
+        errorMessage = message;
+      });
     } finally {
       setState(() {
         _loading = false;

--- a/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
@@ -79,10 +79,17 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
   }
 }
 
-class Message extends StatelessWidget {
+class Message extends StatefulWidget {
   final String message;
 
   const Message(this.message, {super.key});
+
+  @override
+  State<Message> createState() => _MessageState();
+}
+
+class _MessageState extends State<Message> {
+  final ScrollController _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -95,13 +102,17 @@ class Message extends StatelessWidget {
           minWidth: double.infinity,
         ),
         child: Scrollbar(
+          controller: _scrollController,
           radius: const Radius.circular(16.0),
           thumbVisibility: true,
           child: SingleChildScrollView(
+            controller: _scrollController,
             child: AutoSizeText(
-              message,
+              widget.message,
               style: themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
-              textAlign: message.length > 40 && !message.contains("\n") ? TextAlign.start : TextAlign.left,
+              textAlign: widget.message.length > 40 && !widget.message.contains("\n")
+                  ? TextAlign.start
+                  : TextAlign.left,
             ),
           ),
         ),

--- a/lib/routes/lnurl/payment/widgets/lnurl_payment_header.dart
+++ b/lib/routes/lnurl/payment/widgets/lnurl_payment_header.dart
@@ -117,7 +117,6 @@ class _LnUrlPaymentHeaderState extends State<LnUrlPaymentHeader> {
           if (widget.errorMessage.isNotEmpty) ...[
             AutoSizeText(
               widget.errorMessage,
-              maxLines: 3,
               textAlign: TextAlign.center,
               style: themeData.primaryTextTheme.displaySmall?.copyWith(
                 fontSize: 14.3,

--- a/lib/routes/lnurl/widgets/lnurl_metadata.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata.dart
@@ -5,10 +5,17 @@ import 'package:flutter/material.dart';
 import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/min_font_size.dart';
 
-class LNURLMetadataText extends StatelessWidget {
+class LNURLMetadataText extends StatefulWidget {
   const LNURLMetadataText({super.key, required this.metadataText});
 
   final String metadataText;
+
+  @override
+  State<LNURLMetadataText> createState() => _LNURLMetadataTextState();
+}
+
+class _LNURLMetadataTextState extends State<LNURLMetadataText> {
+  final ScrollController _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -18,11 +25,13 @@ class LNURLMetadataText extends StatelessWidget {
         minWidth: double.infinity,
       ),
       child: Scrollbar(
+        controller: _scrollController,
         radius: const Radius.circular(16.0),
         thumbVisibility: true,
         child: SingleChildScrollView(
+          controller: _scrollController,
           child: AutoSizeText(
-            metadataText,
+            widget.metadataText,
             style: Theme.of(context).paymentItemSubtitleTextStyle.copyWith(color: Colors.white70),
             minFontSize: MinFontSize(context).minFontSize,
           ),

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -7,6 +7,7 @@ import 'package:l_breez/routes/receive_payment/widgets/destination_widget/destin
 import 'package:l_breez/routes/receive_payment/widgets/destination_widget/destination_widget_placeholder.dart';
 import 'package:l_breez/routes/receive_payment/widgets/payment_info_message_box/payment_limits_message_box.dart';
 import 'package:l_breez/utils/exceptions.dart';
+import 'package:l_breez/widgets/scrollable_error_message_widget.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 
 class ReceiveLightningAddressPage extends StatefulWidget {
@@ -42,31 +43,32 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
         return Scaffold(
           body: webhookState.isLoading
               ? const DestinationWidgetPlaceholder()
-              : Padding(
-                  padding: const EdgeInsets.only(bottom: 40.0),
-                  child: SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        if (webhookState.lnurlPayUrl != null)
-                          DestinationWidget(
-                            isLnAddress: true,
-                            destination: webhookState.lnurlPayUrl!,
-                            title: texts.receive_payment_method_lightning_address,
-                            infoWidget: const PaymentLimitsMessageBox(),
-                          ),
-                        if (webhookState.lnurlPayError != null)
-                          _ErrorMessage(
-                            message: extractExceptionMessage(webhookState.lnurlPayError!, texts),
-                          ),
-                      ],
+              : (webhookState.lnurlPayError != null)
+                  ? ScrollableErrorMessageWidget(
+                      title: webhookState.lnurlPayErrorTitle ?? "LN Service error:",
+                      message: extractExceptionMessage(webhookState.lnurlPayError!, texts),
+                    )
+                  : Padding(
+                      padding: const EdgeInsets.only(bottom: 40.0),
+                      child: SingleChildScrollView(
+                        child: Column(
+                          children: [
+                            if (webhookState.lnurlPayUrl != null)
+                              DestinationWidget(
+                                isLnAddress: true,
+                                destination: webhookState.lnurlPayUrl!,
+                                title: texts.receive_payment_method_lightning_address,
+                                infoWidget: const PaymentLimitsMessageBox(),
+                              ),
+                          ],
+                        ),
+                      ),
                     ),
-                  ),
-                ),
           bottomNavigationBar: webhookState.lnurlPayError != null
               ? SingleButtonBottomBar(
                   stickToBottom: true,
                   text: texts.invoice_ln_address_action_retry,
-                  onPressed: () => _refreshLnurlPay,
+                  onPressed: () => _refreshLnurlPay(),
                 )
               : SingleButtonBottomBar(
                   stickToBottom: true,
@@ -77,27 +79,6 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                 ),
         );
       },
-    );
-  }
-}
-
-class _ErrorMessage extends StatelessWidget {
-  final String message;
-
-  const _ErrorMessage({
-    required this.message,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 40.0),
-        child: Text(
-          message,
-          textAlign: TextAlign.center,
-        ),
-      ),
     );
   }
 }

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -64,19 +64,32 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                         ),
                       ),
                     ),
-          bottomNavigationBar: webhookState.lnurlPayError != null
-              ? SingleButtonBottomBar(
-                  stickToBottom: true,
-                  text: texts.invoice_ln_address_action_retry,
-                  onPressed: () => _refreshLnurlPay(),
-                )
-              : SingleButtonBottomBar(
-                  stickToBottom: true,
-                  text: texts.qr_code_dialog_action_close,
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                ),
+          bottomNavigationBar: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
+            builder: (BuildContext context, PaymentLimitsState snapshot) {
+              return webhookState.lnurlPayError != null
+                  ? SingleButtonBottomBar(
+                      stickToBottom: true,
+                      text: texts.invoice_ln_address_action_retry,
+                      onPressed: () => _refreshLnurlPay(),
+                    )
+                  : snapshot.hasError
+                      ? SingleButtonBottomBar(
+                          stickToBottom: true,
+                          text: texts.invoice_ln_address_action_retry,
+                          onPressed: () {
+                            final paymentLimitsCubit = context.read<PaymentLimitsCubit>();
+                            paymentLimitsCubit.fetchLightningLimits();
+                          },
+                        )
+                      : SingleButtonBottomBar(
+                          stickToBottom: true,
+                          text: texts.qr_code_dialog_action_close,
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                        );
+            },
+          ),
         );
       },
     );

--- a/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
+++ b/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
@@ -13,6 +13,7 @@ import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/keyboard_done_action.dart';
 import 'package:l_breez/widgets/loader.dart';
+import 'package:l_breez/widgets/scrollable_error_message_widget.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 
 class ReceiveBitcoinAddressPaymentPage extends StatefulWidget {
@@ -64,11 +65,9 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
       body: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
         builder: (BuildContext context, PaymentLimitsState snapshot) {
           if (snapshot.hasError) {
-            return Center(
-              child: Text(
-                texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
-                textAlign: TextAlign.center,
-              ),
+            return ScrollableErrorMessageWidget(
+              title: "Failed to retrieve payment limits:",
+              message: texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
             );
           }
           if (snapshot.onchainPaymentLimits == null) {
@@ -92,23 +91,36 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
           );
         },
       ),
-      bottomNavigationBar: (receivePaymentResponse == null)
-          ? SingleButtonBottomBar(
-              stickToBottom: true,
-              text: texts.invoice_action_create,
-              onPressed: () {
-                if (_formKey.currentState?.validate() ?? false) {
-                  _createSwap();
-                }
-              },
-            )
-          : SingleButtonBottomBar(
-              stickToBottom: true,
-              text: texts.qr_code_dialog_action_close,
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
+      bottomNavigationBar: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
+        builder: (BuildContext context, PaymentLimitsState snapshot) {
+          return (snapshot.hasError)
+              ? SingleButtonBottomBar(
+                  stickToBottom: true,
+                  text: texts.invoice_btc_address_action_retry,
+                  onPressed: () {
+                    final paymentLimitsCubit = context.read<PaymentLimitsCubit>();
+                    paymentLimitsCubit.fetchOnchainLimits();
+                  },
+                )
+              : (receivePaymentResponse == null)
+                  ? SingleButtonBottomBar(
+                      stickToBottom: true,
+                      text: texts.invoice_action_create,
+                      onPressed: () {
+                        if (_formKey.currentState?.validate() ?? false) {
+                          _createSwap();
+                        }
+                      },
+                    )
+                  : SingleButtonBottomBar(
+                      stickToBottom: true,
+                      text: texts.qr_code_dialog_action_close,
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                    );
+        },
+      ),
     );
   }
 

--- a/lib/routes/receive_payment/widgets/payment_info_message_box/payment_limits_message_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_info_message_box/payment_limits_message_box.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/receive_payment/widgets/payment_info_message_box/payment_info_message_box.dart';
 import 'package:l_breez/widgets/loader.dart';
+import 'package:l_breez/widgets/scrollable_error_message_widget.dart';
 
 class PaymentLimitsMessageBox extends StatelessWidget {
   const PaymentLimitsMessageBox({super.key});
@@ -16,14 +17,10 @@ class PaymentLimitsMessageBox extends StatelessWidget {
     return BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
       builder: (BuildContext context, PaymentLimitsState snapshot) {
         if (snapshot.hasError) {
-          return Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 0),
-              child: Text(
-                texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
-                textAlign: TextAlign.center,
-              ),
-            ),
+          return ScrollableErrorMessageWidget(
+            title: "Failed to retrieve payment limits:",
+            padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 0),
+            message: texts.reverse_swap_upstream_generic_error_message(snapshot.errorMessage),
           );
         }
         if (snapshot.lightningPaymentLimits == null) {

--- a/lib/theme/src/theme_extensions.dart
+++ b/lib/theme/src/theme_extensions.dart
@@ -180,4 +180,11 @@ extension ThemeExtensions on ThemeData {
           height: 1.16,
           letterSpacing: 0.39,
         );
+
+  TextStyle get errorTextStyle => TextStyle(
+        color: colorScheme.error,
+        fontSize: 10.5,
+        fontWeight: FontWeight.w400,
+        height: 1.16,
+      );
 }

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -45,9 +45,9 @@ String _getPaymentErrorMessage(PaymentError error, BreezTranslations texts) {
   } else if (error is PaymentError_AmountOutOfRange) {
     message = "Amount is out of range";
   } else if (error is PaymentError_AmountMissing) {
-    message = "Amount is missing ${error.err}";
+    message = "Amount is missing: ${error.err}";
   } else if (error is PaymentError_InvalidNetwork) {
-    message = "Invalid network ${error.err}";
+    message = "Invalid network: ${error.err}";
   } else if (error is PaymentError_Generic) {
     message = "Payment error: ${error.err}";
   } else if (error is PaymentError_InvalidOrExpiredFees) {
@@ -55,7 +55,7 @@ String _getPaymentErrorMessage(PaymentError error, BreezTranslations texts) {
   } else if (error is PaymentError_InsufficientFunds) {
     message = texts.invoice_payment_validator_error_insufficient_local_balance;
   } else if (error is PaymentError_InvalidDescription) {
-    message = "Invalid description ${error.err}";
+    message = "Invalid description: ${error.err}";
   } else if (error is PaymentError_InvalidInvoice) {
     message = "The specified invoice is not valid: ${error.err}";
   } else if (error is PaymentError_InvalidPreimage) {
@@ -95,7 +95,7 @@ String _getLnUrlPayErrorMessage(LnUrlPayError error, BreezTranslations texts) {
   } else if (error is LnUrlPayError_InvoiceExpired) {
     message = "Invoice expired: ${error.err}";
   } else if (error is LnUrlPayError_PaymentFailed) {
-    message = "Payment failed ${error.err}";
+    message = "Payment failed: ${error.err}";
   } else if (error is LnUrlPayError_PaymentTimeout) {
     message = "Payment timeout: ${error.err}";
   } else if (error is LnUrlPayError_RouteNotFound) {

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -28,6 +28,9 @@ String extractExceptionMessage(
   if (exception is PaymentError) {
     return _getPaymentErrorMessage(exception, texts);
   }
+  if (exception is LnUrlPayError) {
+    return _getLnUrlPayErrorMessage(exception, texts);
+  }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
 }
 
@@ -71,6 +74,36 @@ String _getPaymentErrorMessage(PaymentError error, BreezTranslations texts) {
     message = error.err;
   } else if (error is PaymentError_SignerError) {
     message = "Could not sign the transaction: ${error.err}";
+  }
+  return message;
+}
+
+String _getLnUrlPayErrorMessage(LnUrlPayError error, BreezTranslations texts) {
+  String message = error.toString();
+  if (error is LnUrlPayError_AlreadyPaid) {
+    message = "Invoice already paid";
+  } else if (error is LnUrlPayError_Generic) {
+    message = "Generic error: ${error.err}";
+  } else if (error is LnUrlPayError_InvalidAmount) {
+    message = "Invalid amount: ${error.err}";
+  } else if (error is LnUrlPayError_InvalidInvoice) {
+    message = "Invalid invoice: ${error.err}";
+  } else if (error is LnUrlPayError_InvalidNetwork) {
+    message = "Invalid network: ${error.err}";
+  } else if (error is LnUrlPayError_InvalidUri) {
+    message = "Invalid uri: ${error.err}";
+  } else if (error is LnUrlPayError_InvoiceExpired) {
+    message = "Invoice expired: ${error.err}";
+  } else if (error is LnUrlPayError_PaymentFailed) {
+    message = "Payment failed ${error.err}";
+  } else if (error is LnUrlPayError_PaymentTimeout) {
+    message = "Payment timeout: ${error.err}";
+  } else if (error is LnUrlPayError_RouteNotFound) {
+    message = "Route not found: ${error.err}";
+  } else if (error is LnUrlPayError_RouteTooExpensive) {
+    message = "Route too expensive: ${error.err}";
+  } else if (error is LnUrlPayError_ServiceConnectivity) {
+    message = "Service connectivity: ${error.err}";
   }
   return message;
 }

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -25,10 +25,54 @@ String extractExceptionMessage(
     message = _localizedExceptionMessage(texts, message);
     return message;
   }
-  if (exception is PaymentError_InsufficientFunds) {
-    return texts.invoice_payment_validator_error_insufficient_local_balance;
+  if (exception is PaymentError) {
+    return _getPaymentErrorMessage(exception, texts);
   }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
+}
+
+String _getPaymentErrorMessage(PaymentError error, BreezTranslations texts) {
+  String message = error.toString();
+  if (error is PaymentError_AlreadyClaimed) {
+    message = "The specified funds have already been claimed";
+  } else if (error is PaymentError_AlreadyPaid) {
+    message = "The specified funds have already been sent";
+  } else if (error is PaymentError_PaymentInProgress) {
+    message = "The payment is already in progress";
+  } else if (error is PaymentError_AmountOutOfRange) {
+    message = "Amount is out of range";
+  } else if (error is PaymentError_AmountMissing) {
+    message = "Amount is missing ${error.err}";
+  } else if (error is PaymentError_InvalidNetwork) {
+    message = "Invalid network ${error.err}";
+  } else if (error is PaymentError_Generic) {
+    message = "Generic error: ${error.err}";
+  } else if (error is PaymentError_InvalidOrExpiredFees) {
+    message = "The provided fees have expired";
+  } else if (error is PaymentError_InsufficientFunds) {
+    message = texts.invoice_payment_validator_error_insufficient_local_balance;
+  } else if (error is PaymentError_InvalidDescription) {
+    message = "Invalid description ${error.err}";
+  } else if (error is PaymentError_InvalidInvoice) {
+    message = "The specified invoice is not valid: ${error.err}";
+  } else if (error is PaymentError_InvalidPreimage) {
+    message = "The generated preimage is not valid";
+  } else if (error is PaymentError_LwkError) {
+    message = "Lwk error: ${error.err}";
+  } else if (error is PaymentError_PairsNotFound) {
+    message = "Boltz did not return any pairs from the request";
+  } else if (error is PaymentError_PaymentTimeout) {
+    message = "The payment timed out";
+  } else if (error is PaymentError_PersistError) {
+    message = "Could not store the swap details locally";
+  } else if (error is PaymentError_SelfTransferNotSupported) {
+    message = "The payment is a self-transfer, which is not supported";
+  } else if (error is PaymentError_SendError) {
+    message = error.err;
+  } else if (error is PaymentError_SignerError) {
+    message = "Could not sign the transaction: ${error.err}";
+  }
+  return message;
 }
 
 String? _extractInnerErrorMessage(String content) {

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -49,7 +49,7 @@ String _getPaymentErrorMessage(PaymentError error, BreezTranslations texts) {
   } else if (error is PaymentError_InvalidNetwork) {
     message = "Invalid network ${error.err}";
   } else if (error is PaymentError_Generic) {
-    message = "Generic error: ${error.err}";
+    message = "Payment error: ${error.err}";
   } else if (error is PaymentError_InvalidOrExpiredFees) {
     message = "The provided fees have expired";
   } else if (error is PaymentError_InsufficientFunds) {
@@ -83,7 +83,7 @@ String _getLnUrlPayErrorMessage(LnUrlPayError error, BreezTranslations texts) {
   if (error is LnUrlPayError_AlreadyPaid) {
     message = "Invoice already paid";
   } else if (error is LnUrlPayError_Generic) {
-    message = "Generic error: ${error.err}";
+    message = "LNURL Payment error: ${error.err}";
   } else if (error is LnUrlPayError_InvalidAmount) {
     message = "Invalid amount: ${error.err}";
   } else if (error is LnUrlPayError_InvalidInvoice) {

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -106,9 +106,8 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
         if (_currentRoute != null && _currentRoute!.isActive) {
           navigator.removeRoute(_currentRoute!);
         }
-        if (mounted) {
-          showFlushbar(context, message: extractExceptionMessage(err, texts));
-        }
+        final message = extractExceptionMessage(err, texts);
+        showFlushbar(context, message: texts.payment_error_to_send(message));
       }
     });
   }

--- a/lib/widgets/scrollable_error_message_widget.dart
+++ b/lib/widgets/scrollable_error_message_widget.dart
@@ -1,0 +1,70 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme.dart';
+
+class ScrollableErrorMessageWidget extends StatefulWidget {
+  final EdgeInsets? padding;
+  final String? title;
+  final String message;
+
+  const ScrollableErrorMessageWidget({
+    super.key,
+    this.padding,
+    this.title,
+    required this.message,
+  });
+
+  @override
+  State<ScrollableErrorMessageWidget> createState() => _ScrollableErrorMessageWidgetState();
+}
+
+class _ScrollableErrorMessageWidgetState extends State<ScrollableErrorMessageWidget> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    return Padding(
+      padding: widget.padding ?? const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.title != null && widget.title!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: AutoSizeText(
+                widget.title!,
+                style: themeData.textTheme.labelMedium,
+                textAlign: TextAlign.left,
+                maxLines: 1,
+              ),
+            ),
+          Container(
+            constraints: const BoxConstraints(
+              maxHeight: 100,
+              minWidth: double.infinity,
+            ),
+            child: Scrollbar(
+              controller: _scrollController,
+              radius: const Radius.circular(16.0),
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                child: AutoSizeText(
+                  widget.message,
+                  style: themeData.errorTextStyle,
+                  textAlign: widget.message.length > 40 && !widget.message.contains("\n")
+                      ? TextAlign.start
+                      : TextAlign.left,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR addresses miscellaneous UI feedback.

- Map errors to user-friendly error messages
  - Map `PaymentError`'s to user friendly error messages
  - Map `LnUrlPayError`'s to user friendly error messages
    - closes #217
    - closes #3
- **fix:** Address scrollbar issues
- Do not limit error message to 3 lines
- **fix:** Address theme issues on `EnterPaymentInfoPage`
   - closes #225
- Beautify the error messages on receive payment pages
  - Fixed "Retry" mechanisms to refresh lnurl pay address if there has been an error,
  - Added "Retry" mechanisms to fetch payment limits if there has been an error,
  - closes #220
  