### PR TITLE
Display placeholder items while restoring

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -33,7 +33,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
     _log.info("Listening to initial sync event.");
     liquidSDK.didCompleteInitialSyncStream.listen((_) {
       _log.info("Initial sync complete.");
-      emit(state.copyWith(didCompleteInitialSync: true));
+      emit(state.copyWith(isRestoring: false, didCompleteInitialSync: true));
     });
   }
 
@@ -45,6 +45,10 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin {
   @override
   Map<String, dynamic>? toJson(AccountState state) {
     return state.toJson();
+  }
+
+  void setIsRestoring(bool isRestoring) {
+    emit(state.copyWith(isRestoring: isRestoring));
   }
 
   void setOnboardingComplete(bool isComplete) {

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -6,11 +6,13 @@ import 'package:logging/logging.dart';
 final _log = Logger("AccountState");
 
 class AccountState {
+  final bool isRestoring;
   final bool isOnboardingComplete;
   final bool didCompleteInitialSync;
   final GetInfoResponse? walletInfo;
 
   const AccountState({
+    required this.isRestoring,
     required this.isOnboardingComplete,
     required this.didCompleteInitialSync,
     required this.walletInfo,
@@ -18,17 +20,20 @@ class AccountState {
 
   AccountState.initial()
       : this(
+          isRestoring: false,
           isOnboardingComplete: false,
           didCompleteInitialSync: false,
           walletInfo: null,
         );
 
   AccountState copyWith({
+    bool? isRestoring,
     bool? isOnboardingComplete,
     bool? didCompleteInitialSync,
     GetInfoResponse? walletInfo,
   }) {
     return AccountState(
+      isRestoring: isRestoring ?? this.isRestoring,
       isOnboardingComplete: isOnboardingComplete ?? this.isOnboardingComplete,
       didCompleteInitialSync: didCompleteInitialSync ?? this.didCompleteInitialSync,
       walletInfo: walletInfo ?? this.walletInfo,
@@ -39,6 +44,7 @@ class AccountState {
 
   Map<String, dynamic>? toJson() {
     return {
+      "isRestoring": isRestoring,
       "isOnboardingComplete": isOnboardingComplete,
       "walletInfo": walletInfo?.toJson(),
     };
@@ -46,6 +52,7 @@ class AccountState {
 
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
+      isRestoring: json["isRestoring"] ?? false,
       isOnboardingComplete: json["isOnboardingComplete"] ?? false,
       didCompleteInitialSync: false,
       walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -137,7 +137,9 @@ class AccountPage extends StatelessWidget {
                 key: const Key("account_sliver"),
                 fit: StackFit.expand,
                 children: [
-                  if (!showPaymentsList) CustomPaint(painter: BubblePainter(context)),
+                  if (!showPaymentsList && !(accountState.isRestoring && nonFilteredPayments.isEmpty)) ...[
+                    CustomPaint(painter: BubblePainter(context)),
+                  ],
                   CustomScrollView(
                     controller: scrollController,
                     slivers: slivers,

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -8,11 +8,13 @@ import 'package:l_breez/routes/home/widgets/payments_filter/fixed_sliver_delegat
 import 'package:l_breez/routes/home/widgets/payments_filter/header_filter_chip.dart';
 import 'package:l_breez/routes/home/widgets/payments_filter/payments_filter_sliver.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/payments_list.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/placeholder_payment_item.dart';
 import 'package:l_breez/routes/home/widgets/status_text.dart';
 import 'package:l_breez/theme/theme.dart';
 
 const _kFilterMaxSize = 64.0;
 const _kPaymentListItemHeight = 72.0;
+const _kPlaceholderListItemCount = 8;
 
 class AccountPage extends StatelessWidget {
   final GlobalKey firstPaymentItemKey;
@@ -44,17 +46,17 @@ class AccountPage extends StatelessWidget {
               ),
             );
 
-            final bool showSliver = accountState.walletInfo != null &&
-                (nonFilteredPayments.isNotEmpty || paymentFilters.filters != PaymentType.values);
+            bool showPaymentsList = filteredPayments.isNotEmpty;
+            bool hasTypeFilter = paymentFilters.filters != PaymentType.values;
             int? startDate = paymentFilters.fromTimestamp;
             int? endDate = paymentFilters.toTimestamp;
             bool hasDateFilter = startDate != null && endDate != null;
-            if (showSliver) {
+            if (showPaymentsList || hasTypeFilter) {
               slivers.add(
                 PaymentsFilterSliver(
                   maxSize: _kFilterMaxSize,
                   scrollController: scrollController,
-                  hasFilter: paymentFilters.filters != PaymentType.values || hasDateFilter,
+                  hasFilter: hasTypeFilter || hasDateFilter,
                 ),
               );
             }
@@ -69,7 +71,7 @@ class AccountPage extends StatelessWidget {
               );
             }
 
-            if (showSliver) {
+            if (showPaymentsList) {
               slivers.add(
                 PaymentsList(
                   paymentsList: filteredPayments,
@@ -84,13 +86,36 @@ class AccountPage extends StatelessWidget {
                     _bottomPlaceholderSpace(
                       context,
                       paymentFilters.hasDateFilters,
-                      filteredPayments.length,
+                      nonFilteredPayments.isEmpty ? _kPlaceholderListItemCount : filteredPayments.length,
                     ),
                     child: const SizedBox.expand(),
                   ),
                 ),
               );
-            } else if (nonFilteredPayments.isEmpty) {
+            } else if (accountState.isRestoring && nonFilteredPayments.isEmpty) {
+              slivers.add(
+                SliverFixedExtentList(
+                  itemExtent: _kPaymentListItemHeight + 8.0,
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => const PlaceholderPaymentItem(),
+                    childCount: _kPlaceholderListItemCount,
+                  ),
+                ),
+              );
+              slivers.add(
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: FixedSliverDelegate(
+                    _bottomPlaceholderSpace(
+                      context,
+                      paymentFilters.hasDateFilters,
+                      nonFilteredPayments.isEmpty ? _kPlaceholderListItemCount : filteredPayments.length,
+                    ),
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              );
+            } else {
               slivers.add(
                 SliverPersistentHeader(
                   delegate: FixedSliverDelegate(
@@ -112,9 +137,7 @@ class AccountPage extends StatelessWidget {
                 key: const Key("account_sliver"),
                 fit: StackFit.expand,
                 children: [
-                  if (!showSliver) ...[
-                    CustomPaint(painter: BubblePainter(context)),
-                  ],
+                  if (!showPaymentsList) CustomPaint(painter: BubblePainter(context)),
                   CustomScrollView(
                     controller: scrollController,
                     slivers: slivers,

--- a/lib/routes/home/widgets/dashboard/placeholder_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/placeholder_balance_text.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/theme/theme.dart';
+import 'package:shimmer/shimmer.dart';
+
+class PlaceholderBalanceText extends StatefulWidget {
+  final double offsetFactor;
+  const PlaceholderBalanceText({super.key, required this.offsetFactor});
+
+  @override
+  State<PlaceholderBalanceText> createState() => PlaceholderBalanceTextState();
+}
+
+class PlaceholderBalanceTextState extends State<PlaceholderBalanceText> {
+  double get startSize => balanceAmountTextStyle.fontSize!;
+  double get endSize => startSize - 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    final currencyState = context.read<CurrencyCubit>().state;
+
+    return Shimmer.fromColors(
+      baseColor: themeData.colorScheme.onSecondary,
+      highlightColor: themeData.customData.paymentListBgColor.withOpacity(0.5),
+      enabled: true,
+      child: TextButton(
+        style: ButtonStyle(
+          overlayColor: WidgetStateProperty.resolveWith<Color?>(
+            (states) {
+              if ({WidgetState.focused, WidgetState.hovered}.any(states.contains)) {
+                return themeData.customData.paymentListBgColor;
+              }
+              return null;
+            },
+          ),
+        ),
+        onPressed: () {},
+        child: RichText(
+          text: TextSpan(
+            style: balanceAmountTextStyle.copyWith(
+              color: themeData.colorScheme.onSecondary,
+              fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
+            ),
+            text: currencyState.bitcoinCurrency.format(
+              0,
+              removeTrailingZeros: true,
+              includeDisplayName: false,
+            ),
+            children: [
+              TextSpan(
+                text: " ${currencyState.bitcoinCurrency.displayName}",
+                style: balanceCurrencyTextStyle.copyWith(
+                  color: themeData.colorScheme.onSecondary,
+                  fontSize: startSize * 0.6 - (startSize * 0.6 - endSize) * widget.offsetFactor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/home/widgets/dashboard/fiat_balance_text.dart';
+import 'package:l_breez/routes/home/widgets/dashboard/placeholder_balance_text.dart';
 import 'package:l_breez/theme/theme.dart';
 
 import 'balance_text.dart';
@@ -34,7 +35,7 @@ class _WalletDashboardState extends State<WalletDashboard> {
             return BlocBuilder<AccountCubit, AccountState>(
               builder: (context, accountState) {
                 final hiddenBalance = userProfileState.profileSettings.hideBalance;
-                final showBalance = accountState.walletInfo != null;
+                final showBalance = !accountState.isRestoring && accountState.walletInfo != null;
 
                 return Stack(
                   alignment: AlignmentDirectional.topCenter,
@@ -46,17 +47,19 @@ class _WalletDashboardState extends State<WalletDashboard> {
                         color: themeData.customData.dashboardBgColor,
                       ),
                     ),
-                    if (showBalance) ...[
-                      Positioned(
-                        top: 60 - _kBalanceOffsetTransition * widget.offsetFactor,
-                        child: BalanceText(
-                          hiddenBalance: hiddenBalance,
-                          currencyState: currencyState,
-                          accountState: accountState,
-                          offsetFactor: widget.offsetFactor,
-                        ),
-                      ),
-                    ],
+                    Positioned(
+                      top: 60 - _kBalanceOffsetTransition * widget.offsetFactor,
+                      child: showBalance
+                          ? BalanceText(
+                              hiddenBalance: hiddenBalance,
+                              currencyState: currencyState,
+                              accountState: accountState,
+                              offsetFactor: widget.offsetFactor,
+                            )
+                          : PlaceholderBalanceText(
+                              offsetFactor: widget.offsetFactor,
+                            ),
+                    ),
                     Positioned(
                       top: 100 - _kBalanceOffsetTransition * widget.offsetFactor,
                       child: FiatBalanceText(

--- a/lib/routes/home/widgets/payments_list/placeholder_payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/placeholder_payment_item.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:l_breez/theme/theme.dart';
+import 'package:shimmer/shimmer.dart';
+
+class PlaceholderPaymentItem extends StatelessWidget {
+  const PlaceholderPaymentItem({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+
+    final customData = themeData.customData;
+    final paymentListBgColor = customData.paymentListBgColor;
+    return Shimmer.fromColors(
+      baseColor: paymentListBgColor,
+      highlightColor: customData.paymentListBgColor.withOpacity(0.5),
+      enabled: true,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(5),
+          child: Container(
+            color: themeData.customData.paymentListBgColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ListTile(
+                  leading: Container(
+                    height: 72.0,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.1),
+                          offset: const Offset(0.5, 0.5),
+                          blurRadius: 5.0,
+                        ),
+                      ],
+                    ),
+                    child: const CircleAvatar(
+                      radius: 16,
+                      backgroundColor: Colors.white,
+                      child: Icon(
+                        Icons.bolt_rounded,
+                        color: Color(0xb3303234),
+                      ),
+                    ),
+                  ),
+                  title: Transform.translate(
+                    offset: const Offset(-8, 0),
+                    child: Text(
+                      "",
+                      style: themeData.paymentItemTitleTextStyle,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  subtitle: Transform.translate(
+                    offset: const Offset(-8, 0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text("", style: themeData.paymentItemSubtitleTextStyle),
+                      ],
+                    ),
+                  ),
+                  trailing: SizedBox(
+                    height: 44,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          "",
+                          style: themeData.paymentItemAmountTextStyle,
+                        ),
+                        Text(
+                          "",
+                          style: themeData.paymentItemFeeTextStyle,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -12,21 +12,6 @@ class StatusText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<AccountCubit, AccountState>(
-      builder: (context, accountState) {
-        return (!accountState.didCompleteInitialSync)
-            ? const LoadingAnimatedText()
-            : const SdkConnectivityStatusText();
-      },
-    );
-  }
-}
-
-class SdkConnectivityStatusText extends StatelessWidget {
-  const SdkConnectivityStatusText({super.key});
-
-  @override
-  Widget build(BuildContext context) {
     return BlocBuilder<SdkConnectivityCubit, SdkConnectivityState>(
       builder: (context, sdkConnectivityState) {
         switch (sdkConnectivityState) {

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -182,6 +182,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       if (isRestore) {
         await connectionService.restore(mnemonic: mnemonic);
         securityCubit.mnemonicsValidated();
+        accountCubit.setIsRestoring(true);
       } else {
         await connectionService.register();
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1580,6 +1580,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   simple_animations:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,6 +106,7 @@ dependencies:
   share_plus: ^10.1.1
   shared_preferences: ^2.3.2
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences
+  shimmer: ^3.0.0
   simple_animations: ^5.0.2
   synchronized: <3.2.0
   theme_provider: ^0.6.0


### PR DESCRIPTION
Fixes #200

This PR adds a `isRestoring` flag to differentiate between new registrations and restores & introduces placeholder balance & payment list widgets to be shown while syncing.