### PR TITLE
Wait for initial sync to complete before showing wallet information

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -33,7 +33,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     _log.info("Listening to initial sync event.");
     liquidSDK.didCompleteInitialSyncStream.listen((_) {
       _log.info("Initial sync complete.");
-      emit(state.copyWith(didCompleteInitialSync: true));
+      emit(state.copyWith(isRestoring: false, didCompleteInitialSync: true));
     });
   }
 
@@ -45,6 +45,10 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
   @override
   Map<String, dynamic>? toJson(AccountState state) {
     return state.toJson();
+  }
+
+  void setIsRestoring(bool isRestoring) {
+    emit(state.copyWith(isRestoring: isRestoring));
   }
 
   void setOnboardingComplete(bool isComplete) {

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -17,6 +17,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
   }) : super(AccountState.initial()) {
     hydrate();
     _listenAccountChanges();
+    _listenInitialSyncEvent();
   }
 
   void _listenAccountChanges() {
@@ -25,6 +26,14 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
       final newState = state.copyWith(walletInfo: walletInfo);
       _log.info("AccountState changed: $newState");
       emit(newState);
+    });
+  }
+
+  void _listenInitialSyncEvent() {
+    _log.info("Listening to initial sync event.");
+    liquidSDK.didCompleteInitialSyncStream.listen((_) {
+      _log.info("Initial sync complete.");
+      emit(state.copyWith(didCompleteInitialSync: true));
     });
   }
 

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -7,18 +7,30 @@ final _log = Logger("AccountState");
 
 class AccountState {
   final bool isOnboardingComplete;
+  final bool didCompleteInitialSync;
   final GetInfoResponse? walletInfo;
 
-  const AccountState({required this.isOnboardingComplete, required this.walletInfo});
+  const AccountState({
+    required this.isOnboardingComplete,
+    required this.didCompleteInitialSync,
+    required this.walletInfo,
+  });
 
-  AccountState.initial() : this(isOnboardingComplete: false, walletInfo: null);
+  AccountState.initial()
+      : this(
+          isOnboardingComplete: false,
+          didCompleteInitialSync: false,
+          walletInfo: null,
+        );
 
   AccountState copyWith({
     bool? isOnboardingComplete,
+    bool? didCompleteInitialSync,
     GetInfoResponse? walletInfo,
   }) {
     return AccountState(
       isOnboardingComplete: isOnboardingComplete ?? this.isOnboardingComplete,
+      didCompleteInitialSync: didCompleteInitialSync ?? this.didCompleteInitialSync,
       walletInfo: walletInfo ?? this.walletInfo,
     );
   }
@@ -35,6 +47,7 @@ class AccountState {
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
       isOnboardingComplete: json["isOnboardingComplete"] ?? false,
+      didCompleteInitialSync: false,
       walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),
     );
   }

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -6,11 +6,13 @@ import 'package:logging/logging.dart';
 final _log = Logger("AccountState");
 
 class AccountState {
+  final bool isRestoring;
   final bool isOnboardingComplete;
   final bool didCompleteInitialSync;
   final GetInfoResponse? walletInfo;
 
   const AccountState({
+    required this.isRestoring,
     required this.isOnboardingComplete,
     required this.didCompleteInitialSync,
     required this.walletInfo,
@@ -18,17 +20,20 @@ class AccountState {
 
   AccountState.initial()
       : this(
+          isRestoring: false,
           isOnboardingComplete: false,
           didCompleteInitialSync: false,
           walletInfo: null,
         );
 
   AccountState copyWith({
+    bool? isRestoring,
     bool? isOnboardingComplete,
     bool? didCompleteInitialSync,
     GetInfoResponse? walletInfo,
   }) {
     return AccountState(
+      isRestoring: isRestoring ?? this.isRestoring,
       isOnboardingComplete: isOnboardingComplete ?? this.isOnboardingComplete,
       didCompleteInitialSync: didCompleteInitialSync ?? this.didCompleteInitialSync,
       walletInfo: walletInfo ?? this.walletInfo,
@@ -39,6 +44,7 @@ class AccountState {
 
   Map<String, dynamic>? toJson() {
     return {
+      "isRestoring": isRestoring,
       "isOnboardingComplete": isOnboardingComplete,
       "walletInfo": walletInfo?.toJson(),
     };
@@ -46,6 +52,7 @@ class AccountState {
 
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
+      isRestoring: json["isRestoring"] ?? false,
       isOnboardingComplete: json["isOnboardingComplete"] ?? false,
       didCompleteInitialSync: false,
       walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),

--- a/lib/cubit/payments/payments_state.dart
+++ b/lib/cubit/payments/payments_state.dart
@@ -50,7 +50,10 @@ class PaymentsState {
 
   factory PaymentsState.fromJson(Map<String, dynamic> json) {
     return PaymentsState(
-      payments: json['payments'].map((paymentJson) => PaymentData.fromJson(paymentJson)).toList(),
+      payments: (json['payments'] as List<dynamic>?)
+              ?.map((paymentJson) => PaymentData.fromJson(paymentJson))
+              .toList() ??
+          [],
       paymentFilters: PaymentFilters.fromJson(json["paymentFilters"]),
     );
   }

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -44,8 +44,8 @@ class AccountPage extends StatelessWidget {
               ),
             );
 
-            final bool showSliver =
-                nonFilteredPayments.isNotEmpty || paymentFilters.filters != PaymentType.values;
+            final bool showSliver = accountState.walletInfo != null &&
+                (nonFilteredPayments.isNotEmpty || paymentFilters.filters != PaymentType.values);
             int? startDate = paymentFilters.fromTimestamp;
             int? endDate = paymentFilters.toTimestamp;
             bool hasDateFilter = startDate != null && endDate != null;
@@ -89,7 +89,7 @@ class AccountPage extends StatelessWidget {
                   ),
                 ),
               );
-            } else if (accountState.isOnboardingComplete && nonFilteredPayments.isEmpty) {
+            } else if (nonFilteredPayments.isEmpty) {
               slivers.add(
                 SliverPersistentHeader(
                   delegate: FixedSliverDelegate(

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -72,8 +72,9 @@ class AccountPage extends StatelessWidget {
             if (showSliver) {
               slivers.add(
                 PaymentsList(
-                  _kPaymentListItemHeight,
-                  firstPaymentItemKey,
+                  paymentsList: filteredPayments,
+                  paymentItemHeight: _kPaymentListItemHeight,
+                  firstPaymentItemKey: firstPaymentItemKey,
                 ),
               );
               slivers.add(

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -39,7 +39,7 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
 
             List<Widget> warnings = [];
 
-            if (accountState.walletInfo == null) {
+            if (!accountState.didCompleteInitialSync) {
               _log.info("Adding sync warning.");
               warnings.add(
                 WarningAction(

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -17,15 +17,45 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
+
+    return BlocBuilder<AccountCubit, AccountState>(
+      builder: (context, accountState) {
+        return _buildContentWithAccountState(themeData, accountState);
+      },
+    );
+  }
+
+  Widget _buildContentWithAccountState(
+    ThemeData themeData,
+    AccountState accountState,
+  ) {
     return BlocBuilder<SecurityCubit, SecurityState>(
       builder: (context, securityState) {
         return BlocBuilder<BackupCubit, BackupState?>(
           builder: (context, backupState) {
-            _log.fine("Building with: securityState: $securityState backupState: $backupState");
+            _log.fine(
+              "Building with: securityState: $securityState backupState: $backupState accountState: $accountState",
+            );
 
             List<Widget> warnings = [];
 
+            if (accountState.walletInfo == null) {
+              _log.info("Adding sync warning.");
+              warnings.add(
+                WarningAction(
+                  onTap: () async {},
+                  iconWidget: Rotator(
+                    child: Image(
+                      image: const AssetImage("assets/icons/sync.png"),
+                      color: themeData.appBarTheme.actionsIconTheme?.color,
+                    ),
+                  ),
+                ),
+              );
+            }
+
             if (securityState.verificationStatus == VerificationStatus.unverified) {
+              _log.info("Adding mnemonic verification warning.");
               warnings.add(
                 WarningAction(
                   onTap: () async {
@@ -47,6 +77,7 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
             }
 
             if (backupState != null && backupState.status == BackupStatus.inProgress) {
+              _log.info("Adding backup in progress warning.");
               warnings.add(
                 WarningAction(
                   onTap: () {
@@ -68,6 +99,7 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
             }
 
             if (backupState?.status == BackupStatus.failed) {
+              _log.info("Adding backup error warning.");
               warnings.add(
                 WarningAction(
                   onTap: () {
@@ -82,7 +114,10 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
               );
             }
 
-            if (warnings.isEmpty) {}
+            _log.info("Total # of warnings: ${warnings.length}");
+            if (warnings.isEmpty) {
+              return const SizedBox.shrink();
+            }
 
             return Row(
               mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/routes/home/widgets/dashboard/balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/balance_text.dart
@@ -1,17 +1,19 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/theme/theme.dart';
 
 class BalanceText extends StatefulWidget {
-  final UserProfileState userProfileState;
+  final bool hiddenBalance;
   final CurrencyState currencyState;
   final AccountState accountState;
   final double offsetFactor;
 
   const BalanceText({
     super.key,
-    required this.userProfileState,
+    required this.hiddenBalance,
     required this.currencyState,
     required this.accountState,
     required this.offsetFactor,
@@ -30,35 +32,68 @@ class _BalanceTextState extends State<BalanceText> {
     final texts = context.texts();
     final themeData = Theme.of(context);
 
-    return widget.userProfileState.profileSettings.hideBalance
-        ? Text(
-            texts.wallet_dashboard_balance_hide,
-            style: balanceAmountTextStyle.copyWith(
-              color: themeData.colorScheme.onSecondary,
-              fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
-            ),
-          )
-        : RichText(
-            text: TextSpan(
+    return TextButton(
+      style: ButtonStyle(
+        overlayColor: WidgetStateProperty.resolveWith<Color?>(
+          (states) {
+            if ({WidgetState.focused, WidgetState.hovered}.any(states.contains)) {
+              return themeData.customData.paymentListBgColor;
+            }
+            return null;
+          },
+        ),
+      ),
+      onPressed: () => _changeBtcCurrency(context),
+      child: widget.hiddenBalance
+          ? Text(
+              texts.wallet_dashboard_balance_hide,
               style: balanceAmountTextStyle.copyWith(
                 color: themeData.colorScheme.onSecondary,
                 fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
               ),
-              text: widget.currencyState.bitcoinCurrency.format(
-                widget.accountState.walletInfo!.balanceSat.toInt(),
-                removeTrailingZeros: true,
-                includeDisplayName: false,
-              ),
-              children: [
-                TextSpan(
-                  text: " ${widget.currencyState.bitcoinCurrency.displayName}",
-                  style: balanceCurrencyTextStyle.copyWith(
-                    color: themeData.colorScheme.onSecondary,
-                    fontSize: startSize * 0.6 - (startSize * 0.6 - endSize) * widget.offsetFactor,
-                  ),
+            )
+          : RichText(
+              text: TextSpan(
+                style: balanceAmountTextStyle.copyWith(
+                  color: themeData.colorScheme.onSecondary,
+                  fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
                 ),
-              ],
+                text: widget.currencyState.bitcoinCurrency.format(
+                  widget.accountState.walletInfo!.balanceSat.toInt(),
+                  removeTrailingZeros: true,
+                  includeDisplayName: false,
+                ),
+                children: [
+                  TextSpan(
+                    text: " ${widget.currencyState.bitcoinCurrency.displayName}",
+                    style: balanceCurrencyTextStyle.copyWith(
+                      color: themeData.colorScheme.onSecondary,
+                      fontSize: startSize * 0.6 - (startSize * 0.6 - endSize) * widget.offsetFactor,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          );
+    );
+  }
+
+  void _changeBtcCurrency(BuildContext context) {
+    final userProfileCubit = context.read<UserProfileCubit>();
+    final currencyCubit = context.read<CurrencyCubit>();
+    final currencyState = currencyCubit.state;
+
+    if (widget.hiddenBalance == true) {
+      userProfileCubit.updateProfile(hideBalance: false);
+      return;
+    }
+    final list = BitcoinCurrency.currencies;
+    final index = list.indexOf(
+      BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker),
+    );
+    final nextCurrencyIndex = (index + 1) % list.length;
+    if (nextCurrencyIndex == 1) {
+      userProfileCubit.updateProfile(hideBalance: true);
+    }
+    currencyCubit.setBitcoinTicker(list[nextCurrencyIndex].tickerSymbol);
   }
 }

--- a/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
@@ -7,12 +7,14 @@ import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/fiat_conversion.dart';
 
 class FiatBalanceText extends StatelessWidget {
+  final bool hiddenBalance;
   final CurrencyState currencyState;
   final AccountState accountState;
   final double offsetFactor;
 
   const FiatBalanceText({
     super.key,
+    required this.hiddenBalance,
     required this.currencyState,
     required this.accountState,
     required this.offsetFactor,
@@ -22,7 +24,7 @@ class FiatBalanceText extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
 
-    if (!isAboveMinAmount(currencyState, accountState)) {
+    if (!currencyState.fiatEnabled || hiddenBalance || !isAboveMinAmount(currencyState, accountState)) {
       return const SizedBox.shrink();
     }
 
@@ -30,7 +32,7 @@ class FiatBalanceText extends StatelessWidget {
       style: ButtonStyle(
         overlayColor: WidgetStateProperty.resolveWith<Color?>(
           (states) {
-            if (states.contains(WidgetState.focused) || states.contains(WidgetState.hovered)) {
+            if ({WidgetState.focused, WidgetState.hovered}.any(states.contains)) {
               return themeData.customData.paymentListBgColor;
             }
             return null;

--- a/lib/routes/home/widgets/dashboard/placeholder_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/placeholder_balance_text.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/theme/theme.dart';
+import 'package:shimmer/shimmer.dart';
+
+class PlaceholderBalanceText extends StatefulWidget {
+  final double offsetFactor;
+  const PlaceholderBalanceText({super.key, required this.offsetFactor});
+
+  @override
+  State<PlaceholderBalanceText> createState() => PlaceholderBalanceTextState();
+}
+
+class PlaceholderBalanceTextState extends State<PlaceholderBalanceText> {
+  double get startSize => balanceAmountTextStyle.fontSize!;
+  double get endSize => startSize - 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final currencyState = context.read<CurrencyCubit>().state;
+
+    return Shimmer.fromColors(
+      baseColor: themeData.colorScheme.onSecondary,
+      highlightColor: themeData.customData.paymentListBgColor.withOpacity(0.5),
+      enabled: true,
+      child: TextButton(
+        style: ButtonStyle(
+          overlayColor: WidgetStateProperty.resolveWith<Color?>(
+            (states) {
+              if ({WidgetState.focused, WidgetState.hovered}.any(states.contains)) {
+                return themeData.customData.paymentListBgColor;
+              }
+              return null;
+            },
+          ),
+        ),
+        onPressed: () {},
+        child: RichText(
+          text: TextSpan(
+            style: balanceAmountTextStyle.copyWith(
+              color: themeData.colorScheme.onSecondary,
+              fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
+            ),
+            text: currencyState.bitcoinCurrency.format(
+              0,
+              removeTrailingZeros: true,
+              includeDisplayName: false,
+            ),
+            children: [
+              TextSpan(
+                text: " ${currencyState.bitcoinCurrency.displayName}",
+                style: balanceCurrencyTextStyle.copyWith(
+                  color: themeData.colorScheme.onSecondary,
+                  fontSize: startSize * 0.6 - (startSize * 0.6 - endSize) * widget.offsetFactor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -48,7 +48,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
                         color: themeData.customData.dashboardBgColor,
                       ),
                     ),
-                    if (accountState.isOnboardingComplete) ...[
+                    if (accountState.walletInfo != null) ...[
                       Positioned(
                         top: 60 - _kBalanceOffsetTransition * widget.offsetFactor,
                         child: Center(
@@ -91,7 +91,9 @@ class _WalletDashboardState extends State<WalletDashboard> {
                         ),
                       ),
                     ],
-                    if (currencyState.fiatEnabled && !profileSettings.hideBalance) ...[
+                    if (accountState.walletInfo != null &&
+                        currencyState.fiatEnabled &&
+                        !profileSettings.hideBalance) ...[
                       Positioned(
                         top: 100 - _kBalanceOffsetTransition * widget.offsetFactor,
                         child: Center(

--- a/lib/routes/home/widgets/payments_list/payments_list.dart
+++ b/lib/routes/home/widgets/payments_list/payments_list.dart
@@ -1,40 +1,33 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/payment_item.dart';
 
 const _kBottomPadding = 8.0;
 
 class PaymentsList extends StatelessWidget {
-  final double _itemHeight;
+  final List<PaymentData> paymentsList;
+  final double paymentItemHeight;
   final GlobalKey firstPaymentItemKey;
 
-  const PaymentsList(
-    this._itemHeight,
-    this.firstPaymentItemKey, {
+  const PaymentsList({
+    required this.paymentsList,
+    required this.paymentItemHeight,
+    required this.firstPaymentItemKey,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<UserProfileCubit, UserProfileState>(
-      builder: (context, userprofileState) {
-        return BlocBuilder<PaymentsCubit, PaymentsState>(
-          builder: (context, paymentsState) {
-            return SliverFixedExtentList(
-              itemExtent: _itemHeight + _kBottomPadding,
-              delegate: SliverChildBuilderDelegate(
-                (context, index) => PaymentItem(
-                  paymentsState.filteredPayments[index],
-                  0 == index,
-                  firstPaymentItemKey,
-                ),
-                childCount: paymentsState.filteredPayments.length,
-              ),
-            );
-          },
-        );
-      },
+    return SliverFixedExtentList(
+      itemExtent: paymentItemHeight + _kBottomPadding,
+      delegate: SliverChildBuilderDelegate(
+        (context, index) => PaymentItem(
+          paymentsList[index],
+          0 == index,
+          firstPaymentItemKey,
+        ),
+        childCount: paymentsList.length,
+      ),
     );
   }
 }

--- a/lib/routes/home/widgets/payments_list/placeholder_payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/placeholder_payment_item.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme.dart';
+import 'package:shimmer/shimmer.dart';
+
+class PlaceholderPaymentItem extends StatelessWidget {
+  const PlaceholderPaymentItem({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    final customData = themeData.customData;
+    final paymentListBgColor = customData.paymentListBgColor;
+    return Shimmer.fromColors(
+      baseColor: paymentListBgColor,
+      highlightColor: customData.paymentListBgColor.withOpacity(0.5),
+      enabled: true,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(5),
+          child: Container(
+            color: themeData.customData.paymentListBgColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ListTile(
+                  leading: Container(
+                    height: 72.0,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.1),
+                          offset: const Offset(0.5, 0.5),
+                          blurRadius: 5.0,
+                        ),
+                      ],
+                    ),
+                    child: const CircleAvatar(
+                      radius: 16,
+                      backgroundColor: Colors.white,
+                      child: Icon(
+                        Icons.bolt_rounded,
+                        color: Color(0xb3303234),
+                      ),
+                    ),
+                  ),
+                  title: Transform.translate(
+                    offset: const Offset(-8, 0),
+                    child: Text(
+                      "",
+                      style: themeData.paymentItemTitleTextStyle,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  subtitle: Transform.translate(
+                    offset: const Offset(-8, 0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text("", style: themeData.paymentItemSubtitleTextStyle),
+                      ],
+                    ),
+                  ),
+                  trailing: SizedBox(
+                    height: 44,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          "",
+                          style: themeData.paymentItemAmountTextStyle,
+                        ),
+                        Text(
+                          "",
+                          style: themeData.paymentItemFeeTextStyle,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -12,6 +12,21 @@ class StatusText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return BlocBuilder<AccountCubit, AccountState>(
+      builder: (context, accountState) {
+        return (accountState.walletInfo == null)
+            ? const LoadingAnimatedText()
+            : const SdkConnectivityStatusText();
+      },
+    );
+  }
+}
+
+class SdkConnectivityStatusText extends StatelessWidget {
+  const SdkConnectivityStatusText({super.key});
+
+  @override
+  Widget build(BuildContext context) {
     return BlocBuilder<SdkConnectivityCubit, SdkConnectivityState>(
       builder: (context, sdkConnectivityState) {
         switch (sdkConnectivityState) {

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -14,7 +14,7 @@ class StatusText extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<AccountCubit, AccountState>(
       builder: (context, accountState) {
-        return (accountState.walletInfo == null)
+        return (!accountState.didCompleteInitialSync)
             ? const LoadingAnimatedText()
             : const SdkConnectivityStatusText();
       },

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -12,21 +12,6 @@ class StatusText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<AccountCubit, AccountState>(
-      builder: (context, accountState) {
-        return (!accountState.didCompleteInitialSync)
-            ? const LoadingAnimatedText()
-            : const SdkConnectivityStatusText();
-      },
-    );
-  }
-}
-
-class SdkConnectivityStatusText extends StatelessWidget {
-  const SdkConnectivityStatusText({super.key});
-
-  @override
-  Widget build(BuildContext context) {
     return BlocBuilder<SdkConnectivityCubit, SdkConnectivityState>(
       builder: (context, sdkConnectivityState) {
         switch (sdkConnectivityState) {

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -182,6 +182,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       if (isRestore) {
         await connectionService.restore(mnemonic: mnemonic);
         securityCubit.mnemonicsValidated();
+        accountCubit.setIsRestoring(true);
       } else {
         await connectionService.register();
       }

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -10,8 +10,13 @@ class BreezSDKLiquid {
 
   factory BreezSDKLiquid() => _singleton;
 
+  late final Stream<void> didCompleteInitialSyncStream;
+
+  final StreamController<void> _didCompleteInitialSyncController = StreamController<void>.broadcast();
+
   BreezSDKLiquid._internal() {
     initializeLogStream();
+    didCompleteInitialSyncStream = _didCompleteInitialSyncController.stream.take(1);
   }
 
   liquid_sdk.BindingLiquidSdk? _instance;
@@ -115,6 +120,8 @@ class BreezSDKLiquid {
           _paymentEventStream.add(PaymentEvent.fromSdkEvent(event));
         } else if (event is liquid_sdk.SdkEvent_PaymentFailed) {
           _paymentEventStream.addError(event);
+        } else if (event is liquid_sdk.SdkEvent_Synced) {
+          _didCompleteInitialSyncController.add(null);
         }
         await _fetchWalletData(sdk);
       },

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -120,10 +120,11 @@ class BreezSDKLiquid {
           _paymentEventStream.add(PaymentEvent.fromSdkEvent(event));
         } else if (event is liquid_sdk.SdkEvent_PaymentFailed) {
           _paymentEventStream.addError(event);
-        } else if (event is liquid_sdk.SdkEvent_Synced) {
-          _didCompleteInitialSyncController.add(null);
         }
         await _fetchWalletData(sdk);
+        if (event is liquid_sdk.SdkEvent_Synced) {
+          _didCompleteInitialSyncController.add(null);
+        }
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1580,6 +1580,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   simple_animations:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,6 +106,7 @@ dependencies:
   share_plus: ^10.1.1
   shared_preferences: ^2.3.2
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences
+  shimmer: ^3.0.0
   simple_animations: ^5.0.2
   synchronized: <3.2.0
   theme_provider: ^0.6.0


### PR DESCRIPTION
Fixes #157

This PR improves the initial loading experience by managing wallet information loading and handling initial sync.

### Changelist:
- Display a loading animation until wallet information is available.
  - Show an animated "..." text on payment list while waiting for wallet information on fresh install/restores.
  - Show a sync icon while waiting for wallet information on app bar.
    - This icon is mostly visible on fresh install/restores, UI loads before the user has a chance to see it when their wallet is not far behind,
 - Hide balance until wallet information is available.
 - Hide slivers that display wallet information until wallet information is available.
- Add `didInitialSyncComplete` stream to `BreezSdkLiquid` & notify the app layer when initial sync completes.
- Pass payment list from `AccountPage` to `PaymentsList` widget
  - `PaymentsList` widget is not used elsewhere and there's no need to encapsulate state retrieval inside the widget itself
  - This is a negligible change in terms of performance.