### PR TITLE
Improve how refundable items are displayed on payment list

### DIFF
--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/home/widgets/widgets.dart';
 
@@ -39,7 +40,8 @@ class _PaymentDetailsSheetHeaderState extends State<PaymentDetailsSheetHeader> {
           ),
           PaymentDetailsSheetContentTitle(paymentData: widget.paymentData),
           PaymentDetailsSheetDescription(paymentData: widget.paymentData),
-          if (widget.paymentData.isRefunded) ...<Widget>[
+          if (widget.paymentData.isRefunded ||
+              widget.paymentData.status == PaymentState.refundable) ...<Widget>[
             const Padding(
               padding: EdgeInsets.only(top: 8),
               child: Chip(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
@@ -3,7 +3,6 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/currency.dart';
 
@@ -47,9 +46,7 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
                   state.bitcoinTicker,
                 ).format(paymentData.refundTxAmountSat);
                 return Text(
-                  paymentData.paymentType == PaymentType.receive || paymentData.isRefunded
-                      ? texts.payment_details_dialog_amount_positive(amountSats)
-                      : texts.payment_details_dialog_amount_negative(amountSats),
+                  texts.payment_details_dialog_amount_positive(amountSats),
                   style: themeData.primaryTextTheme.displaySmall!.copyWith(
                     fontSize: 18.0,
                     color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
@@ -31,7 +31,7 @@ class PaymentItemAvatar extends StatelessWidget {
         radius: radius,
         backgroundColor: Colors.white,
         child: Icon(
-          paymentData.isRefunded
+          paymentData.isRefunded || paymentData.status == PaymentState.refundable
               ? Icons.close_rounded
               : paymentData.paymentType == PaymentType.receive
                   ? Icons.add_rounded

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
@@ -35,7 +35,7 @@ class PaymentItemSubtitle extends StatelessWidget {
             ),
           ),
         ],
-        if (paymentData.isRefunded) ...<Widget>[
+        if (paymentData.isRefunded || paymentData.status == PaymentState.refundable) ...<Widget>[
           Text(
             ' (Failed)',
             style: subtitleTextStyle.copyWith(


### PR DESCRIPTION
Fixes #332 

This PR is a continuation of #295, and applies the same style choice to payments in `Refundable` state, where applicable.

### Changes:
- Added a `(Failed)` suffix to subtitle of refundable items on payment list
- Used a `X` icon as the payment avatar for refundable items on payment list
- Added a `Failed` chip on payment details for refundable items

Amount & Fees are shown as is.

### Misc:
- Removed obsolete conditional on `PaymentDetailsSheetRefundTxAmount`