### PR TITLE
Enable "Export Keys" option on online builds

### DIFF
--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -5,7 +5,6 @@ import 'package:breez_logger/breez_logger.dart';
 import 'package:breez_preferences/breez_preferences.dart';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
@@ -78,12 +77,11 @@ class _DevelopersViewState extends State<DevelopersView> {
               color: themeData.iconTheme.color,
             ),
             itemBuilder: (context) => [
-              if (kDebugMode)
-                Choice(
-                  title: texts.developers_page_menu_export_keys_title,
-                  icon: Icons.phone_android,
-                  function: _exportKeys,
-                ),
+              Choice(
+                title: texts.developers_page_menu_export_keys_title,
+                icon: Icons.phone_android,
+                function: _exportKeys,
+              ),
               Choice(
                 title: texts.developers_page_menu_share_logs_title,
                 icon: Icons.share,

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -197,7 +197,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       themeProvider.setTheme('dark');
       navigator.pushReplacementNamed('/');
     } catch (error) {
-      _logger.info("Failed to ${isRestore ? "restore" : "register"} wallet", error);
+      _logger.info("Failed to ${isRestore ? "restore" : "register"} wallet.", error);
       if (isRestore) {
         _restoreWalletFromMnemonicSeed(initialWords: mnemonic.split(" "));
       }

--- a/packages/breez_logger/lib/src/breez_logger.dart
+++ b/packages/breez_logger/lib/src/breez_logger.dart
@@ -11,7 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
 final _logger = Logger("BreezLogger");
-final _breezSdkLiquidLogger = Logger("Breez SDK - Liquid");
+final _breezSdkLiquidLogger = Logger("BreezSdkLiquid");
 
 class BreezLogger {
   BreezLogger() {

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -27,12 +27,14 @@ class BreezSDKLiquid {
     required liquid_sdk.ConnectRequest req,
   }) async {
     try {
+      _subscribeToLogStream();
       _instance = await liquid_sdk.connect(req: req);
       _initializeEventsStream(_instance!);
-      _subscribeToSdkStreams(_instance!);
+      _subscribeToEventsStream(_instance!);
       await _fetchWalletData(_instance!);
     } catch (e) {
       _instance = null;
+      _unsubscribeFromSdkStreams();
       rethrow;
     }
   }
@@ -90,12 +92,6 @@ class BreezSDKLiquid {
 
   void _initializeEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
     _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
-  }
-
-  /// Subscribes to SDK's event & log streams.
-  void _subscribeToSdkStreams(liquid_sdk.BindingLiquidSdk sdk) {
-    _subscribeToEventsStream(sdk);
-    _subscribeToLogStream();
   }
 
   final StreamController<liquid_sdk.GetInfoResponse> _walletInfoController =

--- a/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
+++ b/packages/sdk_connectivity_cubit/lib/src/sdk_connectivity_cubit.dart
@@ -6,7 +6,10 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:credentials_manager/credentials_manager.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
 import 'package:sdk_connectivity_cubit/sdk_connectivity_cubit.dart';
+
+final _logger = Logger("SdkConnectivityCubit");
 
 class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
   final CredentialsManager credentialsManager;
@@ -18,23 +21,28 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
   }) : super(SdkConnectivityState.disconnected);
 
   Future<void> register() async {
+    _logger.info("Registering a new wallet.");
     final mnemonic = generateMnemonic(strength: 128);
     await _connect(mnemonic, storeMnemonic: true);
   }
 
   Future<void> restore({required String mnemonic}) async {
+    _logger.info("Restoring wallet.");
     await _connect(mnemonic, storeMnemonic: true);
   }
 
   Future<void> reconnect({String? mnemonic}) async {
+    _logger.info(mnemonic == null ? "Attempting to reconnect." : "Reconnecting.");
     try {
       final restoredMnemonic = mnemonic ?? await credentialsManager.restoreMnemonic();
       if (restoredMnemonic != null) {
         await _connect(restoredMnemonic);
       } else {
-        throw Exception("No mnemonics");
+        _logger.warning("Failed to restore mnemonics.");
+        throw Exception("Failed to restore mnemonics.");
       }
     } catch (e) {
+      _logger.warning("Failed to reconnect. Retrying when network connection is detected.");
       await _retryUntilConnected();
     }
   }
@@ -42,20 +50,25 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
   Future<void> _connect(String mnemonic, {bool storeMnemonic = false}) async {
     try {
       emit(SdkConnectivityState.connecting);
+      _logger.info("Retrieving SDK configuration...");
+      final sdkConfig = (await AppConfig.instance()).sdkConfig;
+      _logger.info("SDK configuration retrieved successfully.");
 
-      final config = await AppConfig.instance();
-      final req = ConnectRequest(mnemonic: mnemonic, config: config.sdkConfig);
+      final req = ConnectRequest(mnemonic: mnemonic, config: sdkConfig);
+      _logger.info("Using the provided mnemonic and SDK configuration to connect to Breez SDK - Liquid.");
       await breezSdkLiquid.connect(req: req);
+      _logger.info("Successfully connected to Breez SDK - Liquid.");
 
       _startSyncing();
 
-      await _storeBreezApiKey(config.sdkConfig.breezApiKey);
+      await _storeBreezApiKey(sdkConfig.breezApiKey);
       if (storeMnemonic) {
         await credentialsManager.storeMnemonic(mnemonic: mnemonic);
       }
 
       emit(SdkConnectivityState.connected);
     } catch (e) {
+      _logger.warning("Failed to connect to Breez SDK - Liquid. Reason: $e");
       if (storeMnemonic) {
         _clearStoredCredentials();
       }
@@ -72,8 +85,10 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
   }
 
   Future<void> _clearStoredCredentials() async {
+    _logger.info("Clearing stored credentials.");
     await credentialsManager.deleteBreezApiKey();
     await credentialsManager.deleteMnemonic();
+    _logger.info("Successfully cleared stored credentials.");
   }
 
   void _startSyncing() {
@@ -82,6 +97,7 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
   }
 
   Future<void> _retryUntilConnected() async {
+    _logger.info("Subscribing to network events.");
     StreamSubscription<List<ConnectivityResult>>? subscription;
     subscription = Connectivity().onConnectivityChanged.listen(
       (event) async {
@@ -91,8 +107,10 @@ class SdkConnectivityCubit extends Cubit<SdkConnectivityState> {
             ));
         // Attempt to reconnect when internet is back.
         if (hasNetworkConnection && state == SdkConnectivityState.disconnected) {
+          _logger.info("Network connection detected.");
           await reconnect();
           if (state == SdkConnectivityState.connected) {
+            _logger.info("SDK has reconnected. Unsubscribing from network events.");
             subscription!.cancel();
           }
         }


### PR DESCRIPTION
This PR 
- enables "Export Keys" option on developers page menu on all build modes.
- subscribes to SDK's log stream before connecting to log any errors encountered during `connect` API call.

#### Changelist:
- Enable "Export Keys" option on release mode
- Subscribe to SDK's log stream before connecting 
  * Unsubscribe from SDK log & event streams if `connect` fails.
  * Add additional logs to `sdk_connectivity_cubit` package.