### PR TITLE
LNURL Withdraw rework cont.

### DIFF
--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -104,6 +104,8 @@ class InputHandler extends Handler {
       return handleBitcoinAddress(context, inputState);
     } else if (inputState is UrlInputState) {
       throw context.texts().payment_info_dialog_error_unsupported_input;
+    } else if (inputState is EmptyInputState) {
+      throw "Failed to parse input.";
     }
   }
 

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
@@ -29,6 +29,14 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
   ModalRoute? _loaderRoute;
 
   @override
+  void initState() {
+    super.initState();
+    _paymentInfoController.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);
@@ -89,14 +97,13 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
           ),
         ),
       ),
-      bottomNavigationBar: SingleButtonBottomBar(
-        text: _paymentInfoController.text.isNotEmpty && errorMessage.isEmpty
-            ? texts.payment_info_dialog_action_approve
-            : texts.payment_info_dialog_action_cancel,
-        onPressed: _paymentInfoController.text.isNotEmpty && errorMessage.isEmpty
-            ? _onApprovePressed
-            : () => Navigator.pop(context),
-      ),
+      bottomNavigationBar: _paymentInfoController.text.isNotEmpty
+          ? SingleButtonBottomBar(
+              stickToBottom: true,
+              text: texts.withdraw_funds_action_next,
+              onPressed: _onApprovePressed,
+            )
+          : const SizedBox.shrink(),
     );
   }
 
@@ -157,7 +164,7 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
       if (_formKey.currentState!.validate()) {
         _setLoading(false);
         if (mounted) Navigator.pop(context);
-        inputCubit.addIncomingInput(_paymentInfoController.text, InputSource.inputField);
+        inputCubit.addIncomingInput(_paymentInfoController.text.trim(), InputSource.inputField);
       }
     } catch (error) {
       _setLoading(false);
@@ -167,6 +174,8 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
           errorMessage = context.texts().payment_info_dialog_error;
         });
       }
+    } finally {
+      _setLoading(false);
     }
   }
 

--- a/lib/routes/lnurl/payment/widgets/lnurl_payment_comment.dart
+++ b/lib/routes/lnurl/payment/widgets/lnurl_payment_comment.dart
@@ -4,11 +4,13 @@ import 'package:flutter/services.dart';
 import 'package:l_breez/theme/src/theme.dart';
 
 class LnUrlPaymentComment extends StatelessWidget {
+  final bool enabled;
   final int maxCommentLength;
   final TextEditingController descriptionController;
 
   const LnUrlPaymentComment({
     super.key,
+    required this.enabled,
     required this.descriptionController,
     required this.maxCommentLength,
   });
@@ -19,6 +21,8 @@ class LnUrlPaymentComment extends StatelessWidget {
     final themeData = Theme.of(context);
 
     return TextFormField(
+      enabled: enabled,
+      readOnly: !enabled,
       controller: descriptionController,
       keyboardType: TextInputType.multiline,
       textInputAction: TextInputAction.done,

--- a/lib/routes/lnurl/payment/widgets/lnurl_payment_limits.dart
+++ b/lib/routes/lnurl/payment/widgets/lnurl_payment_limits.dart
@@ -44,13 +44,25 @@ class LnUrlPaymentLimits extends StatelessWidget {
         ),
       );
     }
+
+    var minNetworkLimit = limitsResponse!.send.minSat.toInt();
+    var maxNetworkLimit = limitsResponse!.send.maxSat.toInt();
     final effectiveMinSat = min(
-      max(limitsResponse!.send.minSat.toInt(), minSendableSat),
-      limitsResponse!.send.maxSat.toInt(),
+      max(minNetworkLimit, minSendableSat),
+      maxNetworkLimit,
     );
-    final effectiveMaxSat = min(limitsResponse!.send.maxSat.toInt(), maxSendableSat);
-    final effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-    final effMaxSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMaxSat);
+    final effectiveMaxSat = max(
+      minNetworkLimit,
+      min(maxNetworkLimit, maxSendableSat),
+    );
+
+    // Displays the original range if range is outside payment limits
+    final effMinSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? minSendableSat : effectiveMinSat,
+    );
+    final effMaxSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? maxSendableSat : effectiveMaxSat,
+    );
 
     return RichText(
       text: TextSpan(

--- a/lib/routes/lnurl/widgets/lnurl_metadata.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata.dart
@@ -54,6 +54,8 @@ class LNURLMetadataImage extends StatelessWidget {
         const imageSize = 128.0;
         return ConstrainedBox(
           constraints: const BoxConstraints(
+            minHeight: imageSize,
+            minWidth: imageSize,
             maxWidth: imageSize,
             maxHeight: imageSize,
           ),
@@ -65,6 +67,6 @@ class LNURLMetadataImage extends StatelessWidget {
         );
       }
     }
-    return Container();
+    return const SizedBox.shrink();
   }
 }

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -95,14 +95,14 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
         max(minNetworkLimit, minWithdrawableSat),
         maxNetworkLimit,
       );
