### PR TITLE
LNURL payment page improved error handling

### DIFF
--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_page.dart
@@ -29,6 +29,14 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
   ModalRoute? _loaderRoute;
 
   @override
+  void initState() {
+    super.initState();
+    _paymentInfoController.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);
@@ -89,14 +97,13 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
           ),
         ),
       ),
-      bottomNavigationBar: SingleButtonBottomBar(
-        text: _paymentInfoController.text.isNotEmpty && errorMessage.isEmpty
-            ? texts.payment_info_dialog_action_approve
-            : texts.payment_info_dialog_action_cancel,
-        onPressed: _paymentInfoController.text.isNotEmpty && errorMessage.isEmpty
-            ? _onApprovePressed
-            : () => Navigator.pop(context),
-      ),
+      bottomNavigationBar: _paymentInfoController.text.isNotEmpty
+          ? SingleButtonBottomBar(
+              stickToBottom: true,
+              text: texts.withdraw_funds_action_next,
+              onPressed: _onApprovePressed,
+            )
+          : const SizedBox.shrink(),
     );
   }
 
@@ -157,7 +164,7 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
       if (_formKey.currentState!.validate()) {
         _setLoading(false);
         if (mounted) Navigator.pop(context);
-        inputCubit.addIncomingInput(_paymentInfoController.text, InputSource.inputField);
+        inputCubit.addIncomingInput(_paymentInfoController.text.trim(), InputSource.inputField);
       }
     } catch (error) {
       _setLoading(false);
@@ -167,6 +174,8 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
           errorMessage = context.texts().payment_info_dialog_error;
         });
       }
+    } finally {
+      _setLoading(false);
     }
   }
 

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -345,41 +345,43 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
           );
         },
       ),
-      bottomNavigationBar: _lightningLimits == null
-          ? SingleButtonBottomBar(
-              stickToBottom: true,
-              text: texts.invoice_ln_address_action_retry,
-              onPressed: () {
-                _fetchLightningLimits();
-              },
-            )
-          : errorMessage.isNotEmpty
+      bottomNavigationBar: _loading
+          ? null
+          : _lightningLimits == null
               ? SingleButtonBottomBar(
                   stickToBottom: true,
-                  text: texts.qr_code_dialog_action_close,
+                  text: texts.invoice_ln_address_action_retry,
                   onPressed: () {
-                    Navigator.of(context).pop();
+                    _fetchLightningLimits();
                   },
                 )
-              : !_isFixedAmount
+              : errorMessage.isNotEmpty
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
-                      text: texts.lnurl_fetch_invoice_action_continue,
-                      onPressed: () async {
-                        if (_formKey.currentState?.validate() ?? false) {
-                          await _openConfirmationPage();
-                        }
+                      text: texts.qr_code_dialog_action_close,
+                      onPressed: () {
+                        Navigator.of(context).pop();
                       },
                     )
-                  : _prepareResponse != null
+                  : !_isFixedAmount
                       ? SingleButtonBottomBar(
                           stickToBottom: true,
-                          text: texts.lnurl_payment_page_action_pay,
+                          text: texts.lnurl_fetch_invoice_action_continue,
                           onPressed: () async {
-                            Navigator.pop(context, _prepareResponse);
+                            if (_formKey.currentState?.validate() ?? false) {
+                              await _openConfirmationPage();
+                            }
                           },
                         )
-                      : const SizedBox.shrink(),
+                      : _prepareResponse != null
+                          ? SingleButtonBottomBar(
+                              stickToBottom: true,
+                              text: texts.lnurl_payment_page_action_pay,
+                              onPressed: () async {
+                                Navigator.pop(context, _prepareResponse);
+                              },
+                            )
+                          : const SizedBox.shrink(),
     );
   }
 

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -17,6 +17,7 @@ import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/keyboard_done_action.dart';
 import 'package:l_breez/widgets/loader.dart';
 import 'package:l_breez/widgets/route.dart';
