### PR TITLE
Replace default titles with 'Liquid' naming with 'Unknown' on outgoing payments

### DIFF
--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/payment_details_extension.dart';
+import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 
 // TODO(erdemyerebasmaz): Liquid - Remove if having PaymentData is not necessary with Liquid SDK
 /// Hold formatted data from Payment to be displayed in the UI, using the minutiae noun instead of details or
@@ -137,17 +138,27 @@ class _PaymentDataFactory {
   _PaymentDataFactory(this._payment, this._texts);
 
   String _title() {
-    final String title = _texts.payment_info_title_unknown;
+    final LnUrlInfo? lnurlInfo = _payment.details.map(
+      lightning: (PaymentDetails_Lightning details) => details.lnurlInfo,
+      orElse: () => null,
+    );
+
+    final String lnAddress = lnurlInfo?.lnAddress ?? '';
+
+    if (lnAddress.isNotEmpty) {
+      return lnAddress;
+    }
     final String description = _payment.details.map(
       lightning: (PaymentDetails_Lightning details) => details.description,
       bitcoin: (PaymentDetails_Bitcoin details) => details.description,
       liquid: (PaymentDetails_Liquid details) => details.description,
       orElse: () => '',
     );
-    if (description.isNotEmpty) {
+    if (description.isNotEmpty && !description.containsLiquidNaming) {
       return description;
     }
-    return title;
+
+    return _texts.payment_info_title_unknown;
   }
 
   DateTime _paymentTime() {

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_content_title.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_content_title.dart
@@ -1,9 +1,10 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
-import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 
 class PaymentDetailsSheetContentTitle extends StatelessWidget {
   final PaymentData paymentData;
@@ -12,17 +13,20 @@ class PaymentDetailsSheetContentTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     String title = paymentData.title;
     if (title.isEmpty) {
       return Container();
     }
-    if (paymentData.paymentType == PaymentType.receive && title.isDefaultTitleWithLiquidNaming) {
+
+    if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
       title = 'Payment to ${userProfileState.profileSettings.name}';
     }
+
     return AutoSizeText(
       title,
       style: themeData.primaryTextTheme.titleLarge!.copyWith(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
@@ -1,10 +1,11 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/payment_details_extension.dart';
-import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 
 class PaymentDetailsSheetDescription extends StatelessWidget {
   final PaymentData paymentData;
@@ -13,10 +14,11 @@ class PaymentDetailsSheetDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     String title = paymentData.title;
-    if (paymentData.paymentType == PaymentType.receive && title.isDefaultTitleWithLiquidNaming) {
+    if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
       title = 'Payment to ${userProfileState.profileSettings.name}';

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
@@ -1,9 +1,10 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/user_profile.dart';
-import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
 class PaymentItemAvatar extends StatelessWidget {
@@ -14,12 +15,17 @@ class PaymentItemAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final String title = paymentData.title;
-    if (paymentData.paymentType == PaymentType.receive && title.isDefaultTitleWithLiquidNaming) {
+    if (title == texts.payment_info_title_unknown) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
       final UserProfileSettings user = userProfileState.profileSettings;
-      return BreezAvatar(user.avatarURL, radius: radius);
+      String? avatarURL = '';
+      if (paymentData.paymentType == PaymentType.receive) {
+        avatarURL = user.avatarURL;
+      }
+      return BreezAvatar(avatarURL, radius: radius);
     } else {
       return CircleAvatar(
         radius: radius,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_title.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_title.dart
@@ -1,9 +1,10 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/theme/theme.dart';
-import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 
 class PaymentItemTitle extends StatelessWidget {
   final PaymentData paymentData;
@@ -15,8 +16,9 @@ class PaymentItemTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     String title = paymentData.title;
-    if (paymentData.paymentType == PaymentType.receive && title.isDefaultTitleWithLiquidNaming) {
+    if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
       title = 'Payment to ${userProfileState.profileSettings.name}';

--- a/lib/utils/extensions/payment_title_extension.dart
+++ b/lib/utils/extensions/payment_title_extension.dart
@@ -1,6 +1,6 @@
 extension PaymentTitleExtension on String {
   // TODO(erdemyerebasmaz): Remove once default descriptions from the SDK is removed
-  bool get isDefaultTitleWithLiquidNaming {
+  bool get containsLiquidNaming {
     return contains('Send to L-BTC address') || contains('Liquid transfer');
   }
 }


### PR DESCRIPTION
Closes #300

This PR replaces payment items with 'Liquid' in their naming but these changes are not yet final, more cases will be handled as the data is available from the SDK. 

In scope of this PR; 
- `description` is set as `title` only if the `description` does not contain 'Liquid' in it's naming
- Default payment title & avatar are set to `Unknown` & `Alien`, respectively
- LN Address is used as payment title for LNURL payments, given the information is available