### PR TITLE
Allow dismissing `PaymentDetailsSheet` when it's content is scrollable

### DIFF
--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -24,16 +24,28 @@ Future<dynamic> showPaymentDetailsSheet(
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(24.0)),
     ),
-    builder: (BuildContext context) => PaymentDetailsSheet(
-      paymentData: paymentData,
-    ),
+    builder: (BuildContext context) {
+      return DraggableScrollableSheet(
+        initialChildSize: 1.0,
+        minChildSize: 0.9,
+        snap: true,
+        snapSizes: <double>[1.0],
+        builder: (BuildContext context, ScrollController scrollController) {
+          return PaymentDetailsSheet(
+            paymentData: paymentData,
+            scrollController: scrollController,
+          );
+        },
+      );
+    },
   );
 }
 
 class PaymentDetailsSheet extends StatelessWidget {
   final PaymentData paymentData;
+  final ScrollController scrollController;
 
-  PaymentDetailsSheet({required this.paymentData, super.key}) {
+  PaymentDetailsSheet({required this.paymentData, required this.scrollController, super.key}) {
     _logger.info('PaymentDetailsSheet for payment: $paymentData');
   }
 
@@ -78,6 +90,7 @@ class PaymentDetailsSheet extends StatelessWidget {
         color: themeData.canvasColor,
       ),
       child: SingleChildScrollView(
+        controller: scrollController,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: SizedBox(


### PR DESCRIPTION
This PR addresses
- #271

`PaymentDetailsSheet` is now wrapped with a `DraggableScrollableSheet` and it's inner `SingleChildScrollView` share the same scroll controller. 

The sheet is dismissed if it's dragged %10 from top. A snap behavior with a single snap size is added to snap back the sheet to it's original state for any drag value below %10.