### PR TITLE
Display LN Address on "Receive via Lightning Address" page

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -52,8 +52,14 @@ class App extends StatelessWidget {
           lazy: false,
           create: (BuildContext context) => WebhookCubit(
             injector.breezSdkLiquid,
-            injector.breezPreferences,
-            injector.notifications,
+            WebhookService(
+              injector.breezSdkLiquid,
+              injector.notifications,
+            ),
+            LnUrlPayService(
+              injector.breezSdkLiquid,
+              injector.breezPreferences,
+            ),
           ),
         ),
         BlocProvider<CurrencyCubit>(

--- a/lib/cubit/webhook/lnurl_pay_service.dart
+++ b/lib/cubit/webhook/lnurl_pay_service.dart
@@ -143,6 +143,7 @@ class LnUrlPayService {
     );
     _logger.info('invalidate lnurl pay response: ${response.statusCode}');
     await resetLnUrlPayKey();
+    await resetLnAddressUsername();
   }
 
   Future<void> setLnUrlPayKey({required String webhookUrl}) async {
@@ -155,5 +156,17 @@ class LnUrlPayService {
 
   Future<void> resetLnUrlPayKey() async {
     return await _breezPreferences.resetLnUrlPayKey();
+  }
+
+  Future<void> setLnAddressUsername({required String lnAddressUsername}) async {
+    return await _breezPreferences.setLnAddressUsername(lnAddressUsername);
+  }
+
+  Future<String?> getLnAddressUsername() async {
+    return await _breezPreferences.getLnAddressUsername();
+  }
+
+  Future<void> resetLnAddressUsername() async {
+    return await _breezPreferences.resetLnAddressUsername();
   }
 }

--- a/lib/cubit/webhook/lnurl_pay_service.dart
+++ b/lib/cubit/webhook/lnurl_pay_service.dart
@@ -114,11 +114,12 @@ class LnUrlPayService {
     }
   }
 
