### PR TITLE
Improve how refunded payments are displayed

### DIFF
--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -118,6 +118,15 @@ class PaymentData {
             status == other.status &&
             details.equals(other.details);
   }
+
+  bool get isRefunded {
+    final int refundTxAmountSat = details.map(
+      bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
+      lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
+      orElse: () => 0,
+    );
+    return refundTxAmountSat > 0 && status == PaymentState.failed;
+  }
 }
 
 class _PaymentDataFactory {

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -119,14 +119,15 @@ class PaymentData {
             details.equals(other.details);
   }
 
-  bool get isRefunded {
-    final int refundTxAmountSat = details.map(
-      bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
-      lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
-      orElse: () => 0,
-    );
-    return refundTxAmountSat > 0 && status == PaymentState.failed;
-  }
+  int get refundTxAmountSat => details.map(
+        bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
+        lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
+        orElse: () => 0,
+      );
+
+  bool get isRefunded => refundTxAmountSat > 0 && status == PaymentState.failed;
+
+  int get actualFeeSat => isRefunded ? amountSat - refundTxAmountSat : feeSat;
 }
 
 class _PaymentDataFactory {

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -53,12 +53,6 @@ class PaymentDetailsSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
 
-    final int refundTxAmountSat = paymentData.details.map(
-      bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
-      lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
-      orElse: () => 0,
-    );
-
     final String? invoice = paymentData.details.map(
       lightning: (PaymentDetails_Lightning details) => details.invoice,
       orElse: () => null,
@@ -128,7 +122,7 @@ class PaymentDetailsSheet extends StatelessWidget {
                         paymentData: paymentData,
                         labelAutoSizeGroup: _labelGroup,
                       ),
-                      if (refundTxAmountSat > 0) ...<Widget>[
+                      if (paymentData.isRefunded) ...<Widget>[
                         PaymentDetailsSheetRefundTxAmount(
                           paymentData: paymentData,
                           labelAutoSizeGroup: _labelGroup,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
@@ -3,10 +3,8 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
-import 'package:l_breez/models/payment_details_extension.dart';
 
 class PaymentDetailsSheetFee extends StatelessWidget {
   final PaymentData paymentData;
@@ -44,20 +42,11 @@ class PaymentDetailsSheetFee extends StatelessWidget {
             reverse: true,
             child: BlocBuilder<CurrencyCubit, CurrencyState>(
               builder: (BuildContext context, CurrencyState state) {
-                int feeSat = paymentData.feeSat;
-                if (paymentData.isRefunded) {
-                  final int refundTxAmountSat = paymentData.details.map(
-                    bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
-                    lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
-                    orElse: () => 0,
-                  );
-                  feeSat = paymentData.amountSat - refundTxAmountSat;
-                }
-                final String feeFormatted = BitcoinCurrency.fromTickerSymbol(
+                final String actualFeeFormatted = BitcoinCurrency.fromTickerSymbol(
                   state.bitcoinTicker,
-                ).format(feeSat);
+                ).format(paymentData.actualFeeSat);
                 return Text(
-                  feeFormatted,
+                  actualFeeFormatted,
                   style: themeData.primaryTextTheme.displaySmall!.copyWith(
                     fontSize: 18.0,
                     color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
@@ -3,8 +3,10 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
 
 class PaymentDetailsSheetFee extends StatelessWidget {
   final PaymentData paymentData;
@@ -42,11 +44,20 @@ class PaymentDetailsSheetFee extends StatelessWidget {
             reverse: true,
             child: BlocBuilder<CurrencyCubit, CurrencyState>(
               builder: (BuildContext context, CurrencyState state) {
-                final String feeSat = BitcoinCurrency.fromTickerSymbol(
+                int feeSat = paymentData.feeSat;
+                if (paymentData.isRefunded) {
+                  final int refundTxAmountSat = paymentData.details.map(
+                    bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
+                    lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
+                    orElse: () => 0,
+                  );
+                  feeSat = paymentData.amountSat - refundTxAmountSat;
+                }
+                final String feeFormatted = BitcoinCurrency.fromTickerSymbol(
                   state.bitcoinTicker,
-                ).format(paymentData.feeSat);
+                ).format(feeSat);
                 return Text(
-                  feeSat,
+                  feeFormatted,
                   style: themeData.primaryTextTheme.displaySmall!.copyWith(
                     fontSize: 18.0,
                     color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
@@ -39,6 +39,15 @@ class _PaymentDetailsSheetHeaderState extends State<PaymentDetailsSheetHeader> {
           ),
           PaymentDetailsSheetContentTitle(paymentData: widget.paymentData),
           PaymentDetailsSheetDescription(paymentData: widget.paymentData),
+          if (widget.paymentData.isRefunded) ...<Widget>[
+            const Padding(
+              padding: EdgeInsets.only(top: 8),
+              child: Chip(
+                label: Text('FAILED'),
+                backgroundColor: Colors.red,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
@@ -6,7 +6,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
-import 'package:l_breez/models/payment_details_extension.dart';
 
 class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
   final PaymentData paymentData;
@@ -20,12 +19,6 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final int refundTxAmountSat = paymentData.details.map(
-      bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
-      lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
-      orElse: () => 0,
-    );
-
     final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
@@ -52,7 +45,7 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
               builder: (BuildContext context, CurrencyState state) {
                 final String amountSats = BitcoinCurrency.fromTickerSymbol(
                   state.bitcoinTicker,
-                ).format(refundTxAmountSat);
+                ).format(paymentData.refundTxAmountSat);
                 return Text(
                   paymentData.paymentType == PaymentType.receive || paymentData.isRefunded
                       ? texts.payment_details_dialog_amount_positive(amountSats)

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
@@ -34,6 +34,7 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
+            // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
             'Refund Tx ${texts.ln_payment_amount_label}',
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
@@ -53,7 +54,7 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
                   state.bitcoinTicker,
                 ).format(refundTxAmountSat);
                 return Text(
-                  paymentData.paymentType == PaymentType.receive
+                  paymentData.paymentType == PaymentType.receive || paymentData.isRefunded
                       ? texts.payment_details_dialog_amount_positive(amountSats)
                       : texts.payment_details_dialog_amount_negative(amountSats),
                   style: themeData.primaryTextTheme.displaySmall!.copyWith(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_amount.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
-import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/theme/theme.dart';
 
 class PaymentItemAmount extends StatelessWidget {
@@ -24,21 +23,14 @@ class PaymentItemAmount extends StatelessWidget {
           final bool hideBalance = userModel.profileSettings.hideBalance;
           return BlocBuilder<CurrencyCubit, CurrencyState>(
             builder: (BuildContext context, CurrencyState currencyState) {
-              int feeSat = paymentData.feeSat;
-              if (paymentData.isRefunded) {
-                final int refundTxAmountSat = paymentData.details.map(
-                  bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
-                  lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
-                  orElse: () => 0,
-                );
-                feeSat = paymentData.amountSat - refundTxAmountSat;
-              }
               final String amount = currencyState.bitcoinCurrency.format(
                 paymentData.amountSat,
                 includeDisplayName: false,
               );
-              final String feeFormatted = currencyState.bitcoinCurrency.format(
-                feeSat,
+
+              final int actualFeeSat = paymentData.actualFeeSat;
+              final String actualFeeFormatted = currencyState.bitcoinCurrency.format(
+                actualFeeSat,
                 includeDisplayName: false,
               );
 
@@ -58,12 +50,12 @@ class PaymentItemAmount extends StatelessWidget {
                                   : texts.wallet_dashboard_payment_item_balance_negative(amount),
                           style: themeData.paymentItemAmountTextStyle,
                         ),
-                  (feeSat == 0 || paymentData.status == PaymentState.pending)
+                  (actualFeeSat == 0 || paymentData.status == PaymentState.pending)
                       ? const SizedBox.shrink()
                       : Text(
                           hideBalance
                               ? texts.wallet_dashboard_payment_item_balance_hide
-                              : texts.wallet_dashboard_payment_item_balance_fee(feeFormatted),
+                              : texts.wallet_dashboard_payment_item_balance_fee(actualFeeFormatted),
                           style: themeData.paymentItemFeeTextStyle,
                         ),
                 ],

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_amount.dart
@@ -39,16 +39,18 @@ class PaymentItemAmount extends StatelessWidget {
                     : MainAxisAlignment.spaceAround,
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  Text(
-                    hideBalance
-                        ? texts.wallet_dashboard_payment_item_balance_hide
-                        : paymentData.paymentType == PaymentType.receive
-                            ? texts.wallet_dashboard_payment_item_balance_positive(amount)
-                            : texts.wallet_dashboard_payment_item_balance_negative(amount),
-                    style: themeData.paymentItemAmountTextStyle,
-                  ),
+                  (paymentData.isRefunded)
+                      ? const SizedBox.shrink()
+                      : Text(
+                          hideBalance
+                              ? texts.wallet_dashboard_payment_item_balance_hide
+                              : paymentData.paymentType == PaymentType.receive
+                                  ? texts.wallet_dashboard_payment_item_balance_positive(amount)
+                                  : texts.wallet_dashboard_payment_item_balance_negative(amount),
+                          style: themeData.paymentItemAmountTextStyle,
+                        ),
                   (fee == 0 || paymentData.status == PaymentState.pending)
-                      ? const SizedBox()
+                      ? const SizedBox.shrink()
                       : Text(
                           hideBalance
                               ? texts.wallet_dashboard_payment_item_balance_hide

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
@@ -25,7 +25,11 @@ class PaymentItemAvatar extends StatelessWidget {
         radius: radius,
         backgroundColor: Colors.white,
         child: Icon(
-          paymentData.paymentType == PaymentType.receive ? Icons.add_rounded : Icons.remove_rounded,
+          paymentData.isRefunded
+              ? Icons.close_rounded
+              : paymentData.paymentType == PaymentType.receive
+                  ? Icons.add_rounded
+                  : Icons.remove_rounded,
           size: radius,
           color: const Color(0xb3303234),
         ),

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
@@ -35,6 +35,14 @@ class PaymentItemSubtitle extends StatelessWidget {
             ),
           ),
         ],
+        if (paymentData.isRefunded) ...<Widget>[
+          Text(
+            ' (Failed)',
+            style: subtitleTextStyle.copyWith(
+              color: themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
+            ),
+          ),
+        ],
       ],
     );
   }


### PR DESCRIPTION
This PR addresses 
- https://github.com/breez/misty-breez/issues/278

#### Screenshots:
<img width="44%" alt="image" src="https://github.com/user-attachments/assets/3ccd514b-557c-4751-a1cb-0f94835a53da" />
<img width="44%" alt="image" src="https://github.com/user-attachments/assets/d31be8d6-d0cf-45e7-b70b-1b6faad9140a" />

#### Changelist:
- Create isRefunded getter on PaymentData d3d8df9
- Show amount as positive on payment details sheet for refunded items c673f16
- Add a 'FAILED' chip to payment details for refunded items 2dea9e3
- Show refund tx amount as positive on payment details sheet for refunded items ee84895
- Hide amount and only display fees for refunded items on payment list 8e17164
- Show 'X' avatar for refunded items on payment list db84199
- Add a '(Failed)' suffix on subtitle of refunded items on payment list ec78c3f