-      final effectiveMaxSat = min(maxNetworkLimit, maxWithdrawableSat);
+      final rawMaxSat = min(maxNetworkLimit, maxWithdrawableSat);
       _updateFormFields(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
       );
       validatePayment(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
         effectiveMinSat: effectiveMinSat,
-        effectiveMaxSat: effectiveMaxSat,
+        effectiveMaxSat: rawMaxSat,
         throwError: true,
       );
     } catch (e) {

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -1,18 +1,20 @@
 import 'dart:math';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:l_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
+import 'package:l_breez/routes/receive_payment/lnurl/widgets/lnurl_withdraw_limits.dart';
 import 'package:l_breez/theme/src/theme.dart';
 import 'package:l_breez/theme/src/theme_extensions.dart';
 import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/always_disabled_focus_node.dart';
+import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/utils/payment_validator.dart';
 import 'package:l_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:l_breez/widgets/keyboard_done_action.dart';
@@ -45,7 +47,8 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
 
   bool _isFixedAmount = false;
   bool _loading = true;
-  String? _errorMessage;
+  bool _isFormEnabled = true;
+  String errorMessage = "";
   LightningPaymentLimitsResponse? _lightningLimits;
 
   @override
@@ -63,70 +66,57 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
     final paymentLimitsCubit = context.read<PaymentLimitsCubit>();
     try {
       final response = await paymentLimitsCubit.fetchLightningLimits();
-      _handleLightningPaymentLimitsResponse(response);
+      setState(() {
+        _lightningLimits = response;
+      });
+      await _handleLightningPaymentLimitsResponse();
     } catch (error) {
       setState(() {
-        _errorMessage = error.toString();
+        errorMessage = extractExceptionMessage(error, getSystemAppLocalizations());
+      });
+    } finally {
+      setState(() {
         _loading = false;
       });
     }
   }
 
