### PR TITLE
Use SharedPreferences for storing onboarding status

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -7,15 +7,16 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:logging/logging.dart';
 
 export 'account_state.dart';
+export 'onboarding_preferences.dart';
 
 final Logger _logger = Logger('AccountCubit');
 
 class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> {
   final BreezSDKLiquid breezSdkLiquid;
 
-  AccountCubit({
-    required this.breezSdkLiquid,
-  }) : super(AccountState.initial()) {
+  AccountCubit(
+    this.breezSdkLiquid,
+  ) : super(AccountState.initial()) {
     hydrate();
     _listenAccountChanges();
     _listenInitialSyncEvent();
@@ -52,9 +53,5 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
 
   void setIsRestoring(bool isRestoring) {
     emit(state.copyWith(isRestoring: isRestoring));
-  }
-
-  void setOnboardingComplete(bool isComplete) {
-    emit(state.copyWith(isOnboardingComplete: isComplete));
   }
 }

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -7,13 +7,11 @@ final Logger _logger = Logger('AccountState');
 
 class AccountState {
   final bool isRestoring;
-  final bool isOnboardingComplete;
   final bool didCompleteInitialSync;
   final GetInfoResponse? walletInfo;
 
   const AccountState({
     required this.isRestoring,
-    required this.isOnboardingComplete,
     required this.didCompleteInitialSync,
     required this.walletInfo,
   });
@@ -21,20 +19,17 @@ class AccountState {
   AccountState.initial()
       : this(
           isRestoring: false,
-          isOnboardingComplete: false,
           didCompleteInitialSync: false,
           walletInfo: null,
         );
 
   AccountState copyWith({
     bool? isRestoring,
-    bool? isOnboardingComplete,
     bool? didCompleteInitialSync,
     GetInfoResponse? walletInfo,
   }) {
     return AccountState(
       isRestoring: isRestoring ?? this.isRestoring,
-      isOnboardingComplete: isOnboardingComplete ?? this.isOnboardingComplete,
       didCompleteInitialSync: didCompleteInitialSync ?? this.didCompleteInitialSync,
       walletInfo: walletInfo ?? this.walletInfo,
     );
@@ -45,7 +40,6 @@ class AccountState {
   Map<String, dynamic>? toJson() {
     return <String, dynamic>{
       'isRestoring': isRestoring,
-      'isOnboardingComplete': isOnboardingComplete,
       'walletInfo': walletInfo?.toJson(),
     };
   }
@@ -53,7 +47,6 @@ class AccountState {
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
       isRestoring: json['isRestoring'] ?? false,
-      isOnboardingComplete: json['isOnboardingComplete'] ?? false,
       didCompleteInitialSync: false,
       walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),
     );

--- a/lib/cubit/account/onboarding_preferences.dart
+++ b/lib/cubit/account/onboarding_preferences.dart
@@ -1,0 +1,50 @@
+import 'package:logging/logging.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final Logger _logger = Logger('OnboardingPreferences');
+
+class OnboardingPreferences {
+  static const bool kDefaultOnboardingComplete = false;
+  static const String _kOnboardingComplete = 'onboarding_complete';
+
+  static Future<void> setOnboardingComplete(bool value, {int maxRetries = 3}) async {
+    int attempt = 0;
+    while (attempt < maxRetries) {
+      try {
+        final SharedPreferences prefs = await SharedPreferences.getInstance();
+        final bool success = await prefs.setBool(_kOnboardingComplete, value);
+
+        if (success) {
+          _logger.info('Saved isOnboardingComplete to SharedPreferences successfully.');
+          return;
+        } else {
+          throw Exception(
+            'Failed to save isOnboardingComplete to SharedPreferences on attempt $attempt.',
+          );
+        }
+      } catch (e, stackTrace) {
+        attempt++;
+        _logger.warning('Attempt $attempt failed: $e');
+        _logger.warning('Stack trace: $stackTrace');
+
+        if (attempt >= maxRetries) {
+          _logger.severe('Max retry attempts reached.');
+          rethrow;
+        }
+        await Future<void>.delayed(Duration(milliseconds: 500 * attempt));
+      }
+    }
+  }
+
+  static Future<bool> isOnboardingComplete() async {
+    try {
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final bool result = prefs.getBool(_kOnboardingComplete) ?? kDefaultOnboardingComplete;
+      _logger.info('Retrieved isOnboardingComplete: $result');
+      return result;
+    } catch (e) {
+      _logger.warning('Failed to get isOnboardingComplete from SharedPreferences: $e');
+      return false;
+    }
+  }
+}

--- a/lib/main/main.dart
+++ b/lib/main/main.dart
@@ -7,12 +7,10 @@ void main() {
   bootstrap(
     (
       ServiceInjector injector,
-      AccountCubit accountCubit,
       SdkConnectivityCubit sdkConnectivityCubit,
     ) =>
         App(
       injector: injector,
-      accountCubit: accountCubit,
       sdkConnectivityCubit: sdkConnectivityCubit,
     ),
   );

--- a/lib/routes/initial_walkthrough/initial_walkthrough_page.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough_page.dart
@@ -194,7 +194,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       } else {
         await connectionService.register();
       }
-      accountCubit.setOnboardingComplete(true);
+      await OnboardingPreferences.setOnboardingComplete(true);
       themeProvider.setTheme('dark');
       navigator.pushReplacementNamed('/');
     } catch (error) {


### PR DESCRIPTION
This PR tries a different approach on #85 by decoupling onboarding status from `AccountState` and storing it on `SharedPreferences`.

Added a retry mechanism to handle transient failures when saving `isOnboardingComplete` to `SharedPreferences`. It retries up to 3 times by default with an increasing delay (500ms * attempt) between attemps and rethrows the exception if all attempts fail.