### PR TITLE
Fix: Persist payment list

### DIFF
--- a/lib/cubit/payments/payments_state.dart
+++ b/lib/cubit/payments/payments_state.dart
@@ -50,7 +50,10 @@ class PaymentsState {
 
   factory PaymentsState.fromJson(Map<String, dynamic> json) {
     return PaymentsState(
-      payments: json['payments'].map((paymentJson) => PaymentData.fromJson(paymentJson)).toList(),
+      payments: (json['payments'] as List<dynamic>?)
+              ?.map((paymentJson) => PaymentData.fromJson(paymentJson))
+              .toList() ??
+          [],
       paymentFilters: PaymentFilters.fromJson(json["paymentFilters"]),
     );
   }

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -121,6 +121,7 @@ class BreezSDKLiquid {
         } else if (event is liquid_sdk.SdkEvent_PaymentFailed) {
           _paymentEventStream.addError(event);
         } else if (event is liquid_sdk.SdkEvent_Synced) {
+          await _listPayments(sdk: _instance!);
           _didCompleteInitialSyncController.add(null);
         }
         await _fetchWalletData(sdk);

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -120,11 +120,11 @@ class BreezSDKLiquid {
           _paymentEventStream.add(PaymentEvent.fromSdkEvent(event));
         } else if (event is liquid_sdk.SdkEvent_PaymentFailed) {
           _paymentEventStream.addError(event);
-        } else if (event is liquid_sdk.SdkEvent_Synced) {
-          await _listPayments(sdk: _instance!);
-          _didCompleteInitialSyncController.add(null);
         }
         await _fetchWalletData(sdk);
+        if (event is liquid_sdk.SdkEvent_Synced) {
+          _didCompleteInitialSyncController.add(null);
+        }
       },
     );
   }


### PR DESCRIPTION
This PR fixes `PaymentState`'s `fromJson` logic that populates payments list and force updates payment list when initial sync is completed.