### PR TITLE
Support BOLT12 in enter payment info page

### DIFF
--- a/lib/routes/enter_payment_info/enter_payment_info_page.dart
+++ b/lib/routes/enter_payment_info/enter_payment_info_page.dart
@@ -156,7 +156,8 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
       if (!(inputType is InputType_Bolt11 ||
           inputType is InputType_Bolt12Offer ||
           inputType is InputType_LnUrlPay ||
-          inputType is InputType_LnUrlWithdraw)) {
+          inputType is InputType_LnUrlWithdraw ||
+          inputType is InputType_Bolt12Offer)) {
         errMsg = texts.payment_info_dialog_error_unsupported_input;
       }
       if (inputType is InputType_Bolt11 && inputType.invoice.amountMsat == BigInt.zero) {


### PR DESCRIPTION
This adds support for paying BOLT12 offers or BIP353 addresses that resolve to BOLT12 offer in the enter payment info page.