### PR TITLE
Track newly received payments when on "Receive via Lightning Address" page

### DIFF
--- a/lib/cubit/input/input_cubit.dart
+++ b/lib/cubit/input/input_cubit.dart
@@ -38,8 +38,8 @@ class InputCubit extends Cubit<InputState> {
     _decodeInvoiceController.add(InputData(data: input, source: source));
   }
 
-  Future<void> trackPayment(String? paymentDestination) async {
-    _log.info("Tracking incoming payment: $paymentDestination");
+  Future<void> trackPaymentEvents(String? paymentDestination) async {
+    _log.info("Tracking incoming payment events for: $paymentDestination");
     final paymentDestinationIsEmpty = paymentDestination == null || paymentDestination.isEmpty;
     await ServiceInjector().liquidSDK.paymentEventStream.firstWhere((paymentEvent) {
       final payment = paymentEvent.payment;

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -49,6 +49,7 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                       children: [
                         if (webhookState.lnurlPayUrl != null)
                           DestinationWidget(
+                            isLnAddress: true,
                             destination: webhookState.lnurlPayUrl!,
                             title: texts.receive_payment_method_lightning_address,
                             infoWidget: const PaymentLimitsMessageBox(),

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -113,16 +113,18 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   void _onPaymentFinished(bool isSuccess) {
     Timer(const Duration(milliseconds: 1000), () {
       if (!mounted) return;
-      if (isSuccess == true) {
-        // Close the page and show successful payment route
-        Navigator.of(context)
-          ..pop()
-          ..push(
-            PageRouteBuilder(
-              opaque: false,
-              pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
-            ),
-          );
+      if (isSuccess) {
+        final navigator = Navigator.of(context);
+        if (!widget.isLnAddress) {
+          navigator.pop(); // Only pop if destination is not an LN Address
+        }
+        // Show successful payment route
+        navigator.push(
+          PageRouteBuilder(
+            opaque: false,
+            pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+          ),
+        );
       } else {
         if (widget.isLnAddress) _paymentStateSubscription?.cancel();
         showFlushbar(context, title: "", message: "Payment failed.");

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -130,7 +130,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
       navigator.push(
         PageRouteBuilder(
           opaque: false,
-          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(particlesEnabled: false),
         ),
       );
     } else {

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -78,6 +78,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   }
 
   void _trackNewPayments() {
+    _log.info("Tracking new payments.");
     final paymentsCubit = context.read<PaymentsCubit>();
     _receivedPaymentSubscription?.cancel();
     _receivedPaymentSubscription = paymentsCubit.stream
@@ -106,7 +107,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   void _trackPaymentEvents(String? destination) {
     final inputCubit = context.read<InputCubit>();
     inputCubit
-        .trackPayment(destination)
+        .trackPaymentEvents(destination)
         .then((_) => _onPaymentFinished(true))
         .catchError((e) => _onTrackPaymentError(e));
   }

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -125,26 +125,24 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   }
 
   void _onPaymentFinished(bool isSuccess) {
-    Timer(const Duration(milliseconds: 1000), () {
-      if (!mounted) return;
-      if (isSuccess) {
-        final navigator = Navigator.of(context);
-        if (!widget.isLnAddress) {
-          navigator.pop(); // Only pop if destination is not an LN Address
-        }
-        // Show successful payment route
-        navigator.push(
-          PageRouteBuilder(
-            opaque: false,
-            pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
-          ),
-        );
-      } else {
-        if (!widget.isLnAddress) {
-          showFlushbar(context, title: "", message: "Payment failed.");
-        }
+    if (!mounted) return;
+    if (isSuccess) {
+      final navigator = Navigator.of(context);
+      if (!widget.isLnAddress) {
+        navigator.pop(); // Only pop if destination is not an LN Address
       }
-    });
+      // Show successful payment route
+      navigator.push(
+        PageRouteBuilder(
+          opaque: false,
+          pageBuilder: (_, __, ___) => const SuccessfulPaymentRoute(),
+        ),
+      );
+    } else {
+      if (!widget.isLnAddress) {
+        showFlushbar(context, title: "", message: "Payment failed.");
+      }
+    }
   }
 
   @override

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -49,8 +49,9 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   @override
   void didUpdateWidget(covariant DestinationWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-
-    /// Receive pages other than LN Address wait for user input for invoice to be created, hence they rely on didUpdateWidget and not initState
+    // For receive payment pages other than LN Address, user input is required before creating an invoice.
+    // Therefore, they rely on `didUpdateWidget` instead of `initState` to capture updates after
+    // initial widget setup.
     if (!widget.isLnAddress) {
       _trackPaymentEvents(getUpdatedDestination(oldWidget));
     }
@@ -128,10 +129,9 @@ class _DestinationWidgetState extends State<DestinationWidget> {
     if (!mounted) return;
     if (isSuccess) {
       final navigator = Navigator.of(context);
-      if (!widget.isLnAddress) {
-        navigator.pop(); // Only pop if destination is not an LN Address
-      }
-      // Show successful payment route
+      // Only pop if the destination is not an LN Address,
+      // as there's no way to 1:1 match payments on the LN Address page.
+      if (!widget.isLnAddress) navigator.pop();
       navigator.push(
         PageRouteBuilder(
           opaque: false,

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -52,11 +52,23 @@ class _DestinationWidgetState extends State<DestinationWidget> {
 
     /// Receive pages other than LN Address wait for user input for invoice to be created, hence they rely on didUpdateWidget and not initState
     if (!widget.isLnAddress) {
-      final hasUpdatedDestination = widget.destination != oldWidget.destination;
-      if (hasUpdatedDestination || _hasNewDestination(widget.snapshot, oldWidget.snapshot)) {
-        _trackPaymentEvents(widget.destination ?? widget.snapshot?.data?.destination);
-      }
+      _trackPaymentEvents(getUpdatedDestination(oldWidget));
     }
+  }
+
+  String? getUpdatedDestination(DestinationWidget oldWidget) {
+    final hasUpdatedDestination = widget.destination != oldWidget.destination;
+    if (widget.destination != null && hasUpdatedDestination) {
+      return widget.destination!;
+    }
+
+    final newSnapshotDestination = widget.snapshot?.data?.destination;
+    final oldSnapshotDestination = oldWidget.snapshot?.data?.destination;
+    if (newSnapshotDestination != null && newSnapshotDestination != oldSnapshotDestination) {
+      return newSnapshotDestination;
+    }
+
+    return null;
   }
 
   @override
@@ -94,15 +106,6 @@ class _DestinationWidgetState extends State<DestinationWidget> {
       _processedPayments.add(paymentId);
     }
     _onPaymentFinished(isPaymentReceived);
-  }
-
-  bool _hasNewDestination(
-    AsyncSnapshot<ReceivePaymentResponse>? newSnapshot,
-    AsyncSnapshot<ReceivePaymentResponse>? oldSnapshot,
-  ) {
-    return newSnapshot?.hasData == true &&
-        oldSnapshot?.hasData == true &&
-        newSnapshot!.data!.destination != oldSnapshot!.data!.destination;
   }
 
   void _trackPaymentEvents(String? destination) {

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -126,8 +126,11 @@ class _DestinationWidgetState extends State<DestinationWidget> {
           ),
         );
       } else {
-        if (widget.isLnAddress) _paymentStateSubscription?.cancel();
-        showFlushbar(context, title: "", message: "Payment failed.");
+        if (widget.isLnAddress) {
+          _paymentStateSubscription?.cancel();
+        } else {
+          showFlushbar(context, title: "", message: "Payment failed.");
+        }
       }
     });
   }

--- a/lib/routes/receive_payment/widgets/successful_payment/successful_payment.dart
+++ b/lib/routes/receive_payment/widgets/successful_payment/successful_payment.dart
@@ -3,7 +3,9 @@ import 'package:l_breez/routes/receive_payment/widgets/destination_widget/widget
 import 'package:l_breez/routes/receive_payment/widgets/successful_payment/successful_payment_message.dart';
 
 class SuccessfulPaymentRoute extends StatefulWidget {
-  const SuccessfulPaymentRoute({super.key});
+  final bool particlesEnabled;
+
+  const SuccessfulPaymentRoute({super.key, this.particlesEnabled = true});
 
   @override
   State<StatefulWidget> createState() => SuccessfulPaymentRouteState();
@@ -53,7 +55,7 @@ class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute> with Tic
       if (status == AnimationStatus.reverse) {
         Future.delayed(const Duration(milliseconds: 400), () {
           setState(() {
-            showParticles = true;
+            showParticles = widget.particlesEnabled;
           });
           _particlesController.forward();
         });


### PR DESCRIPTION
Since LN Address payments are handled by the notification extensions, by the help of LNURL services, there isn't an easy way to track LN Address payments as there are no associated PaymentEvent's to listen for.

Although we cannot listen for direct payment events for LN addresses, we can still monitor the payments list. When a user is opens "Receive via Lightning Address" page, we check for new payments in the list.

If a new incoming payment is detected, we display the successful payment route to the user.

**Known bugs & issues:**
- [x] Successful payment route is shown for both pending & completed status updates for the same payment. 
  - [Show successful payment route once for each payment](https://github.com/breez/misty-breez/pull/223/commits/a9ff444bb499a83037066c84c91a70237b0a89f7)
- [x] There's a noticeable delay between payment list being updated with new item & it being handled on "Receive via Lightning Address" page
  - Does not appear to be an app related(_Flutter component_) issue, force syncing earlier on SDK's notification extension plugin could help with the delay.
  - This will be investigated handled in scope of another PR