-  Future<void> updateLnAddressUsername(WalletInfo walletInfo, String username) async {
+  Future<Map<String, String>> updateLnAddressUsername(WalletInfo walletInfo, String username) async {
     final String? webhookUrl = await getLnUrlPayKey();
-    if (webhookUrl != null) {
-      await registerLnurlpay(walletInfo, webhookUrl, username: username);
+    if (webhookUrl == null) {
+      throw Exception('Failed to retrieve registered webhook.');
     }
+    return await registerLnurlpay(walletInfo, webhookUrl, username: username);
   }
 
   Future<void> _invalidateLnurlPay(String pubKey, String toInvalidate) async {

--- a/lib/cubit/webhook/lnurl_pay_service.dart
+++ b/lib/cubit/webhook/lnurl_pay_service.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+
+import 'package:breez_preferences/breez_preferences.dart';
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:http/http.dart' as http;
+import 'package:l_breez/cubit/webhook/webhook_state.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('LnUrlPayService');
+
+class LnUrlPayService {
+  static const String lnurlServiceURL = 'https://breez.fun';
+
+  final BreezSDKLiquid _breezSdkLiquid;
+  final BreezPreferences _breezPreferences;
+
+  LnUrlPayService(this._breezSdkLiquid, this._breezPreferences);
+
+  Future<Map<String, String>> registerLnurlpay(
+    WalletInfo walletInfo,
+    String webhookUrl, {
+    String? username,
+  }) async {
+    final String pubKey = walletInfo.pubkey;
+
+    await _invalidatePreviousWebhookIfNeeded(pubKey, webhookUrl);
+
+    final int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    // TODO(erdemyerebasmaz): Utilize user's username(only when user has created a new wallet)
+    // TODO(erdemyerebasmaz): Handle multiple device setup cases
+    final String? lnAddressUsername =
+        (username ?? await _breezPreferences.getProfileName())?.replaceAll(' ', '');
+
+    final SignMessageResponse? signMessageRes = await _generateSignature(
+      webhookUrl: webhookUrl,
+      currentTime: currentTime,
+      lnAddressUsername: lnAddressUsername,
+    );
+
+    if (signMessageRes == null) {
+      throw Exception('Missing signature');
+    }
+
+    final Map<String, String> response = await _postWebhookRegistrationRequest(
+      pubKey: pubKey,
+      webhookUrl: webhookUrl,
+      currentTime: currentTime,
+      lnAddressUsername: lnAddressUsername,
+      signature: signMessageRes.signature,
+    );
+
+    await setLnUrlPayKey(webhookUrl: webhookUrl);
+    return response;
+  }
+
+  Future<void> _invalidatePreviousWebhookIfNeeded(String pubKey, String webhookUrl) async {
+    final String? lastUsedLnurlPay = await getLnUrlPayKey();
+    if (lastUsedLnurlPay != null && lastUsedLnurlPay != webhookUrl) {
+      await _invalidateLnurlPay(pubKey, lastUsedLnurlPay);
+    }
+  }
+
+  Future<SignMessageResponse?> _generateSignature({
+    required String webhookUrl,
+    required int currentTime,
+    String? lnAddressUsername,
+  }) async {
+    final String username = lnAddressUsername?.isNotEmpty == true ? '-$lnAddressUsername' : '';
+    final String message = '$currentTime-$webhookUrl$username';
+
+    final SignMessageRequest req = SignMessageRequest(message: message);
+    return _breezSdkLiquid.instance?.signMessage(req: req);
+  }
+
+  Future<Map<String, String>> _postWebhookRegistrationRequest({
+    required String pubKey,
+    required String webhookUrl,
+    required int currentTime,
+    required String signature,
+    String? lnAddressUsername,
+  }) async {
+    final String lnurlWebhookUrl = '$lnurlServiceURL/lnurlpay/$pubKey';
+    final Uri uri = Uri.parse(lnurlWebhookUrl);
+
+    final http.Response jsonResponse = await http.post(
+      uri,
+      body: jsonEncode(
+        AddWebhookRequest(
+          time: currentTime,
+          webhookUrl: webhookUrl,
+          username: lnAddressUsername,
+          signature: signature,
+        ).toJson(),
+      ),
+    );
+
+    if (jsonResponse.statusCode == 200) {
+      final Map<String, dynamic> data = jsonDecode(jsonResponse.body);
+      final String lnurl = data['lnurl'];
+      final String lnAddress = data.containsKey('lightning_address') ? data['lightning_address'] : '';
+      _logger.info('Registered LnUrl Webhook: $webhookUrl, lnurl = $lnurl, lnAddress = $lnAddress');
+      return <String, String>{
+        'lnurl': lnurl,
+        'lnAddress': lnAddress,
+      };
+    } else {
+      // TODO(erdemyerebasmaz): Handle username conflicts(only when user has created a new wallet)
+      // Add a random four-digit identifier, a discriminator, as a suffix if user's username is taken(~1/600 probability of conflict)
+      // Add a retry & randomizer logic until first registration succeeds
+      // TODO(erdemyerebasmaz): Handle custom username conflicts
+      throw Exception('Failed to register LnUrl Webhook: ${jsonResponse.body}');
+    }
+  }
+
+  Future<void> updateLnAddressUsername(WalletInfo walletInfo, String username) async {
+    final String? webhookUrl = await getLnUrlPayKey();
+    if (webhookUrl != null) {
+      await registerLnurlpay(walletInfo, webhookUrl, username: username);
+    }
+  }
+
+  Future<void> _invalidateLnurlPay(String pubKey, String toInvalidate) async {
+    final String lnurlWebhookUrl = '$lnurlServiceURL/lnurlpay/$pubKey';
+    final int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final SignMessageRequest req = SignMessageRequest(message: '$currentTime-$toInvalidate');
+    final SignMessageResponse? signMessageRes = _breezSdkLiquid.instance?.signMessage(req: req);
+    if (signMessageRes == null) {
+      throw Exception('Missing signature');
+    }
+    final Uri uri = Uri.parse(lnurlWebhookUrl);
+    final http.Response response = await http.delete(
+      uri,
+      body: jsonEncode(
+        RemoveWebhookRequest(
+          time: currentTime,
+          webhookUrl: toInvalidate,
+          signature: signMessageRes.signature,
+        ).toJson(),
+      ),
+    );
+    _logger.info('invalidate lnurl pay response: ${response.statusCode}');
+    await resetLnUrlPayKey();
+  }
+
+  Future<void> setLnUrlPayKey({required String webhookUrl}) async {
+    return await _breezPreferences.setLnUrlPayKey(webhookUrl);
+  }
+
+  Future<String?> getLnUrlPayKey() async {
+    return await _breezPreferences.getLnUrlPayKey();
+  }
+
+  Future<void> resetLnUrlPayKey() async {
+    return await _breezPreferences.resetLnUrlPayKey();
+  }
+}

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -1,162 +1,84 @@
-import 'dart:convert';
-
-import 'package:breez_preferences/breez_preferences.dart';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
-import 'package:firebase_notifications_client/firebase_notifications_client.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
-import 'package:http/http.dart' as http;
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:logging/logging.dart';
 
+export 'lnurl_pay_service.dart';
+export 'webhook_service.dart';
 export 'webhook_state.dart';
 
 final Logger _logger = Logger('WebhookCubit');
 
 class WebhookCubit extends Cubit<WebhookState> {
-  static const String notifierServiceURL = 'https://notifier.breez.technology';
-  static const String lnurlServiceURL = 'https://breez.fun';
-
   final BreezSDKLiquid _breezSdkLiquid;
-  final BreezPreferences _breezPreferences;
-  final NotificationsClient _notifications;
+  final WebhookService _webhookService;
+  final LnUrlPayService _lnUrlPayService;
 
-  WebhookCubit(
-    this._breezSdkLiquid,
-    this._breezPreferences,
-    this._notifications,
-  ) : super(WebhookState()) {
+  WebhookCubit(this._breezSdkLiquid, this._webhookService, this._lnUrlPayService) : super(WebhookState()) {
     _breezSdkLiquid.walletInfoStream.first.then(
       (GetInfoResponse getInfoResponse) => refreshWebhooks(walletInfo: getInfoResponse.walletInfo),
     );
   }
 
   Future<void> refreshWebhooks({WalletInfo? walletInfo, String? username}) async {
-    _logger.info('Refreshing webhooks');
+    _logger.info('Refreshing Webhooks');
     emit(WebhookState(isLoading: true));
     try {
       walletInfo = walletInfo ?? (await _breezSdkLiquid.instance?.getInfo())?.walletInfo;
       if (walletInfo != null) {
-        await _registerWebhooks(walletInfo, username: username);
+        final String webhookUrl = await _webhookService.generateWebhookURL();
+        await _webhookService.registerWebhook(webhookUrl);
+        final Map<String, String> lnUrlData = await _lnUrlPayService.registerLnurlpay(
+          walletInfo,
+          webhookUrl,
+          username: username,
+        );
+        emit(
+          WebhookState(
+            lnurlPayUrl: lnUrlData['lnurl'],
+            lnAddress: lnUrlData['lnAddress'],
+          ),
+        );
       } else {
         throw Exception('Unable to retrieve wallet information.');
       }
     } catch (err) {
-      _logger.warning('Failed to refresh lnurlpay: $err');
+      _logger.warning('Failed to refresh webhooks: $err');
       emit(
-        state.copyWith(
+        WebhookState(
           lnurlPayErrorTitle: 'Failed to refresh Lightning Address:',
           lnurlPayError: err.toString(),
         ),
       );
-    } finally {
-      emit(state.copyWith(isLoading: false));
     }
   }
 
-  Future<void> _registerWebhooks(WalletInfo walletInfo, {String? username}) async {
+  Future<void> updateLnAddressUsername({required String username}) async {
+    emit(WebhookState(isLoading: true));
     try {
-      final String webhookUrl = await _generateWebhookURL();
-      await _breezSdkLiquid.instance?.registerWebhook(webhookUrl: webhookUrl);
-      _logger.info('SDK webhook registered: $webhookUrl');
-      await _registerLnurlpay(walletInfo, webhookUrl, username: username);
+      final GetInfoResponse? walletInfo = await _breezSdkLiquid.instance?.getInfo();
+      if (walletInfo != null) {
+        await _lnUrlPayService.updateLnAddressUsername(walletInfo.walletInfo, username);
+        final Map<String, String> lnUrlData = await _lnUrlPayService.registerLnurlpay(
+          walletInfo.walletInfo,
+          await _lnUrlPayService.getLnUrlPayKey() ?? '',
+          username: username,
+        );
+        emit(
+          WebhookState(
+            lnurlPayUrl: lnUrlData['lnurl'],
+            lnAddress: lnUrlData['lnAddress'],
+          ),
+        );
+      }
     } catch (err) {
-      _logger.warning('Failed to register webhooks: $err');
-      emit(state.copyWith(lnurlPayErrorTitle: 'Failed to register webhooks:', lnurlPayError: err.toString()));
-      rethrow;
+      emit(
+        WebhookState(
+          lnurlPayErrorTitle: 'Failed to update Lightning Address username:',
+          lnurlPayError: err.toString(),
+        ),
+      );
     }
-  }
-
-  // TODO(erdemyerebasmaz): Make this a public method so that it can be used to customize LN Addresses
-  // TODO(erdemyerebasmaz): Currently the only endpoint generates a webhook URL & registers to it beforehand, which is not necessary for customizing username
-  Future<void> _registerLnurlpay(
-    WalletInfo walletInfo,
-    String webhookUrl, {
-    String? username,
-  }) async {
-    final String? lastUsedLnurlPay = await _breezPreferences.getLnUrlPayKey();
-    if (lastUsedLnurlPay != null && lastUsedLnurlPay != webhookUrl) {
-      await _invalidateLnurlPay(walletInfo, lastUsedLnurlPay);
-    }
-    // TODO(erdemyerebasmaz): Utilize user's username(only when user has created a new wallet)
-    // TODO(erdemyerebasmaz): Handle multiple device setup cases
-    String? lnAddressUsername = username ?? await _breezPreferences.getProfileName();
-    lnAddressUsername = lnAddressUsername?.replaceAll(' ', '');
-    final int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final String optionalUsernameKey = lnAddressUsername != null ? '-$lnAddressUsername' : '';
-    final SignMessageRequest req =
-        SignMessageRequest(message: '$currentTime-$webhookUrl$optionalUsernameKey');
-    final SignMessageResponse? signMessageRes = _breezSdkLiquid.instance?.signMessage(req: req);
-    if (signMessageRes == null) {
-      throw Exception('Missing signature');
-    }
-    final String lnurlWebhookUrl = '$lnurlServiceURL/lnurlpay/${walletInfo.pubkey}';
-    final Uri uri = Uri.parse(lnurlWebhookUrl);
-    final http.Response jsonResponse = await http.post(
-      uri,
-      body: jsonEncode(
-        AddWebhookRequest(
-          time: currentTime,
-          webhookUrl: webhookUrl,
-          username: lnAddressUsername,
-          signature: signMessageRes.signature,
-        ).toJson(),
-      ),
-    );
-    if (jsonResponse.statusCode == 200) {
-      final Map<String, dynamic> data = jsonDecode(jsonResponse.body);
-      final String lnurl = data['lnurl'];
-      final String lnAddress = data.containsKey('lightning_address') ? data['lightning_address'] : '';
-      _logger.info('lnurlpay webhook registered: $webhookUrl, lnurl = $lnurl, lnAddress = $lnAddress');
-      await _breezPreferences.setLnUrlPayKey(webhookUrl);
-      emit(WebhookState(lnurlPayUrl: lnurl, lnAddress: lnAddress));
-    } else {
-      // TODO(erdemyerebasmaz): Handle username conflicts(only when user has created a new wallet)
-      // Add a random four-digit identifier, a discriminator, as a suffix if user's username is taken(~1/600 probability of conflict)
-      // Add a retry & randomizer logic until first registration succeeds
-      // TODO(erdemyerebasmaz): Handle custom username conflicts
-      throw jsonResponse.body;
-    }
-  }
-
-  Future<void> _invalidateLnurlPay(
-    WalletInfo walletInfo,
-    String toInvalidate,
-  ) async {
-    final String lnurlWebhookUrl = '$lnurlServiceURL/lnurlpay/${walletInfo.pubkey}';
-    final int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final SignMessageRequest req = SignMessageRequest(message: '$currentTime-$toInvalidate');
-    final SignMessageResponse? signMessageRes = _breezSdkLiquid.instance?.signMessage(req: req);
-    if (signMessageRes == null) {
-      throw Exception('Missing signature');
-    }
-    final Uri uri = Uri.parse(lnurlWebhookUrl);
-    final http.Response response = await http.delete(
-      uri,
-      body: jsonEncode(
-        RemoveWebhookRequest(
-          time: currentTime,
-          webhookUrl: toInvalidate,
-          signature: signMessageRes.signature,
-        ).toJson(),
-      ),
-    );
-    _logger.info('invalidate lnurl pay response: ${response.statusCode}');
-    await _breezPreferences.resetLnUrlPayKey();
-  }
-
-  Future<String> _generateWebhookURL() async {
-    final String? token = await _notifications.getToken();
-    _logger.info('Retrieved token, registering…');
-    final String platform = defaultTargetPlatform == TargetPlatform.iOS
-        ? 'ios'
-        : defaultTargetPlatform == TargetPlatform.android
-            ? 'android'
-            : '';
-    if (platform.isEmpty) {
-      throw Exception('Notifications for platform is not supported');
-    }
-    return '$notifierServiceURL/api/v1/notify?platform=$platform&token=$token';
   }
 }

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -64,20 +64,19 @@ class WebhookCubit extends Cubit<WebhookState> {
     );
     try {
       final GetInfoResponse? walletInfo = await _breezSdkLiquid.instance?.getInfo();
-      if (walletInfo != null) {
-        await _lnUrlPayService.updateLnAddressUsername(walletInfo.walletInfo, username);
-        final Map<String, String> lnUrlData = await _lnUrlPayService.registerLnurlpay(
-          walletInfo.walletInfo,
-          await _lnUrlPayService.getLnUrlPayKey() ?? '',
-          username: username,
-        );
-        emit(
-          WebhookState(
-            lnurlPayUrl: lnUrlData['lnurl'],
-            lnAddress: lnUrlData['lnAddress'],
-          ),
-        );
+      if (walletInfo == null) {
+        throw Exception('Failed to retrieve wallet info.');
       }
+      final Map<String, String> lnUrlData = await _lnUrlPayService.updateLnAddressUsername(
+        walletInfo.walletInfo,
+        username,
+      );
+      emit(
+        WebhookState(
+          lnurlPayUrl: lnUrlData['lnurl'],
+          lnAddress: lnUrlData['lnAddress'],
+        ),
+      );
     } catch (err) {
       emit(
         state.copyWith(

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -47,8 +47,8 @@ class WebhookCubit extends Cubit<WebhookState> {
       _logger.warning('Failed to refresh webhooks: $err');
       emit(
         WebhookState(
-          webhookError: 'Failed to refresh Lightning Address:',
-          webhookErrorTitle: err.toString(),
+          webhookError: err.toString(),
+          webhookErrorTitle: 'Failed to refresh Lightning Address:',
         ),
       );
     }
@@ -58,8 +58,8 @@ class WebhookCubit extends Cubit<WebhookState> {
     emit(
       WebhookState(
         isLoading: true,
-        lnAddress: state.lnAddress,
         lnurlPayUrl: state.lnurlPayUrl,
+        lnAddress: state.lnAddress,
       ),
     );
     try {
@@ -80,8 +80,8 @@ class WebhookCubit extends Cubit<WebhookState> {
     } catch (err) {
       emit(
         state.copyWith(
-          lnurlPayErrorTitle: 'Failed to update Lightning Address username:',
           lnurlPayError: err.toString(),
+          lnurlPayErrorTitle: 'Failed to update Lightning Address username:',
         ),
       );
     } finally {

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -47,15 +47,21 @@ class WebhookCubit extends Cubit<WebhookState> {
       _logger.warning('Failed to refresh webhooks: $err');
       emit(
         WebhookState(
-          lnurlPayErrorTitle: 'Failed to refresh Lightning Address:',
-          lnurlPayError: err.toString(),
+          webhookError: 'Failed to refresh Lightning Address:',
+          webhookErrorTitle: err.toString(),
         ),
       );
     }
   }
 
   Future<void> updateLnAddressUsername({required String username}) async {
-    emit(WebhookState(isLoading: true));
+    emit(
+      WebhookState(
+        isLoading: true,
+        lnAddress: state.lnAddress,
+        lnurlPayUrl: state.lnurlPayUrl,
+      ),
+    );
     try {
       final GetInfoResponse? walletInfo = await _breezSdkLiquid.instance?.getInfo();
       if (walletInfo != null) {
@@ -74,11 +80,13 @@ class WebhookCubit extends Cubit<WebhookState> {
       }
     } catch (err) {
       emit(
-        WebhookState(
+        state.copyWith(
           lnurlPayErrorTitle: 'Failed to update Lightning Address username:',
           lnurlPayError: err.toString(),
         ),
       );
+    } finally {
+      emit(state.copyWith(isLoading: false));
     }
   }
 }

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -34,7 +34,7 @@ class WebhookCubit extends Cubit<WebhookState> {
       final Map<String, String> lnUrlData = await _lnUrlPayService.registerLnurlpay(
         walletInfo,
         webhookUrl,
-        username: username ?? state.lnAddressUsername,
+        username: username ?? await _lnUrlPayService.getLnAddressUsername(),
       );
       emit(
         WebhookState(
@@ -70,11 +70,11 @@ class WebhookCubit extends Cubit<WebhookState> {
         walletInfo.walletInfo,
         lnAddressUsername,
       );
+      await _lnUrlPayService.setLnAddressUsername(lnAddressUsername: lnAddressUsername);
       emit(
         WebhookState(
           lnurlPayUrl: lnUrlData['lnurl'],
           lnAddress: lnUrlData['lnAddress'],
-          lnAddressUsername: lnAddressUsername,
         ),
       );
     } catch (err) {

--- a/lib/cubit/webhook/webhook_cubit.dart
+++ b/lib/cubit/webhook/webhook_cubit.dart
@@ -68,6 +68,8 @@ class WebhookCubit extends Cubit<WebhookState> {
     }
   }
 
+  // TODO(erdemyerebasmaz): Make this a public method so that it can be used to customize LN Addresses
+  // TODO(erdemyerebasmaz): Currently the only endpoint generates a webhook URL & registers to it beforehand, which is not necessary for customizing username
   Future<void> _registerLnurlpay(
     WalletInfo walletInfo,
     String webhookUrl, {
@@ -77,6 +79,8 @@ class WebhookCubit extends Cubit<WebhookState> {
     if (lastUsedLnurlPay != null && lastUsedLnurlPay != webhookUrl) {
       await _invalidateLnurlPay(walletInfo, lastUsedLnurlPay);
     }
+    // TODO(erdemyerebasmaz): Utilize user's username(only when user has created a new wallet)
+    // TODO(erdemyerebasmaz): Handle multiple device setup cases
     String? lnAddressUsername = username ?? await _breezPreferences.getProfileName();
     lnAddressUsername = lnAddressUsername?.replaceAll(' ', '');
     final int currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -108,6 +112,10 @@ class WebhookCubit extends Cubit<WebhookState> {
       await _breezPreferences.setLnUrlPayKey(webhookUrl);
       emit(WebhookState(lnurlPayUrl: lnurl, lnAddress: lnAddress));
     } else {
+      // TODO(erdemyerebasmaz): Handle username conflicts(only when user has created a new wallet)
+      // Add a random four-digit identifier, a discriminator, as a suffix if user's username is taken(~1/600 probability of conflict)
+      // Add a retry & randomizer logic until first registration succeeds
+      // TODO(erdemyerebasmaz): Handle custom username conflicts
       throw jsonResponse.body;
     }
   }

--- a/lib/cubit/webhook/webhook_service.dart
+++ b/lib/cubit/webhook/webhook_service.dart
@@ -1,0 +1,41 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:firebase_notifications_client/firebase_notifications_client.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('WebhookService');
+
+class WebhookService {
+  static const String notifierServiceURL = 'https://notifier.breez.technology';
+
+  final BreezSDKLiquid _breezSdkLiquid;
+  final NotificationsClient _notifications;
+
+  WebhookService(this._breezSdkLiquid, this._notifications);
+
+  Future<String> generateWebhookURL() async {
+    final String? token = await _notifications.getToken();
+    _logger.info('Retrieved token, generating webhook URL.');
+    final String platform = defaultTargetPlatform == TargetPlatform.iOS
+        ? 'ios'
+        : defaultTargetPlatform == TargetPlatform.android
+            ? 'android'
+            : '';
+    if (platform.isEmpty) {
+      throw Exception('Notifications for platform is not supported');
+    }
+    final String webhookUrl = '$notifierServiceURL/api/v1/notify?platform=$platform&token=$token';
+    _logger.info('Generated webhook URL: $webhookUrl');
+    return webhookUrl;
+  }
+
+  Future<void> registerWebhook(String webhookUrl) async {
+    try {
+      await _breezSdkLiquid.instance?.registerWebhook(webhookUrl: webhookUrl);
+      _logger.info('Registered webhook: $webhookUrl');
+    } catch (err) {
+      _logger.warning('Failed to register webhook: $err');
+      rethrow;
+    }
+  }
+}

--- a/lib/cubit/webhook/webhook_state.dart
+++ b/lib/cubit/webhook/webhook_state.dart
@@ -1,11 +1,13 @@
 class WebhookState {
   final String? lnurlPayUrl;
+  final String? lnAddress;
   final String? lnurlPayError;
   final String? lnurlPayErrorTitle;
   final bool isLoading;
 
   WebhookState({
     this.lnurlPayUrl,
+    this.lnAddress,
     this.lnurlPayError,
     this.lnurlPayErrorTitle,
     this.isLoading = false,
@@ -13,12 +15,14 @@ class WebhookState {
 
   WebhookState copyWith({
     String? lnurlPayUrl,
+    String? lnAddress,
     String? lnurlPayError,
     String? lnurlPayErrorTitle,
     bool? isLoading,
   }) {
     return WebhookState(
       lnurlPayUrl: lnurlPayUrl ?? this.lnurlPayUrl,
+      lnAddress: lnAddress ?? this.lnAddress,
       lnurlPayError: lnurlPayError ?? this.lnurlPayError,
       lnurlPayErrorTitle: lnurlPayErrorTitle ?? this.lnurlPayErrorTitle,
       isLoading: isLoading ?? this.isLoading,

--- a/lib/cubit/webhook/webhook_state.dart
+++ b/lib/cubit/webhook/webhook_state.dart
@@ -1,6 +1,8 @@
 class WebhookState {
   final String? lnurlPayUrl;
   final String? lnAddress;
+  final String? webhookError;
+  final String? webhookErrorTitle;
   final String? lnurlPayError;
   final String? lnurlPayErrorTitle;
   final bool isLoading;
@@ -8,6 +10,8 @@ class WebhookState {
   WebhookState({
     this.lnurlPayUrl,
     this.lnAddress,
+    this.webhookError,
+    this.webhookErrorTitle,
     this.lnurlPayError,
     this.lnurlPayErrorTitle,
     this.isLoading = false,
@@ -16,6 +20,8 @@ class WebhookState {
   WebhookState copyWith({
     String? lnurlPayUrl,
     String? lnAddress,
+    String? webhookError,
+    String? webhookErrorTitle,
     String? lnurlPayError,
     String? lnurlPayErrorTitle,
     bool? isLoading,
@@ -23,10 +29,24 @@ class WebhookState {
     return WebhookState(
       lnurlPayUrl: lnurlPayUrl ?? this.lnurlPayUrl,
       lnAddress: lnAddress ?? this.lnAddress,
+      webhookError: webhookError ?? this.webhookError,
+      webhookErrorTitle: webhookErrorTitle ?? this.webhookErrorTitle,
       lnurlPayError: lnurlPayError ?? this.lnurlPayError,
       lnurlPayErrorTitle: lnurlPayErrorTitle ?? this.lnurlPayErrorTitle,
       isLoading: isLoading ?? this.isLoading,
     );
+  }
+
+  @override
+  String toString() {
+    return 'WebhookState('
+        'lnurlPayUrl: $lnurlPayUrl, '
+        'lnAddress: $lnAddress, '
+        'webhookError: $webhookError, '
+        'webhookErrorTitle: $webhookErrorTitle, '
+        'lnurlPayError: $lnurlPayError, '
+        'lnurlPayErrorTitle: $lnurlPayErrorTitle, '
+        'isLoading: $isLoading)';
   }
 }
 

--- a/lib/cubit/webhook/webhook_state.dart
+++ b/lib/cubit/webhook/webhook_state.dart
@@ -1,7 +1,6 @@
 class WebhookState {
   final String? lnurlPayUrl;
   final String? lnAddress;
-  final String? lnAddressUsername;
   final String? webhookError;
   final String? webhookErrorTitle;
   final String? lnurlPayError;
@@ -11,7 +10,6 @@ class WebhookState {
   WebhookState({
     this.lnurlPayUrl,
     this.lnAddress,
-    this.lnAddressUsername,
     this.webhookError,
     this.webhookErrorTitle,
     this.lnurlPayError,

--- a/lib/cubit/webhook/webhook_state.dart
+++ b/lib/cubit/webhook/webhook_state.dart
@@ -1,6 +1,7 @@
 class WebhookState {
   final String? lnurlPayUrl;
   final String? lnAddress;
+  final String? lnAddressUsername;
   final String? webhookError;
   final String? webhookErrorTitle;
   final String? lnurlPayError;
@@ -10,6 +11,7 @@ class WebhookState {
   WebhookState({
     this.lnurlPayUrl,
     this.lnAddress,
+    this.lnAddressUsername,
     this.webhookError,
     this.webhookErrorTitle,
     this.lnurlPayError,

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -45,11 +45,11 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                     color: themeData.primaryColor.withValues(alpha: .5),
                   ),
                 )
-              : webhookState.lnurlPayError != null
+              : webhookState.webhookError != null
                   ? ScrollableErrorMessageWidget(
                       showIcon: true,
-                      title: webhookState.lnurlPayErrorTitle ?? texts.lightning_address_service_error_title,
-                      message: extractExceptionMessage(webhookState.lnurlPayError!, texts),
+                      title: webhookState.webhookErrorTitle ?? texts.lightning_address_service_error_title,
+                      message: extractExceptionMessage(webhookState.webhookError!, texts),
                     )
                   : webhookState.lnurlPayUrl != null
                       ? Padding(
@@ -79,11 +79,11 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                       : const SizedBox.shrink(),
           bottomNavigationBar: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
             builder: (BuildContext context, PaymentLimitsState snapshot) {
-              return webhookState.lnurlPayError != null || snapshot.hasError
+              return webhookState.webhookError != null || snapshot.hasError
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
                       text: texts.invoice_ln_address_action_retry,
-                      onPressed: webhookState.lnurlPayError != null
+                      onPressed: webhookState.webhookError != null
                           ? () => _refreshWebhooks()
                           : () {
                               final PaymentLimitsCubit paymentLimitsCubit =

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -67,8 +67,8 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
                               padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
                               child: SingleChildScrollView(
                                 child: DestinationWidget(
-                                  isLnAddress: true,
                                   destination: webhookState.lnurlPayUrl,
+                                  lnAddress: webhookState.lnAddress,
                                   paymentMethod: texts.receive_payment_method_lightning_address,
                                   infoWidget: const PaymentLimitsMessageBox(),
                                 ),

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -17,19 +17,19 @@ final Logger _logger = Logger('DestinationWidget');
 class DestinationWidget extends StatefulWidget {
   final AsyncSnapshot<ReceivePaymentResponse>? snapshot;
   final String? destination;
+  final String? lnAddress;
   final String? paymentMethod;
   final void Function()? onLongPress;
   final Widget? infoWidget;
-  final bool isLnAddress;
 
   const DestinationWidget({
     super.key,
     this.snapshot,
     this.destination,
+    this.lnAddress,
     this.paymentMethod,
     this.onLongPress,
     this.infoWidget,
-    this.isLnAddress = false,
   });
 
   @override
@@ -42,7 +42,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   @override
   void initState() {
     super.initState();
-    if (widget.isLnAddress) {
+    if (widget.lnAddress != null && widget.lnAddress!.isNotEmpty) {
       // Ignore new payments for a duration upon generating LN Address.
       // This delay is added to avoid popping the page before user gets the chance to copy,
       // share or get their LN address scanned.
@@ -56,7 +56,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
     // For receive payment pages other than LN Address, user input is required before creating an invoice.
     // Therefore, they rely on `didUpdateWidget` instead of `initState` to capture updates after
     // initial widget setup.
-    if (!widget.isLnAddress) {
+    if (!(widget.lnAddress != null && widget.lnAddress!.isNotEmpty)) {
       _trackPaymentEvents(getUpdatedDestination(oldWidget));
     }
   }
@@ -152,6 +152,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
           child: DestinationQRWidget(
             snapshot: widget.snapshot,
             destination: widget.destination,
+            lnAddress: widget.lnAddress,
             paymentMethod: widget.paymentMethod,
             onLongPress: widget.onLongPress,
             infoWidget: widget.infoWidget,

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_actions.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_actions.dart
@@ -10,13 +10,15 @@ import 'package:share_plus/share_plus.dart';
 class DestinationActions extends StatelessWidget {
   final AsyncSnapshot<ReceivePaymentResponse>? snapshot;
   final String? destination;
+  final String? lnAddress;
   final String? paymentMethod;
 
   const DestinationActions({
     required this.snapshot,
     required this.destination,
-    super.key,
+    this.lnAddress,
     this.paymentMethod,
+    super.key,
   });
 
   @override
@@ -31,6 +33,7 @@ class DestinationActions extends StatelessWidget {
                 Expanded(
                   child: _CopyButton(
                     destination: destination,
+                    lnAddress: lnAddress,
                     paymentMethod: paymentMethod,
                   ),
                 ),
@@ -51,10 +54,12 @@ class DestinationActions extends StatelessWidget {
 class _CopyButton extends StatelessWidget {
   final String destination;
   final String? paymentMethod;
+  final String? lnAddress;
 
   const _CopyButton({
     required this.destination,
     this.paymentMethod,
+    this.lnAddress,
   });
 
   @override
@@ -85,10 +90,13 @@ class _CopyButton extends StatelessWidget {
             style: balanceFiatConversionTextStyle,
           ),
           onPressed: () {
-            ServiceInjector().deviceClient.setClipboardText(destination);
+            ServiceInjector().deviceClient.setClipboardText(
+                  (lnAddress != null && lnAddress!.isNotEmpty) ? lnAddress! : destination,
+                );
             showFlushbar(
               context,
-              message: (paymentMethod != null && paymentMethod!.isNotEmpty)
+              message: (lnAddress != null && lnAddress!.isNotEmpty) ||
+                      (paymentMethod != null && paymentMethod!.isNotEmpty)
                   ? texts.payment_details_dialog_copied(paymentMethod!)
                   : texts.invoice_btc_address_deposit_address_copied,
               duration: const Duration(seconds: 3),

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_information.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_information.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:l_breez/routes/receive_payment/widgets/widgets.dart';
+import 'package:l_breez/widgets/widgets.dart';
+
+class DestinationInformation extends StatefulWidget {
+  final String lnAddress;
+
+  const DestinationInformation({
+    required this.lnAddress,
+    super.key,
+  });
+
+  @override
+  DestinationInformationState createState() => DestinationInformationState();
+}
+
+class DestinationInformationState extends State<DestinationInformation> {
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
+    return GestureDetector(
+      onTapDown: (TapDownDetails details) {
+        // TODO(erdemyerebasmaz): Display the dropdown menu in a static place that does not obstruct LN Address
+        final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+        final Offset offset = details.globalPosition;
+
+        showMenu(
+          context: context,
+          color: themeData.colorScheme.surface,
+          position: RelativeRect.fromRect(
+            Rect.fromPoints(offset, offset),
+            Offset.zero & overlay.size,
+          ),
+          items: <PopupMenuItem<String>>[
+            const PopupMenuItem<String>(
+              // TODO(erdemyerebasmaz): Replace with const var
+              value: 'customize',
+              child: Row(
+                children: <Widget>[
+                  Icon(Icons.edit),
+                  SizedBox(
+                    width: 8.0,
+                  ),
+                  // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
+                  Text('Customize Address'),
+                ],
+              ),
+            ),
+          ],
+        ).then((String? value) {
+          // TODO(erdemyerebasmaz): Replace with const var
+          if (value == 'customize') {
+            if (context.mounted) {
+              showModalBottomSheet(
+                context: context,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(12.0)),
+                ),
+                isScrollControlled: true,
+                builder: (BuildContext context) => UpdateLnAddressUsernameBottomSheet(
+                  lnAddress: widget.lnAddress,
+                ),
+              );
+            }
+          }
+        });
+      },
+      child: WarningBox(
+        boxPadding: const EdgeInsets.only(bottom: 24.0),
+        contentPadding: const EdgeInsets.symmetric(
+          vertical: 16,
+          horizontal: 16,
+        ),
+        borderColor: Colors.transparent,
+        backgroundColor: Theme.of(context).canvasColor,
+        child: Center(
+          child: Text(
+            widget.lnAddress,
+            style: themeData.primaryTextTheme.bodyMedium!.copyWith(fontSize: 18.0),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_qr_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_qr_widget.dart
@@ -9,6 +9,7 @@ import 'package:l_breez/widgets/widgets.dart';
 class DestinationQRWidget extends StatelessWidget {
   final AsyncSnapshot<ReceivePaymentResponse>? snapshot;
   final String? destination;
+  final String? lnAddress;
   final String? paymentMethod;
   final void Function()? onLongPress;
   final Widget? infoWidget;
@@ -16,10 +17,11 @@ class DestinationQRWidget extends StatelessWidget {
   const DestinationQRWidget({
     required this.snapshot,
     required this.destination,
+    this.lnAddress,
     this.paymentMethod,
-    super.key,
     this.onLongPress,
     this.infoWidget,
+    super.key,
   });
 
   @override
@@ -49,7 +51,11 @@ class DestinationQRWidget extends StatelessWidget {
           snapshot: snapshot,
           destination: destination,
           paymentMethod: paymentMethod,
+          lnAddress: lnAddress,
         ),
+        if (lnAddress != null && lnAddress!.isNotEmpty) ...<Widget>[
+          DestinationInformation(lnAddress: lnAddress!),
+        ],
         if (infoWidget != null) ...<Widget>[
           SizedBox(
             width: MediaQuery.of(context).size.width,

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -2,7 +2,6 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/widgets/widgets.dart';
@@ -116,21 +115,14 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                         ),
                         border: const OutlineInputBorder(),
                       ),
-                      inputFormatters: <TextInputFormatter>[
-                        TextInputFormatter.withFunction(
-                          (_, TextEditingValue newValue) => newValue.copyWith(
-                            text: newValue.text.replaceAll(',', '.'),
-                          ),
-                        ),
-                      ],
-                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      keyboardType: TextInputType.emailAddress,
                       autofocus: true,
                       validator: (String? value) {
                         if (value == null || value.isEmpty) {
                           // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
                           return 'Please enter a username';
                         }
-                        final String email = '$value@${widget.lnAddress.split('@').last}';
+                        final String email = '${value.trim()}@${widget.lnAddress.split('@').last}';
                         // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
                         return EmailValidator.validate(email) ? null : 'Invalid username.';
                       },
@@ -158,7 +150,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                         // TODO(erdemyerebasmaz): Handle registration errors
                         if (_formKey.currentState?.validate() ?? false) {
                           final WebhookCubit webhookCubit = context.read<WebhookCubit>();
-                          webhookCubit.refreshWebhooks(username: _usernameController.text);
+                          webhookCubit.updateLnAddressUsername(username: _usernameController.text);
                           Navigator.pop(context);
                         }
                       },

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -50,12 +50,6 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
       child: SingleChildScrollView(
         child: BlocBuilder<WebhookCubit, WebhookState>(
           builder: (BuildContext context, WebhookState state) {
-            if (state.isLoading ||
-                (state.lnurlPayError != null && state.lnurlPayError!.isNotEmpty) ||
-                (state.lnurlPayUrl != null && state.lnurlPayUrl!.isEmpty)) {
-              return const Center(child: CircularProgressIndicator());
-            }
-
             final ThemeData themeData = Theme.of(context);
             final Color errorBorderColor = themeData.colorScheme.error;
 
@@ -140,7 +134,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                     child: SingleButtonBottomBar(
                       text: texts.currency_converter_dialog_action_done,
                       expand: true,
-                      onPressed: () {
+                      onPressed: () async {
                         if (_usernameController.text.isEmpty) {
                           Navigator.pop(context);
                           return;
@@ -150,8 +144,22 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                         // TODO(erdemyerebasmaz): Handle registration errors
                         if (_formKey.currentState?.validate() ?? false) {
                           final WebhookCubit webhookCubit = context.read<WebhookCubit>();
-                          webhookCubit.updateLnAddressUsername(username: _usernameController.text);
-                          Navigator.pop(context);
+                          await webhookCubit.updateLnAddressUsername(username: _usernameController.text);
+                          if (context.mounted) {
+                            if (state.lnurlPayError == null) {
+                              Navigator.pop(context);
+                              showFlushbar(
+                                context,
+                                message: 'Successfully updated Lightning Address username.',
+                              );
+                            } else {
+                              Navigator.pop(context);
+                              showFlushbar(
+                                context,
+                                message: 'Failed to update Lightning Address username.',
+                              );
+                            }
+                          }
                         }
                       },
                     ),

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -144,7 +144,9 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                         // TODO(erdemyerebasmaz): Handle registration errors
                         if (_formKey.currentState?.validate() ?? false) {
                           final WebhookCubit webhookCubit = context.read<WebhookCubit>();
-                          await webhookCubit.updateLnAddressUsername(username: _usernameController.text);
+                          await webhookCubit.updateLnAddressUsername(
+                            username: _usernameController.text.toLowerCase().trim(),
+                          );
                           if (context.mounted) {
                             if (state.lnurlPayError == null) {
                               Navigator.pop(context);

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -145,7 +145,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                         if (_formKey.currentState?.validate() ?? false) {
                           final WebhookCubit webhookCubit = context.read<WebhookCubit>();
                           await webhookCubit.updateLnAddressUsername(
-                            username: _usernameController.text.toLowerCase().trim(),
+                            lnAddressUsername: _usernameController.text.toLowerCase().trim(),
                           );
                           if (context.mounted) {
                             if (state.lnurlPayError == null) {

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -1,0 +1,175 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:email_validator/email_validator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/widgets/widgets.dart';
+
+class UpdateLnAddressUsernameBottomSheet extends StatefulWidget {
+  final String lnAddress;
+
+  const UpdateLnAddressUsernameBottomSheet({
+    required this.lnAddress,
+    super.key,
+  });
+
+  @override
+  State<UpdateLnAddressUsernameBottomSheet> createState() => _UpdateLnAddressUsernameBottomSheetState();
+}
+
+class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUsernameBottomSheet> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _usernameController = TextEditingController();
+  final FocusNode _usernameFocusNode = FocusNode();
+  KeyboardDoneAction _doneAction = KeyboardDoneAction();
+
+  @override
+  void initState() {
+    super.initState();
+    _usernameController.text = widget.lnAddress.split('@').first;
+    _usernameController.addListener(() => setState(() {}));
+    _doneAction = KeyboardDoneAction(focusNodes: <FocusNode>[_usernameFocusNode]);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _doneAction.dispose();
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SingleChildScrollView(
+        child: BlocBuilder<WebhookCubit, WebhookState>(
+          builder: (BuildContext context, WebhookState state) {
+            if (state.isLoading ||
+                (state.lnurlPayError != null && state.lnurlPayError!.isNotEmpty) ||
+                (state.lnurlPayUrl != null && state.lnurlPayUrl!.isEmpty)) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final ThemeData themeData = Theme.of(context);
+            final Color errorBorderColor = themeData.colorScheme.error;
+
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Align(
+                  child: Container(
+                    margin: const EdgeInsets.only(top: 8.0),
+                    width: 40.0,
+                    height: 6.5,
+                    decoration: BoxDecoration(
+                      color: Colors.white24,
+                      borderRadius: BorderRadius.circular(50),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
+                    'Customize Address:',
+                    style: themeData.primaryTextTheme.headlineMedium!.copyWith(
+                      fontSize: 18.0,
+                      color: Colors.white,
+                    ),
+                    textAlign: TextAlign.left,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Form(
+                    key: _formKey,
+                    child: TextFormField(
+                      controller: _usernameController,
+                      focusNode: _usernameFocusNode,
+                      decoration: InputDecoration(
+                        // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
+                        labelText: 'Username',
+                        errorBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: errorBorderColor),
+                        ),
+                        focusedErrorBorder: OutlineInputBorder(
+                          borderSide: BorderSide(color: errorBorderColor),
+                        ),
+                        errorMaxLines: 2,
+                        errorStyle: themeData.primaryTextTheme.bodySmall!.copyWith(
+                          color: errorBorderColor,
+                        ),
+                        suffix: const Padding(
+                          padding: EdgeInsets.only(right: 8.0),
+                          // TODO(erdemyerebasmaz): Retrieve this from lnAddress itself & store it temporarily
+                          child: Text(
+                            '@breez.fun',
+                          ),
+                        ),
+                        border: const OutlineInputBorder(),
+                      ),
+                      inputFormatters: <TextInputFormatter>[
+                        TextInputFormatter.withFunction(
+                          (_, TextEditingValue newValue) => newValue.copyWith(
+                            text: newValue.text.replaceAll(',', '.'),
+                          ),
+                        ),
+                      ],
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      autofocus: true,
+                      validator: (String? value) {
+                        if (value == null || value.isEmpty) {
+                          // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
+                          return 'Please enter a username';
+                        }
+                        final String email = '$value@${widget.lnAddress.split('@').last}';
+                        // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
+                        return EmailValidator.validate(email) ? null : 'Invalid username.';
+                      },
+                      onEditingComplete: () => _usernameFocusNode.unfocus(),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8.0),
+                Align(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0,
+                      vertical: 16.0,
+                    ),
+                    child: SingleButtonBottomBar(
+                      text: texts.currency_converter_dialog_action_done,
+                      expand: true,
+                      onPressed: () {
+                        if (_usernameController.text.isEmpty) {
+                          Navigator.pop(context);
+                          return;
+                        }
+
+                        // TODO(erdemyerebasmaz): Implement validation & registration logic
+                        // TODO(erdemyerebasmaz): Handle registration errors
+                        if (_formKey.currentState?.validate() ?? false) {
+                          final WebhookCubit webhookCubit = context.read<WebhookCubit>();
+                          webhookCubit.refreshWebhooks(username: _usernameController.text);
+                          Navigator.pop(context);
+                        }
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/widgets.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/widgets.dart
@@ -1,5 +1,7 @@
 export 'compact_qr_image.dart';
-export 'destination_header.dart';
+export 'destination_actions.dart';
+export 'destination_information.dart';
 export 'destination_qr_image.dart';
 export 'destination_qr_widget.dart';
 export 'loading_or_error.dart';
+export 'update_ln_address_username_bottom_sheet.dart';

--- a/packages/breez_preferences/lib/src/breez_preferences.dart
+++ b/packages/breez_preferences/lib/src/breez_preferences.dart
@@ -14,6 +14,7 @@ const String _kPaymentOptionExemptFee = 'payment_options_exempt_fee';
 const String _kPaymentOptionChannelSetupFeeLimit = 'payment_options_channel_setup_fee_limit';
 const String _kReportPrefKey = 'report_preference_key';
 const String _kLnUrlPayKey = 'lnurlpay_key';
+const String _kLnAddressUsername = 'ln_address_name';
 const String _kProfileName = 'profile_name';
 
 final Logger _logger = Logger('BreezPreferences');
@@ -123,5 +124,21 @@ class BreezPreferences {
     _logger.info('set profile name: $profileName');
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString(_kProfileName, profileName);
+  }
+
+  Future<String?> getLnAddressUsername() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_kLnAddressUsername);
+  }
+
+  Future<void> setLnAddressUsername(String lnAddressUsername) async {
+    _logger.info('Set LN Address Name: $lnAddressUsername');
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kLnAddressUsername, lnAddressUsername);
+  }
+
+  Future<void> resetLnAddressUsername() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kLnAddressUsername);
   }
 }


### PR DESCRIPTION
Closes #319 

With this PR, users **LN Address** is now displayed on `Receive via Lightning Address` page and it can be customized through `Customize Address` option on it's dropdown menu.

Both **LNURLp** & **LN Address** is now stored & accessible via `WebhookState`.

- **LNURLp** is used on QR Code can be shared via `Share` button.
- **LN Address** is shown below action buttons & can be copied via `Copy` button.