### PR TITLE
Utilize 'Use All Funds' value properly when setting amount on outgoing swap transactions 

### DIFF
--- a/lib/routes/send_payment/chainswap/send_chainswap_form.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_form.dart
@@ -18,7 +18,7 @@ class SendChainSwapForm extends StatefulWidget {
   final GlobalKey<FormState> formKey;
   final TextEditingController amountController;
   final TextEditingController addressController;
-  final bool useEntireBalance;
+  final bool isDrain;
   final ValueChanged<bool> onChanged;
   final BitcoinAddressData? btcAddressData;
   final BitcoinCurrency bitcoinCurrency;
@@ -29,7 +29,7 @@ class SendChainSwapForm extends StatefulWidget {
     required this.amountController,
     required this.addressController,
     required this.onChanged,
-    required this.useEntireBalance,
+    required this.isDrain,
     required this.bitcoinCurrency,
     required this.paymentLimits,
     super.key,
@@ -105,7 +105,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
             bitcoinCurrency: widget.bitcoinCurrency,
             controller: widget.amountController,
             focusNode: _amountFocusNode,
-            useEntireBalance: widget.useEntireBalance,
+            isDrain: widget.isDrain,
             balance: widget.paymentLimits.send.maxSat,
             policy: WithdrawFundsPolicy(
               WithdrawKind.withdrawFunds,
@@ -171,7 +171,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
                     trailing: Padding(
                       padding: const EdgeInsets.only(bottom: 8.0),
                       child: Switch(
-                        value: widget.useEntireBalance,
+                        value: widget.isDrain,
                         activeColor: Colors.white,
                         activeTrackColor: themeData.primaryColor,
                         onChanged: (bool value) async {

--- a/lib/routes/send_payment/chainswap/send_chainswap_form_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_form_page.dart
@@ -10,6 +10,8 @@ class SendChainSwapFormPage extends StatefulWidget {
   final BitcoinAddressData? btcAddressData;
   final TextEditingController amountController;
   final TextEditingController addressController;
+  final bool isDrain;
+  final ValueChanged<bool> onChanged;
 
   const SendChainSwapFormPage({
     required this.formKey,
@@ -17,6 +19,8 @@ class SendChainSwapFormPage extends StatefulWidget {
     required this.paymentLimits,
     required this.amountController,
     required this.addressController,
+    required this.isDrain,
+    required this.onChanged,
     super.key,
     this.btcAddressData,
   });
@@ -26,8 +30,6 @@ class SendChainSwapFormPage extends StatefulWidget {
 }
 
 class _SendChainSwapFormPageState extends State<SendChainSwapFormPage> {
-  bool _useEntireBalance = false;
-
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -49,14 +51,12 @@ class _SendChainSwapFormPageState extends State<SendChainSwapFormPage> {
                 formKey: widget.formKey,
                 amountController: widget.amountController,
                 addressController: widget.addressController,
-                useEntireBalance: _useEntireBalance,
+                isDrain: widget.isDrain,
                 btcAddressData: widget.btcAddressData,
                 bitcoinCurrency: widget.bitcoinCurrency,
                 paymentLimits: widget.paymentLimits,
                 onChanged: (bool value) {
-                  setState(() {
-                    _useEntireBalance = value;
-                  });
+                  widget.onChanged(value);
                 },
               ),
             ),

--- a/lib/routes/send_payment/chainswap/send_chainswap_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_page.dart
@@ -29,6 +29,8 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
   final TextEditingController _amountController = TextEditingController();
   final TextEditingController _addressController = TextEditingController();
 
+  bool isDrain = false;
+
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
@@ -80,6 +82,12 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
             bitcoinCurrency: currencyState.bitcoinCurrency,
             paymentLimits: snapshot.onchainPaymentLimits!,
             btcAddressData: widget.btcAddressData,
+            isDrain: isDrain,
+            onChanged: (bool value) {
+              setState(() {
+                isDrain = value;
+              });
+            },
           );
         },
       ),
@@ -121,7 +129,7 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
             builder: (_) => SendChainSwapConfirmationPage(
               amountSat: amount,
               onchainRecipientAddress: getAddress(),
-              isDrain: _isDrain(amount),
+              isDrain: isDrain ? isDrain : _isDrain(amount),
             ),
           ),
         );

--- a/lib/routes/send_payment/chainswap/send_chainswap_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_page.dart
@@ -128,8 +128,8 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
           FadeInRoute<void>(
             builder: (_) => SendChainSwapConfirmationPage(
               amountSat: amount,
-              onchainRecipientAddress: getAddress(),
-              isDrain: isDrain ? isDrain : _isDrain(amount),
+              onchainRecipientAddress: _addressController.text,
+              isDrain: isDrain,
             ),
           ),
         );
@@ -165,15 +165,5 @@ class _SendChainSwapPageState extends State<SendChainSwapPage> {
       _logger.warning('Failed to parse the input amount', e);
     }
     return amount;
-  }
-
-  bool _isDrain(int amount) {
-    final AccountCubit accountCubit = context.read<AccountCubit>();
-    final AccountState accountState = accountCubit.state;
-    return accountState.walletInfo!.balanceSat.toInt() == amount;
-  }
-
-  String getAddress() {
-    return _addressController.text;
   }
 }

--- a/lib/routes/send_payment/chainswap/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/send_payment/chainswap/widgets/withdraw_funds_amount_text_form_field.dart
@@ -13,16 +13,16 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
     required super.bitcoinCurrency,
     required super.context,
     required TextEditingController super.controller,
-    required FocusNode super.focusNode,
-    required bool useEntireBalance,
+    required FocusNode focusNode,
+    required bool isDrain,
     required WithdrawFundsPolicy policy,
     required BigInt balance,
     super.key,
   }) : super(
           texts: context.texts(),
-          enabled: !useEntireBalance,
-          enableInteractiveSelection: !useEntireBalance,
-          readOnly: policy.withdrawKind == WithdrawKind.unexpectedFunds || useEntireBalance,
+          enableInteractiveSelection: !isDrain,
+          readOnly: policy.withdrawKind == WithdrawKind.unexpectedFunds || isDrain,
+          focusNode: isDrain ? null : focusNode,
           validatorFn: (int amount) {
             _logger.info('Validator called for $amount');
             return PaymentValidator(


### PR DESCRIPTION
Closes #298

#### Changelist:
- Utilize 'Use All Funds' value properly between SendChainSwap pages & widgets
- Do not disable amount field when user is using all funds
  - Validation errors are now shown for disabled fields
  - Disable focusing amount field when user is using all funds
- `useEntireBalance` instances are renamed to `isDrain` on SendChainSwap pages