+import 'package:l_breez/widgets/scrollable_error_message_widget.dart';
 import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 import 'package:service_injector/service_injector.dart';
 
@@ -190,6 +191,20 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
           String? base64String = metadataMap['image/png;base64'] ?? metadataMap['image/jpeg;base64'];
           String payeeName = metadataMap["text/identifier"] ?? widget.requestData.domain;
           String? metadataText = metadataMap['text/long-desc'] ?? metadataMap['text/plain'];
+
+          if (_lightningLimits == null) {
+            if (errorMessage.isEmpty) {
+              return Center(
+                child: Loader(
+                  color: themeData.primaryColor.withOpacity(0.5),
+                ),
+              );
+            }
+            return ScrollableErrorMessageWidget(
+              title: "Failed to retrieve payment limits:",
+              message: texts.reverse_swap_upstream_generic_error_message(errorMessage),
+            );
+          }
 
           final minNetworkLimit = _lightningLimits!.send.minSat.toInt();
           final maxNetworkLimit = _lightningLimits!.send.maxSat.toInt();

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -100,11 +100,13 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       maxNetworkLimit,
     );
     final rawMaxSat = min(maxNetworkLimit, maxSendableSat);
+    final effectiveMaxSat = max(minNetworkLimit, rawMaxSat);
     _updateFormFields(amountSat: minSendableSat);
     final errorMessage = validatePayment(
       amountSat: _isFixedAmount ? minSendableSat : effectiveMinSat,
       effectiveMinSat: effectiveMinSat,
-      effectiveMaxSat: rawMaxSat,
+      rawMaxSat: rawMaxSat,
+      effectiveMaxSat: effectiveMaxSat,
       throwError: true,
     );
     if (errorMessage == null && _isFixedAmount) {
@@ -389,6 +391,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
   String? validatePayment({
     required int amountSat,
     required int effectiveMinSat,
+    int? rawMaxSat,
     required int effectiveMaxSat,
     bool throwError = false,
   }) {
@@ -408,7 +411,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       final maxNetworkLimitFormatted = currencyState.bitcoinCurrency.format(maxNetworkLimit);
       message =
           "Payment amount is outside the allowed limits, which range from $minNetworkLimitFormatted to $maxNetworkLimitFormatted";
-    } else if (effectiveMaxSat < effectiveMinSat) {
+    } else if (rawMaxSat != null && rawMaxSat < effectiveMinSat) {
       final networkLimit = currencyState.bitcoinCurrency.format(
         effectiveMinSat,
         includeDisplayName: true,

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -213,12 +213,10 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                   mainAxisSize: MainAxisSize.max,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (base64String != null && base64String.isNotEmpty) ...[
-                      Padding(
-                        padding: EdgeInsets.zero,
-                        child: Center(child: LNURLMetadataImage(base64String: base64String)),
-                      ),
-                    ],
+                    Padding(
+                      padding: EdgeInsets.zero,
+                      child: Center(child: LNURLMetadataImage(base64String: base64String)),
+                    ),
                     if (_isFixedAmount) ...[
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 16.0),

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -300,7 +300,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                           },
                         ),
                       ),