-  void _handleLightningPaymentLimitsResponse(LightningPaymentLimitsResponse response) {
-    final minWithdrawableSat = widget.requestData.minWithdrawable.toInt() ~/ 1000;
-    final maxWithdrawableSat = widget.requestData.maxWithdrawable.toInt() ~/ 1000;
-    final effectiveMinSat = max(response.receive.minSat.toInt(), minWithdrawableSat);
-    final effectiveMaxSat = min(response.receive.maxSat.toInt(), maxWithdrawableSat);
-
-    _validateEffectiveLimits(effectiveMinSat: effectiveMinSat, effectiveMaxSat: effectiveMaxSat);
-
-    _updateFormFields(effectiveMaxSat: effectiveMaxSat);
-
-    setState(() {
-      _lightningLimits = response;
-      _loading = false;
-    });
-  }
-
-  void _validateEffectiveLimits({
-    required int effectiveMinSat,
-    required int effectiveMaxSat,
-  }) {
-    if (effectiveMaxSat < effectiveMinSat) {
-      final texts = context.texts();
-      final currencyCubit = context.read<CurrencyCubit>();
-      final currencyState = currencyCubit.state;
-
-      final isFixedAmountWithinLimits = _isFixedAmount && (effectiveMinSat == effectiveMaxSat);
-      if (!isFixedAmountWithinLimits) {
-        final effMinWithdrawableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-        final effMaxWithdrawableFormatted = currencyState.bitcoinCurrency.format(effectiveMaxSat);
-        throw Exception(
-          "Payment amount is outside the allowed limits, which range from $effMinWithdrawableFormatted to $effMaxWithdrawableFormatted",
-        );
-      }
-
-      final networkLimit = currencyState.bitcoinCurrency.format(
-        effectiveMinSat,
-        includeDisplayName: true,
+  Future<void> _handleLightningPaymentLimitsResponse() async {
+    try {
+      final minNetworkLimit = _lightningLimits!.receive.minSat.toInt();
+      final maxNetworkLimit = _lightningLimits!.receive.maxSat.toInt();
+      final minWithdrawableSat = widget.requestData.minWithdrawable.toInt() ~/ 1000;
+      final maxWithdrawableSat = widget.requestData.maxWithdrawable.toInt() ~/ 1000;
+      final effectiveMinSat = min(
+        max(minNetworkLimit, minWithdrawableSat),
+        maxNetworkLimit,
       );
-      throw Exception(texts.invoice_payment_validator_error_payment_below_invoice_limit(networkLimit));
+      final effectiveMaxSat = min(maxNetworkLimit, maxWithdrawableSat);
+      _updateFormFields(
+        amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
+      );
+      validatePayment(
+        amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
+        effectiveMinSat: effectiveMinSat,
+        effectiveMaxSat: effectiveMaxSat,
+        throwError: true,
+      );
+    } catch (e) {
+      rethrow;
     }
   }
 
   void _updateFormFields({
-    required int effectiveMaxSat,
+    required int amountSat,
   }) {
     if (_isFixedAmount) {
       final currencyCubit = context.read<CurrencyCubit>();
       final currencyState = currencyCubit.state;
 
       _amountController.text = currencyState.bitcoinCurrency.format(
-        effectiveMaxSat,
+        amountSat,
         includeDisplayName: false,
       );
-    } else if (_amountFocusNode.canRequestFocus) {
-      _amountFocusNode.requestFocus();
     }
 
     _descriptionController.text = widget.requestData.defaultDescription;
@@ -141,14 +131,13 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
+    final themeData = Theme.of(context);
 
     return Scaffold(
       key: _scaffoldKey,
       body: BlocBuilder<CurrencyCubit, CurrencyState>(
         builder: (context, currencyState) {
           if (_loading) {
-            final themeData = Theme.of(context);
-
             return Center(
               child: Loader(
                 color: themeData.primaryColor.withOpacity(0.5),
@@ -156,24 +145,18 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
             );
           }
 
-          if (_errorMessage != null) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32.0),
-                child: Text(
-                  _errorMessage!,
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            );
-          }
-
+          final minNetworkLimit = _lightningLimits!.receive.minSat.toInt();
+          final maxNetworkLimit = _lightningLimits!.receive.maxSat.toInt();
           final minWithdrawableSat = widget.requestData.minWithdrawable.toInt() ~/ 1000;
           final maxWithdrawableSat = widget.requestData.maxWithdrawable.toInt() ~/ 1000;
-          final effectiveMinSat = max(_lightningLimits!.receive.minSat.toInt(), minWithdrawableSat);
-          final effectiveMaxSat = min(_lightningLimits!.receive.maxSat.toInt(), maxWithdrawableSat);
-          final effMinWithdrawableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-          final effMaxWithdrawableFormatted = currencyState.bitcoinCurrency.format(effectiveMaxSat);
+          final effectiveMinSat = min(
+            max(minNetworkLimit, minWithdrawableSat),
+            maxNetworkLimit,
+          );
+          final effectiveMaxSat = max(
+            minNetworkLimit,
+            min(maxNetworkLimit, maxWithdrawableSat),
+          );
 
           return Padding(
             padding: const EdgeInsets.only(bottom: 40.0),
@@ -192,7 +175,8 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
                             keyboardType: TextInputType.multiline,
                             textInputAction: TextInputAction.done,
                             maxLines: null,
-                            readOnly: true,
+                            readOnly: !_isFormEnabled,
+                            enabled: _isFormEnabled,
                             focusNode: AlwaysDisabledFocusNode(),
                             decoration: InputDecoration(
                               labelText: texts.payment_details_dialog_action_for_payment_description,
@@ -205,42 +189,66 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
                           texts: texts,
                           bitcoinCurrency: currencyState.bitcoinCurrency,
                           focusNode: _isFixedAmount ? AlwaysDisabledFocusNode() : _amountFocusNode,
-                          autofocus: !_isFixedAmount,
-                          readOnly: _isFixedAmount,
+                          readOnly: !_isFormEnabled || _isFixedAmount,
+                          enabled: _isFormEnabled,
                           controller: _amountController,
-                          validatorFn: (amount) => validatePayment(
-                            amount: amount,
+                          validatorFn: (amountSat) => validatePayment(
+                            amountSat: amountSat,
                             effectiveMinSat: effectiveMinSat,
                             effectiveMaxSat: effectiveMaxSat,
                           ),
+                          returnFN: (amountStr) async {
+                            if (amountStr.isNotEmpty) {
+                              final amountSat = currencyState.bitcoinCurrency.parse(amountStr);
+                              setState(() {
+                                _amountController.text = currencyState.bitcoinCurrency.format(
+                                  amountSat,
+                                  includeDisplayName: false,
+                                );
+                              });
+                              _formKey.currentState?.validate();
+                            }
+                          },
+                          onFieldSubmitted: (amountStr) async {
+                            if (amountStr.isNotEmpty) {
+                              _formKey.currentState?.validate();
+                            }
+                          },
                           style: FieldTextStyle.textStyle,
+                          errorMaxLines: 3,
                         ),
                         if (!_isFixedAmount) ...[
+                          const SizedBox(height: 8.0),
                           Padding(
                             padding: const EdgeInsets.only(top: 8),
-                            child: RichText(
-                              text: TextSpan(
-                                style: FieldTextStyle.labelStyle,
-                                children: <TextSpan>[
-                                  TextSpan(
-                                    text: texts.lnurl_fetch_invoice_min(
-                                      effMinWithdrawableFormatted,
-                                    ),
-                                    recognizer: TapGestureRecognizer()
-                                      ..onTap = () => _pasteAmount(currencyState, effectiveMinSat),
-                                  ),
-                                  TextSpan(
-                                    text: texts.lnurl_fetch_invoice_and(
-                                      effMaxWithdrawableFormatted,
-                                    ),
-                                    recognizer: TapGestureRecognizer()
-                                      ..onTap = () => _pasteAmount(currencyState, effectiveMaxSat),
-                                  ),
-                                ],
-                              ),
+                            child: LnUrlWithdrawLimits(
+                              limitsResponse: _lightningLimits,
+                              minWithdrawableSat: minWithdrawableSat,
+                              maxWithdrawableSat: maxWithdrawableSat,
+                              onTap: (amountSat) async {
+                                _amountFocusNode.unfocus();
+                                setState(() {
+                                  _amountController.text = currencyState.bitcoinCurrency.format(
+                                    amountSat,
+                                    includeDisplayName: false,
+                                  );
+                                });
+                                _formKey.currentState?.validate();
+                              },
                             ),
-                          )
-                        ]
+                          ),
+                        ],
+                        if (errorMessage.isNotEmpty) ...[
+                          const SizedBox(height: 8.0),
+                          AutoSizeText(
+                            errorMessage,
+                            maxLines: 3,
+                            textAlign: TextAlign.left,
+                            style: FieldTextStyle.labelStyle.copyWith(
+                              color: themeData.colorScheme.error,
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),
@@ -252,21 +260,21 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
       ),
       bottomNavigationBar: _loading
           ? null
-          : (_errorMessage == null)
+          : errorMessage.isNotEmpty
               ? SingleButtonBottomBar(
+                  stickToBottom: true,
+                  text: texts.qr_code_dialog_action_close,
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                )
+              : SingleButtonBottomBar(
                   stickToBottom: true,
                   text: texts.invoice_action_redeem,
                   onPressed: () {
                     if (_formKey.currentState?.validate() ?? false) {
                       _withdraw();
                     }
-                  },
-                )
-              : SingleButtonBottomBar(
-                  stickToBottom: true,
-                  text: texts.qr_code_dialog_action_close,
-                  onPressed: () {
-                    Navigator.of(context).pop();
                   },
                 ),
     );
@@ -298,42 +306,73 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
   }
 
   String? validatePayment({
-    required int amount,
+    required int amountSat,
     required int effectiveMinSat,
     required int effectiveMaxSat,
+    bool throwError = false,
   }) {
     final texts = context.texts();
     final currencyCubit = context.read<CurrencyCubit>();
     final currencyState = currencyCubit.state;
 
-    if (amount > effectiveMaxSat) {
-      return texts.lnurl_withdraw_dialog_error_amount_exceeds(effectiveMaxSat);
+    if (errorMessage.isNotEmpty) {
+      return errorMessage;
     }
 
-    if (amount < effectiveMinSat) {
-      return texts.lnurl_withdraw_dialog_error_amount_below(effectiveMinSat);
+    String? message;
+    if (_lightningLimits == null) {
+      message = "Failed to retrieve network payment limits. Please try again later.";
     }
 
-    return PaymentValidator(
-      validatePayment: _validatePayment,
-      currency: currencyState.bitcoinCurrency,
-      texts: context.texts(),
-    ).validateIncoming(amount);
+    if (_isFixedAmount && effectiveMinSat == effectiveMaxSat) {
+      final minNetworkLimit = _lightningLimits!.receive.minSat.toInt();
+      final maxNetworkLimit = _lightningLimits!.receive.maxSat.toInt();
+      final minNetworkLimitFormatted = currencyState.bitcoinCurrency.format(minNetworkLimit);
+      final maxNetworkLimitFormatted = currencyState.bitcoinCurrency.format(maxNetworkLimit);
+      message =
+          "Payment amount is outside the allowed limits, which range from $minNetworkLimitFormatted to $maxNetworkLimitFormatted";
+    } else if (effectiveMaxSat < effectiveMinSat) {
+      final networkLimit = currencyState.bitcoinCurrency.format(
+        effectiveMinSat,
+        includeDisplayName: true,
+      );
+      message = texts.invoice_payment_validator_error_payment_below_invoice_limit(networkLimit);
+      setState(() {
+        _isFormEnabled = false;
+      });
+    } else if (amountSat > effectiveMaxSat) {
+      final networkLimit = "(${currencyState.bitcoinCurrency.format(
+        effectiveMaxSat,
+        includeDisplayName: true,
+      )})";
+      message = throwError
+          ? texts.valid_payment_error_exceeds_the_limit(networkLimit)
+          : texts.lnurl_withdraw_dialog_error_amount_exceeds(effectiveMaxSat);
+    } else if (amountSat < effectiveMinSat) {
+      final effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
+      message = throwError
+          ? "${texts.invoice_payment_validator_error_payment_below_invoice_limit(effMinSendableFormatted)}."
+          : texts.lnurl_withdraw_dialog_error_amount_below(effectiveMinSat);
+    } else {
+      message = PaymentValidator(
+        validatePayment: _validateLnUrlWithdraw,
+        currency: currencyState.bitcoinCurrency,
+        texts: context.texts(),
+      ).validateOutgoing(amountSat);
+    }
+    setState(() {
+      errorMessage = message ?? "";
+    });
+    if (message != null && throwError) {
+      throw message;
+    }
+    return message;
   }
 
-  void _validatePayment(int amount, bool outgoing) {
+  void _validateLnUrlWithdraw(int amount, bool outgoing) {
     final accountState = context.read<AccountCubit>().state;
     final balance = accountState.walletInfo!.balanceSat.toInt();
     final lnUrlCubit = context.read<LnUrlCubit>();
     return lnUrlCubit.validateLnUrlPayment(BigInt.from(amount), outgoing, _lightningLimits!, balance);
-  }
-
-  void _pasteAmount(CurrencyState currencyState, int amountSat) {
-    setState(() {
-      _amountController.text = currencyState.bitcoinCurrency.format(
-        amountSat,
-        includeDisplayName: false,
-      );
-    });
   }
 }

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -96,13 +96,15 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
         maxNetworkLimit,
       );
       final rawMaxSat = min(maxNetworkLimit, maxWithdrawableSat);
+      final effectiveMaxSat = max(minNetworkLimit, rawMaxSat);
       _updateFormFields(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
       );
       validatePayment(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
         effectiveMinSat: effectiveMinSat,
-        effectiveMaxSat: rawMaxSat,
+        rawMaxSat: rawMaxSat,
+        effectiveMaxSat: effectiveMaxSat,
         throwError: true,
       );
     } catch (e) {
@@ -286,7 +288,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
                     _fetchLightningLimits();
                   },
                 )
-              : errorMessage.isNotEmpty
+              : !_isFormEnabled || _isFixedAmount && errorMessage.isNotEmpty
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
                       text: texts.qr_code_dialog_action_close,
@@ -334,6 +336,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
   String? validatePayment({
     required int amountSat,
     required int effectiveMinSat,
+    int? rawMaxSat,
     required int effectiveMaxSat,
     bool throwError = false,
   }) {
@@ -357,7 +360,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
       final maxNetworkLimitFormatted = currencyState.bitcoinCurrency.format(maxNetworkLimit);
       message =
           "Payment amount is outside the allowed limits, which range from $minNetworkLimitFormatted to $maxNetworkLimitFormatted";
-    } else if (effectiveMaxSat < effectiveMinSat) {
+    } else if (rawMaxSat != null && rawMaxSat < effectiveMinSat) {
       final networkLimit = currencyState.bitcoinCurrency.format(
         effectiveMinSat,
         includeDisplayName: true,

--- a/lib/routes/receive_payment/lnurl/widgets/lnurl_withdraw_limits.dart
+++ b/lib/routes/receive_payment/lnurl/widgets/lnurl_withdraw_limits.dart
@@ -1,0 +1,88 @@
+import 'dart:math';
+
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/theme/src/theme.dart';
+
+class LnUrlWithdrawLimits extends StatelessWidget {
+  final LightningPaymentLimitsResponse? limitsResponse;
+  final int minWithdrawableSat;
+  final int maxWithdrawableSat;
+  final Future<void> Function(dynamic amount) onTap;
+
+  const LnUrlWithdrawLimits({
+    super.key,
+    required this.limitsResponse,
+    required this.minWithdrawableSat,
+    required this.maxWithdrawableSat,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final currencyCubit = context.read<CurrencyCubit>();
+    final currencyState = currencyCubit.state;
+
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+
+    if (limitsResponse == null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: AutoSizeText(
+          "Failed to fetch payment limits.",
+          maxLines: 3,
+          textAlign: TextAlign.left,
+          style: FieldTextStyle.labelStyle.copyWith(
+            color: themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
+          ),
+        ),
+      );
+    }
+
+    final minNetworkLimit = limitsResponse!.receive.minSat.toInt();
+    final maxNetworkLimit = limitsResponse!.receive.maxSat.toInt();
+    final effectiveMinSat = min(
+      max(minNetworkLimit, minWithdrawableSat),
+      maxNetworkLimit,
+    );
+    final effectiveMaxSat = max(
+      minNetworkLimit,
+      min(maxNetworkLimit, maxWithdrawableSat),
+    );
+
+    // Displays the original range if range is outside payment limits
+    final effMinSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? minWithdrawableSat : effectiveMinSat,
+    );
+    final effMaxSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? maxWithdrawableSat : effectiveMaxSat,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: TextSpan(
+            style: FieldTextStyle.labelStyle,
+            children: <TextSpan>[
+              TextSpan(
+                text: texts.lnurl_fetch_invoice_min(effMinSendableFormatted),
+                recognizer: TapGestureRecognizer()..onTap = () => onTap(effectiveMinSat),
+              ),
+              TextSpan(
+                text: texts.lnurl_fetch_invoice_and(effMaxSendableFormatted),
+                recognizer: TapGestureRecognizer()..onTap = () => onTap(effectiveMaxSat),
+              )
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -31,6 +31,9 @@ String extractExceptionMessage(
   if (exception is LnUrlPayError) {
     return _getLnUrlPayErrorMessage(exception, texts);
   }
+  if (exception is LnUrlWithdrawError) {
+    return _getLnUrlWithdrawErrorMessage(exception, texts);
+  }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
 }
 
@@ -103,6 +106,24 @@ String _getLnUrlPayErrorMessage(LnUrlPayError error, BreezTranslations texts) {
   } else if (error is LnUrlPayError_RouteTooExpensive) {
     message = "Route too expensive: ${error.err}";
   } else if (error is LnUrlPayError_ServiceConnectivity) {
+    message = "Service connectivity: ${error.err}";
+  }
+  return message;
+}
+
+String _getLnUrlWithdrawErrorMessage(LnUrlWithdrawError error, BreezTranslations texts) {
+  String message = error.toString();
+  if (error is LnUrlWithdrawError_Generic) {
+    message = "LNURL Withdraw error: ${error.err}";
+  } else if (error is LnUrlWithdrawError_InvalidAmount) {
+    message = "Invalid amount: ${error.err}";
+  } else if (error is LnUrlWithdrawError_InvalidInvoice) {
+    message = "Invalid invoice: ${error.err}";
+  } else if (error is LnUrlWithdrawError_InvalidUri) {
+    message = "Invalid uri: ${error.err}";
+  } else if (error is LnUrlWithdrawError_InvoiceNoRoutingHints) {
+    message = "No routing hints: ${error.err}";
+  } else if (error is LnUrlWithdrawError_ServiceConnectivity) {
     message = "Service connectivity: ${error.err}";
   }
   return message;


### PR DESCRIPTION
This PR expands upon the LNURL Withdraw UI introduced in #167 by improving error handling and fullscreen support on payment processing dialog.

### Changelist:
- Error messages are now shown with the withdraw request data, previously on the error was shown to the user
  - Handled cases where:
    - there are etwork payment limit retrieval errors,
    - payment amount is outside network payment limits for fixed invoices,
    - accepted payment range is below network limits.
  - Pre-populates form fields with `LnUrlWithdrawRequestData` at all times
  - Disables form if data is invalid or below network limits,
  - Introduces & uses `LnUrlWithdrawLimits` widget to show LN Service's accepted payment range.
- Show flushbar messages for input parsing errors
  - Handles LNURL parsing issues related to service or connection failures
- Users can now refresh payment limits on the `LnUrlWithdraw` page _if there's been an error retrieving them_ without re-opening the page
- Maps `LnUrlWithdrawError`'s to user-friendly messages  
- `LNURLWithdrawDialog` is now a fullscreen dialog

