### PR TITLE
Reflect payment expiry changes

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -23,8 +23,8 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
   void _listenAccountChanges() {
     _logger.info('Listening to account changes');
     breezSdkLiquid.walletInfoStream.distinct().listen(
-      (GetInfoResponse walletInfo) {
-        final AccountState newState = state.copyWith(walletInfo: walletInfo);
+      (GetInfoResponse infoResponse) {
+        final AccountState newState = state.copyWith(walletInfo: infoResponse.walletInfo);
         _logger.info('AccountState changed: $newState');
         emit(newState);
       },

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -8,7 +8,7 @@ final Logger _logger = Logger('AccountState');
 class AccountState {
   final bool isRestoring;
   final bool didCompleteInitialSync;
-  final GetInfoResponse? walletInfo;
+  final WalletInfo? walletInfo;
 
   const AccountState({
     required this.isRestoring,
@@ -26,7 +26,7 @@ class AccountState {
   AccountState copyWith({
     bool? isRestoring,
     bool? didCompleteInitialSync,
-    GetInfoResponse? walletInfo,
+    WalletInfo? walletInfo,
   }) {
     return AccountState(
       isRestoring: isRestoring ?? this.isRestoring,
@@ -48,7 +48,7 @@ class AccountState {
     return AccountState(
       isRestoring: json['isRestoring'] ?? false,
       didCompleteInitialSync: false,
-      walletInfo: GetInfoResponseFromJson.fromJson(json['walletInfo']),
+      walletInfo: WalletInfoFromJson.fromJson(json['walletInfo']),
     );
   }
 
@@ -56,7 +56,7 @@ class AccountState {
   String toString() => jsonEncode(toJson());
 }
 
-extension GetInfoResponseToJson on GetInfoResponse {
+extension WalletInfoToJson on WalletInfo {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'balanceSat': balanceSat.toString(),
@@ -68,8 +68,8 @@ extension GetInfoResponseToJson on GetInfoResponse {
   }
 }
 
-extension GetInfoResponseFromJson on GetInfoResponse {
-  static GetInfoResponse? fromJson(Map<String, dynamic>? json) {
+extension WalletInfoFromJson on WalletInfo {
+  static WalletInfo? fromJson(Map<String, dynamic>? json) {
     if (json == null) {
       _logger.info('walletInfo is missing from AccountState JSON.');
       return null;
@@ -84,7 +84,7 @@ extension GetInfoResponseFromJson on GetInfoResponse {
       return null;
     }
 
-    return GetInfoResponse(
+    return WalletInfo(
       balanceSat: BigInt.parse(json['balanceSat'] as String),
       pendingSendSat: BigInt.parse(json['pendingSendSat'] as String),
       pendingReceiveSat: BigInt.parse(json['pendingReceiveSat'] as String),

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -28,17 +28,17 @@ class WebhookCubit extends Cubit<WebhookState> {
     this._notifications,
   ) : super(WebhookState()) {
     _breezSdkLiquid.walletInfoStream.first.then(
-      (GetInfoResponse walletInfo) => refreshLnurlPay(walletInfo: walletInfo),
+      (GetInfoResponse getInfoResponse) => refreshLnurlPay(getInfoResponse: getInfoResponse),
     );
   }
 
-  Future<void> refreshLnurlPay({GetInfoResponse? walletInfo}) async {
+  Future<void> refreshLnurlPay({GetInfoResponse? getInfoResponse}) async {
     _logger.info('Refreshing Lightning Address');
     emit(WebhookState(isLoading: true));
     try {
-      final GetInfoResponse? getInfoResponse = walletInfo ?? await _breezSdkLiquid.instance?.getInfo();
+      getInfoResponse = getInfoResponse ?? await _breezSdkLiquid.instance?.getInfo();
       if (getInfoResponse != null) {
-        await _registerWebhooks(getInfoResponse);
+        await _registerWebhooks(getInfoResponse.walletInfo);
       } else {
         throw Exception('Unable to retrieve wallet information.');
       }
@@ -55,7 +55,7 @@ class WebhookCubit extends Cubit<WebhookState> {
     }
   }
 
-  Future<void> _registerWebhooks(GetInfoResponse walletInfo) async {
+  Future<void> _registerWebhooks(WalletInfo walletInfo) async {
     try {
       final String webhookUrl = await _generateWebhookURL();
       await _breezSdkLiquid.instance?.registerWebhook(webhookUrl: webhookUrl);
@@ -70,7 +70,7 @@ class WebhookCubit extends Cubit<WebhookState> {
   }
 
   Future<String> _registerLnurlpay(
-    GetInfoResponse walletInfo,
+    WalletInfo walletInfo,
     String webhookUrl,
   ) async {
     final String? lastUsedLnurlPay = await _breezPreferences.getLnUrlPayKey();
@@ -107,7 +107,7 @@ class WebhookCubit extends Cubit<WebhookState> {
   }
 
   Future<void> _invalidateLnurlPay(
-    GetInfoResponse walletInfo,
+    WalletInfo walletInfo,
     String toInvalidate,
   ) async {
     final String lnurlWebhookUrl = '$lnurlServiceURL/lnurlpay/${walletInfo.pubkey}';

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -28,17 +28,17 @@ class WebhookCubit extends Cubit<WebhookState> {
     this._notifications,
   ) : super(WebhookState()) {
     _breezSdkLiquid.walletInfoStream.first.then(
-      (GetInfoResponse getInfoResponse) => refreshLnurlPay(getInfoResponse: getInfoResponse),
+      (GetInfoResponse getInfoResponse) => refreshLnurlPay(walletInfo: getInfoResponse.walletInfo),
     );
   }
 
-  Future<void> refreshLnurlPay({GetInfoResponse? getInfoResponse}) async {
+  Future<void> refreshLnurlPay({WalletInfo? walletInfo}) async {
     _logger.info('Refreshing Lightning Address');
     emit(WebhookState(isLoading: true));
     try {
-      getInfoResponse = getInfoResponse ?? await _breezSdkLiquid.instance?.getInfo();
-      if (getInfoResponse != null) {
-        await _registerWebhooks(getInfoResponse.walletInfo);
+      walletInfo = walletInfo ?? (await _breezSdkLiquid.instance?.getInfo())?.walletInfo;
+      if (walletInfo != null) {
+        await _registerWebhooks(walletInfo);
       } else {
         throw Exception('Unable to retrieve wallet information.');
       }

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -56,6 +56,7 @@ extension PaymentDetailsFromJson on PaymentDetails {
         return PaymentDetails.lightning(
           swapId: json['swapId'] as String,
           description: json['description'] as String,
+          liquidExpirationBlockheight: json['liquidExpirationBlockheight'] as int,
           preimage: json['preimage'] as String?,
           bolt11: json['bolt11'] as String?,
           refundTxId: json['refundTxId'] as String?,
@@ -72,6 +73,8 @@ extension PaymentDetailsFromJson on PaymentDetails {
           swapId: json['swapId'] as String,
           description: json['description'] as String,
           refundTxId: json['refundTxId'] as String?,
+          bitcoinExpirationBlockheight: json['bitcoinExpirationBlockheight'] as int?,
+          liquidExpirationBlockheight: json['liquidExpirationBlockheight'] as int?,
           refundTxAmountSat:
               json['refundTxAmountSat'] != null ? BigInt.parse(json['refundTxAmountSat'] as String) : null,
         );


### PR DESCRIPTION
This PR:
- Changes the occurrences of `GetInfoResponse` to use its new inner field of type `WalletInfo`
- Adds the `liquidExpirationBlockheight` and `bitcoinExpirationBlockheight` fields to the lightning and bitcoin payment details