-                      if (errorMessage.isNotEmpty) ...[
+                      if (!_isFormEnabled || _isFixedAmount && errorMessage.isNotEmpty) ...[
                         const SizedBox(height: 8.0),
                         AutoSizeText(
                           errorMessage,
@@ -359,7 +359,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                     _fetchLightningLimits();
                   },
                 )
-              : errorMessage.isNotEmpty
+              : !_isFormEnabled || _isFixedAmount && errorMessage.isNotEmpty
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
                       text: texts.qr_code_dialog_action_close,
@@ -370,7 +370,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                   : !_isFixedAmount
                       ? SingleButtonBottomBar(
                           stickToBottom: true,
-                          text: texts.lnurl_fetch_invoice_action_continue,
+                          text: texts.withdraw_funds_action_next,
                           onPressed: () async {
                             if (_formKey.currentState?.validate() ?? false) {
                               await _openConfirmationPage();
@@ -380,7 +380,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                       : _prepareResponse != null
                           ? SingleButtonBottomBar(
                               stickToBottom: true,
-                              text: texts.lnurl_payment_page_action_pay,
+                              text: texts.bottom_action_bar_send,
                               onPressed: () async {
                                 Navigator.pop(context, _prepareResponse);
                               },

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -22,13 +22,14 @@ import 'package:l_breez/widgets/single_button_bottom_bar.dart';
 import 'package:service_injector/service_injector.dart';
 
 class LnUrlPaymentPage extends StatefulWidget {
+  final bool isConfirmation;
   final LnUrlPayRequestData requestData;
   final String? comment;
 
   static const routeName = "/lnurl_payment";
   static const paymentMethod = PaymentMethod.lightning;
 
-  const LnUrlPaymentPage({super.key, required this.requestData, this.comment});
+  const LnUrlPaymentPage({super.key, this.isConfirmation = false, required this.requestData, this.comment});
 
   @override
   State<StatefulWidget> createState() => LnUrlPaymentPageState();
@@ -400,7 +401,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       message = "Failed to retrieve network payment limits. Please try again later.";
     }
 
-    if (_isFixedAmount && effectiveMinSat == effectiveMaxSat) {
+    if (!widget.isConfirmation && _isFixedAmount && effectiveMinSat == effectiveMaxSat) {
       final minNetworkLimit = _lightningLimits!.send.minSat.toInt();
       final maxNetworkLimit = _lightningLimits!.send.maxSat.toInt();
       final minNetworkLimitFormatted = currencyState.bitcoinCurrency.format(minNetworkLimit);
@@ -467,6 +468,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
         builder: (_) => BlocProvider(
           create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().liquidSDK),
           child: LnUrlPaymentPage(
+            isConfirmation: true,
             requestData: requestData,
             comment: _descriptionController.text,
           ),

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -109,6 +109,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       effectiveMaxSat: effectiveMaxSat,
       throwError: true,
     );
+    _updateFormFields(amountSat: effectiveMinSat);
     if (errorMessage == null && _isFixedAmount) {
       await _prepareLnUrlPayment(rawMaxSat);
     }

--- a/lib/routes/lnurl/payment/widgets/lnurl_payment_comment.dart
+++ b/lib/routes/lnurl/payment/widgets/lnurl_payment_comment.dart
@@ -4,11 +4,13 @@ import 'package:flutter/services.dart';
 import 'package:l_breez/theme/src/theme.dart';
 
 class LnUrlPaymentComment extends StatelessWidget {
+  final bool enabled;
   final int maxCommentLength;
   final TextEditingController descriptionController;
 
   const LnUrlPaymentComment({
     super.key,
+    required this.enabled,
     required this.descriptionController,
     required this.maxCommentLength,
   });
@@ -19,6 +21,8 @@ class LnUrlPaymentComment extends StatelessWidget {
     final themeData = Theme.of(context);
 
     return TextFormField(
+      enabled: enabled,
+      readOnly: !enabled,
       controller: descriptionController,
       keyboardType: TextInputType.multiline,
       textInputAction: TextInputAction.done,

--- a/lib/routes/lnurl/payment/widgets/lnurl_payment_limits.dart
+++ b/lib/routes/lnurl/payment/widgets/lnurl_payment_limits.dart
@@ -44,13 +44,25 @@ class LnUrlPaymentLimits extends StatelessWidget {
         ),
       );
     }
+
+    var minNetworkLimit = limitsResponse!.send.minSat.toInt();
+    var maxNetworkLimit = limitsResponse!.send.maxSat.toInt();
     final effectiveMinSat = min(
-      max(limitsResponse!.send.minSat.toInt(), minSendableSat),
-      limitsResponse!.send.maxSat.toInt(),
+      max(minNetworkLimit, minSendableSat),
+      maxNetworkLimit,
     );
-    final effectiveMaxSat = min(limitsResponse!.send.maxSat.toInt(), maxSendableSat);
-    final effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-    final effMaxSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMaxSat);
+    final effectiveMaxSat = max(
+      minNetworkLimit,
+      min(maxNetworkLimit, maxSendableSat),
+    );
+
+    // Displays the original range if range is outside payment limits
+    final effMinSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? minSendableSat : effectiveMinSat,
+    );
+    final effMaxSendableFormatted = currencyState.bitcoinCurrency.format(
+      (effectiveMinSat == effectiveMaxSat) ? maxSendableSat : effectiveMaxSat,
+    );
 
     return RichText(
       text: TextSpan(

--- a/lib/routes/lnurl/widgets/lnurl_metadata.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata.dart
@@ -54,6 +54,8 @@ class LNURLMetadataImage extends StatelessWidget {
         const imageSize = 128.0;
         return ConstrainedBox(
           constraints: const BoxConstraints(
+            minHeight: imageSize,
+            minWidth: imageSize,
             maxWidth: imageSize,
             maxHeight: imageSize,
           ),
@@ -65,6 +67,6 @@ class LNURLMetadataImage extends StatelessWidget {
         );
       }
     }
-    return Container();
+    return const SizedBox.shrink();
   }
 }

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -288,7 +288,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
                     _fetchLightningLimits();
                   },
                 )
-              : errorMessage.isNotEmpty
+              : !_isFormEnabled || _isFixedAmount && errorMessage.isNotEmpty
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
                       text: texts.qr_code_dialog_action_close,

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -96,13 +96,15 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
         maxNetworkLimit,
       );
       final rawMaxSat = min(maxNetworkLimit, maxWithdrawableSat);
+      final effectiveMaxSat = max(minNetworkLimit, rawMaxSat);
       _updateFormFields(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
       );
       validatePayment(
         amountSat: _isFixedAmount ? minWithdrawableSat : effectiveMinSat,
         effectiveMinSat: effectiveMinSat,
-        effectiveMaxSat: rawMaxSat,
+        rawMaxSat: rawMaxSat,
+        effectiveMaxSat: effectiveMaxSat,
         throwError: true,
       );
     } catch (e) {
@@ -334,6 +336,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
   String? validatePayment({
     required int amountSat,
     required int effectiveMinSat,
+    int? rawMaxSat,
     required int effectiveMaxSat,
     bool throwError = false,
   }) {
@@ -357,7 +360,7 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
       final maxNetworkLimitFormatted = currencyState.bitcoinCurrency.format(maxNetworkLimit);
       message =
           "Payment amount is outside the allowed limits, which range from $minNetworkLimitFormatted to $maxNetworkLimitFormatted";
-    } else if (effectiveMaxSat < effectiveMinSat) {
+    } else if (rawMaxSat != null && rawMaxSat < effectiveMinSat) {
       final networkLimit = currencyState.bitcoinCurrency.format(
         effectiveMinSat,
         includeDisplayName: true,


### PR DESCRIPTION
This PR bring changes from #227 into LNURL payment page to improve error handling and ensure consistency.

### Changelist:
- Error messages are now shown with the payment request data. Previously, only the error was shown to the user
  - Handled cases where:
    - there are network payment limit retrieval errors,
    - payment amount is outside network payment limits for fixed invoices,
    - accepted payment range is below network limits.
   - Pre-populates form fields with LnUrlPayRequestData if possible
   -   Sets amount to effective minimum amount if there's no errors
   - Disables form if data is invalid or below network limits,
 - Users can now refresh payment limits on the LnUrlPayment page if there's been an error retrieving them without re-opening the page
 - Change bottom bar button visibility & texts per feedback
    - "Close" button is only shown for invalid invoices,
    - "Continue" texts are replaced with "Next",
    - "Pay" text is replaced with "Send",
    - Fixed a bug where the same error message is shown in two different places on LNURL payment UI