### PR TITLE
Open an external LN payment validator on clicking payment preimage

### DIFF
--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -28,7 +28,8 @@ extension PaymentDetailsToJson on PaymentDetails {
         'swapId': details.swapId,
         'description': details.description,
         'preimage': details.preimage,
-        'bolt11': details.bolt11,
+        'invoice': details.invoice,
+        'destinationPubkey': details.destinationPubkey,
         'refundTxId': details.refundTxId,
         'refundTxAmountSat': details.refundTxAmountSat?.toString(),
       },
@@ -58,7 +59,8 @@ extension PaymentDetailsFromJson on PaymentDetails {
           description: json['description'] as String,
           liquidExpirationBlockheight: json['liquidExpirationBlockheight'] as int,
           preimage: json['preimage'] as String?,
-          bolt11: json['bolt11'] as String?,
+          invoice: json['invoice'] as String?,
+          destinationPubkey: json['destinationPubkey'] as String?,
           refundTxId: json['refundTxId'] as String?,
           refundTxAmountSat:
               json['refundTxAmountSat'] != null ? BigInt.parse(json['refundTxAmountSat'] as String) : null,
@@ -95,8 +97,9 @@ extension PaymentDetailsExtension on PaymentDetails {
               lightning: (PaymentDetails_Lightning o) =>
                   o.swapId == (this as PaymentDetails_Lightning).swapId &&
                   o.description == (this as PaymentDetails_Lightning).description &&
+                  o.destinationPubkey == (this as PaymentDetails_Lightning).destinationPubkey &&
                   o.preimage == (this as PaymentDetails_Lightning).preimage &&
-                  o.bolt11 == (this as PaymentDetails_Lightning).bolt11 &&
+                  o.invoice == (this as PaymentDetails_Lightning).invoice &&
                   o.refundTxId == (this as PaymentDetails_Lightning).refundTxId &&
                   o.refundTxAmountSat == (this as PaymentDetails_Lightning).refundTxAmountSat,
               liquid: (PaymentDetails_Liquid o) =>
@@ -115,8 +118,8 @@ extension PaymentDetailsExtension on PaymentDetails {
 extension PaymentDetailsHashCode on PaymentDetails {
   int calculateHashCode() {
     return map(
-      lightning: (PaymentDetails_Lightning o) =>
-          Object.hash(o.swapId, o.description, o.preimage, o.bolt11, o.refundTxId, o.refundTxAmountSat),
+      lightning: (PaymentDetails_Lightning o) => Object.hash(o.swapId, o.description, o.destinationPubkey,
+          o.preimage, o.invoice, o.refundTxId, o.refundTxAmountSat),
       liquid: (PaymentDetails_Liquid o) => Object.hash(o.destination, o.description),
       bitcoin: (PaymentDetails_Bitcoin o) =>
           Object.hash(o.swapId, o.description, o.refundTxId, o.refundTxAmountSat),

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -118,8 +118,15 @@ extension PaymentDetailsExtension on PaymentDetails {
 extension PaymentDetailsHashCode on PaymentDetails {
   int calculateHashCode() {
     return map(
-      lightning: (PaymentDetails_Lightning o) => Object.hash(o.swapId, o.description, o.destinationPubkey,
-          o.preimage, o.invoice, o.refundTxId, o.refundTxAmountSat),
+      lightning: (PaymentDetails_Lightning o) => Object.hash(
+        o.swapId,
+        o.description,
+        o.destinationPubkey,
+        o.preimage,
+        o.invoice,
+        o.refundTxId,
+        o.refundTxAmountSat,
+      ),
       liquid: (PaymentDetails_Liquid o) => Object.hash(o.destination, o.description),
       bitcoin: (PaymentDetails_Bitcoin o) =>
           Object.hash(o.swapId, o.description, o.refundTxId, o.refundTxAmountSat),

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -128,8 +128,8 @@ class PaymentDetailsSheet extends StatelessWidget {
                         paymentData: paymentData,
                         labelAutoSizeGroup: _labelGroup,
                       ),
-                      if (bolt11.isNotEmpty) ...<Widget>[
-                        PaymentDetailsSheetBolt11(bolt11: bolt11),
+                      if (invoice != null && invoice.isNotEmpty) ...<Widget>[
+                        PaymentDetailsSheetInvoice(invoice: invoice),
                       ],
                       if (paymentPreimage.isNotEmpty) ...<Widget>[
                         PaymentDetailsSheetPreimage(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -47,23 +47,20 @@ class PaymentDetailsSheet extends StatelessWidget {
       orElse: () => 0,
     );
 
-    final String? bolt11 = paymentData.details.map(
-      lightning: (PaymentDetails_Lightning details) => details.bolt11,
+    final String? invoice = paymentData.details.map(
+      lightning: (PaymentDetails_Lightning details) => details.invoice,
       orElse: () => null,
     );
 
-    final String? bolt12Offer = paymentData.details.map(
-      lightning: (PaymentDetails_Lightning details) => details.bolt12Offer,
-      orElse: () => null,
+    final String destinationPubkey = paymentData.details.map(
+      lightning: (PaymentDetails_Lightning details) => details.destinationPubkey ?? '',
+      orElse: () => '',
     );
-
-    final String? invoice = bolt11 ?? bolt12Offer;
 
     final String paymentPreimage = paymentData.details.map(
-          lightning: (PaymentDetails_Lightning details) => details.preimage,
-          orElse: () => '',
-        ) ??
-        '';
+      lightning: (PaymentDetails_Lightning details) => details.preimage ?? '',
+      orElse: () => '',
+    );
 
     final String swapId = paymentData.details.map(
       bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
@@ -133,9 +130,12 @@ class PaymentDetailsSheet extends StatelessWidget {
                       ],
                       if (paymentPreimage.isNotEmpty) ...<Widget>[
                         PaymentDetailsSheetPreimage(
-                          invoice: bolt11 ?? bolt12Offer,
+                          invoice: invoice,
                           paymentPreimage: paymentPreimage,
                         ),
+                      ],
+                      if (destinationPubkey.isNotEmpty) ...<Widget>[
+                        PaymentDetailsSheetDestinationPubkey(destinationPubkey: destinationPubkey),
                       ],
                       if (paymentData.txId.isNotEmpty) ...<Widget>[
                         PaymentDetailsSheetTxId(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -47,11 +47,17 @@ class PaymentDetailsSheet extends StatelessWidget {
       orElse: () => 0,
     );
 
-    final String bolt11 = paymentData.details.map(
-          lightning: (PaymentDetails_Lightning details) => details.bolt11,
-          orElse: () => '',
-        ) ??
-        '';
+    final String? bolt11 = paymentData.details.map(
+      lightning: (PaymentDetails_Lightning details) => details.bolt11,
+      orElse: () => null,
+    );
+
+    final String? bolt12Offer = paymentData.details.map(
+      lightning: (PaymentDetails_Lightning details) => details.bolt12Offer,
+      orElse: () => null,
+    );
+
+    final String? invoice = bolt11 ?? bolt12Offer;
 
     final String paymentPreimage = paymentData.details.map(
           lightning: (PaymentDetails_Lightning details) => details.preimage,
@@ -126,7 +132,10 @@ class PaymentDetailsSheet extends StatelessWidget {
                         PaymentDetailsSheetBolt11(bolt11: bolt11),
                       ],
                       if (paymentPreimage.isNotEmpty) ...<Widget>[
-                        PaymentDetailsSheetPreimage(paymentPreimage: paymentPreimage),
+                        PaymentDetailsSheetPreimage(
+                          invoice: bolt11 ?? bolt12Offer,
+                          paymentPreimage: paymentPreimage,
+                        ),
                       ],
                       if (paymentData.txId.isNotEmpty) ...<Widget>[
                         PaymentDetailsSheetTxId(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_destination_pubkey.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_destination_pubkey.dart
@@ -1,0 +1,27 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/material.dart';
+import 'package:l_breez/widgets/widgets.dart';
+
+class PaymentDetailsSheetDestinationPubkey extends StatelessWidget {
+  final String destinationPubkey;
+
+  const PaymentDetailsSheetDestinationPubkey({required this.destinationPubkey, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
+
+    return ShareablePaymentRow(
+      tilePadding: EdgeInsets.zero,
+      dividerColor: Colors.transparent,
+      title: '${texts.payment_details_dialog_single_info_node_id}:',
+      titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
+        fontSize: 18.0,
+        color: Colors.white,
+      ),
+      sharedValue: destinationPubkey,
+    );
+  }
+}

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_invoice.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_invoice.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
-class PaymentDetailsSheetBolt11 extends StatelessWidget {
-  final String bolt11;
+class PaymentDetailsSheetInvoice extends StatelessWidget {
+  final String invoice;
 
-  const PaymentDetailsSheetBolt11({required this.bolt11, super.key});
+  const PaymentDetailsSheetInvoice({required this.invoice, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +18,7 @@ class PaymentDetailsSheetBolt11 extends StatelessWidget {
         fontSize: 18.0,
         color: Colors.white,
       ),
-      sharedValue: bolt11,
+      sharedValue: invoice,
     );
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_preimage.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_preimage.dart
@@ -1,12 +1,18 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
+import 'package:l_breez/utils/ln_payment_validator_utils.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
 class PaymentDetailsSheetPreimage extends StatelessWidget {
   final String paymentPreimage;
+  final String? invoice;
 
-  const PaymentDetailsSheetPreimage({required this.paymentPreimage, super.key});
+  const PaymentDetailsSheetPreimage({
+    required this.paymentPreimage,
+    required this.invoice,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +28,11 @@ class PaymentDetailsSheetPreimage extends StatelessWidget {
         color: Colors.white,
       ),
       sharedValue: paymentPreimage,
+      isURL: invoice != null,
+      urlValue: LnPaymentValidatorUtils().formatLnPaymentValidatorUrl(
+        invoice: invoice!,
+        preimage: paymentPreimage,
+      ),
     );
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
@@ -1,9 +1,9 @@
 export 'payment_details_sheet_amount.dart';
-export 'payment_details_sheet_bolt11.dart';
 export 'payment_details_sheet_content_title.dart';
 export 'payment_details_sheet_date.dart';
 export 'payment_details_sheet_description.dart';
 export 'payment_details_sheet_fee.dart';
+export 'payment_details_sheet_invoice.dart';
 export 'payment_details_sheet_preimage.dart';
 export 'payment_details_sheet_refund_tx_fee_amount.dart';
 export 'payment_details_sheet_swap_id.dart';

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
@@ -2,6 +2,7 @@ export 'payment_details_sheet_amount.dart';
 export 'payment_details_sheet_content_title.dart';
 export 'payment_details_sheet_date.dart';
 export 'payment_details_sheet_description.dart';
+export 'payment_details_sheet_destination_pubkey.dart';
 export 'payment_details_sheet_fee.dart';
 export 'payment_details_sheet_invoice.dart';
 export 'payment_details_sheet_preimage.dart';

--- a/lib/utils/blockchain_explorer_utils.dart
+++ b/lib/utils/blockchain_explorer_utils.dart
@@ -1,4 +1,3 @@
-// TODO(erdemyerebasmaz): Liquid - This file is unused - Re-add for swap tx's after input parser is implemented
 class BlockChainExplorerUtils {
   String formatTransactionUrl({
     required String txid,

--- a/lib/utils/ln_payment_validator_utils.dart
+++ b/lib/utils/ln_payment_validator_utils.dart
@@ -2,7 +2,7 @@ class LnPaymentValidatorUtils {
   String formatLnPaymentValidatorUrl({
     required String invoice,
     required String preimage,
-    String lnPaymentValidator = 'https://validate-payment.netlify.app/',
+    String lnPaymentValidator = 'https://validate-payment.com/',
   }) {
     return '$lnPaymentValidator/?invoice=$invoice&preimage=$preimage';
   }

--- a/lib/utils/ln_payment_validator_utils.dart
+++ b/lib/utils/ln_payment_validator_utils.dart
@@ -1,0 +1,9 @@
+class LnPaymentValidatorUtils {
+  String formatLnPaymentValidatorUrl({
+    required String invoice,
+    required String preimage,
+    String lnPaymentValidator = 'https://validate-payment.netlify.app/',
+  }) {
+    return '$lnPaymentValidator/?invoice=$invoice&preimage=$preimage';
+  }
+}


### PR DESCRIPTION
This PR addresses 
- #255

[Demonstration](https://github.com/user-attachments/assets/42d5681e-2597-40a0-b2e6-77e33915fe24)

#### Changelist:
- Link to an external LN payment validator on clicking payment preimage f9cd184
- Display bolt12 offers on Invoice tile f4d05a5
- Remove obsolete TODO comment 927ade3