### PR TITLE
Change parse call to SDK instance

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -41,6 +41,7 @@ class App extends StatelessWidget {
         ),
         BlocProvider<InputCubit>(
           create: (BuildContext context) => InputCubit(
+            injector.breezSdkLiquid,
             injector.lightningLinks,
             injector.deviceClient,
           ),

--- a/lib/routes/send_payment/chainswap/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/send_payment/chainswap/widgets/bitcoin_address_text_form_field.dart
@@ -1,7 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/routes.dart';
 import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/widgets/widgets.dart';
@@ -115,8 +117,9 @@ class BitcoinAddressTextFormFieldState extends State<BitcoinAddressTextFormField
   }
 
   Future<bool> isValidBitcoinAddress() async {
+    final InputCubit inputCubit = context.read<InputCubit>();
     try {
-      final InputType inputType = await parse(input: widget.controller.text);
+      final InputType inputType = await inputCubit.parseInput(input: widget.controller.text);
       return inputType is InputType_BitcoinAddress;
     } catch (e) {
       return false;

--- a/packages/breez_sdk_liquid/lib/src/model/config_extension.dart
+++ b/packages/breez_sdk_liquid/lib/src/model/config_extension.dart
@@ -11,6 +11,7 @@ extension ConfigCopyWith on Config {
     int? zeroConfMinFeeRateMsat,
     BigInt? zeroConfMaxAmountSat,
     String? breezApiKey,
+    List<ExternalInputParser>? externalInputParsers,
   }) {
     return Config(
       liquidElectrumUrl: liquidElectrumUrl ?? this.liquidElectrumUrl,
@@ -22,6 +23,7 @@ extension ConfigCopyWith on Config {
       zeroConfMinFeeRateMsat: zeroConfMinFeeRateMsat ?? this.zeroConfMinFeeRateMsat,
       zeroConfMaxAmountSat: zeroConfMaxAmountSat ?? this.zeroConfMaxAmountSat,
       breezApiKey: breezApiKey ?? this.breezApiKey,
+      externalInputParsers: externalInputParsers ?? this.externalInputParsers,
     );
   }
 }


### PR DESCRIPTION
This PR:
- adds `BreezSDKLiquid` to the `InputCupit` so we can call `parse()` on the SDK instance
- adds `externalInputParsers` to the `Config` extension

CI run using https://github.com/breez/breez-sdk-liquid/pull/605: 
https://github.com/breez/misty-breez/actions/runs/12324221413