### PR TITLE
fix: ITMS-90899: Macs with Apple silicon support issue

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0.0</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -109,7 +111,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-    <key>FirebaseAppDelegateProxyEnabled</key>
-    <false/>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
> Hello,
> 
> We noticed one or more issues with a recent delivery for the following app:
> 
> Misty Breez
> Version 0.1.0
> Build 6192.1
> Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-90899: Macs with Apple silicon support issue - The app isn‘t compatible with the provided minimum macOS version of 12.5. It can run on macOS 13.0 or later. Please specify an LSMinimumSystemVersion value of 13.0 or later in a new build, or select a compatible version in App Store Connect. For details, visit: https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/manage-availability-of-iphone-and-ipad-apps-on-macs-with-apple-silicon.
> 
> Apple Developer Relations