### PR TITLE
fix: Migrate archive from 3.x to 4.x

### DIFF
--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -156,8 +156,8 @@ class _DevelopersViewState extends State<DevelopersView> {
     final String walletStoragePath = '$sdkDirPath/$networkName/$fingerprint';
     final String storageFilePath = '$walletStoragePath/storage.sql';
     final File storageFile = File(storageFilePath);
-    encoder.addFile(storageFile);
-    encoder.close();
+    await encoder.addFile(storageFile);
+    await encoder.close();
     final XFile zipFile = XFile(zipFilePath);
     Share.shareXFiles(<XFile>[zipFile]);
   }

--- a/packages/breez_logger/lib/src/breez_logger.dart
+++ b/packages/breez_logger/lib/src/breez_logger.dart
@@ -129,8 +129,8 @@ void shareLog() async {
   final ZipFileEncoder encoder = ZipFileEncoder();
   final String zipFilePath = '$appDir/l-breez.logs.zip';
   encoder.create(zipFilePath);
-  encoder.addDirectory(Directory('$appDir/logs/'));
-  encoder.close();
+  await encoder.addDirectory(Directory('$appDir/logs/'));
+  await encoder.close();
   final XFile zipFile = XFile(zipFilePath);
   Share.shareXFiles(<XFile>[zipFile]);
 }


### PR DESCRIPTION
Fixes #308

Breaking changes on `archive` package was not documented well and this issue went overlooked.