### PR TITLE
fix: Validate outgoing swap amount against account balance

### DIFF
--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -122,7 +122,7 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
     }
     final Limits limits = outgoing ? onchainLimits.send : onchainLimits.receive;
     if (amount > limits.maxSat) {
-      throw PaymentExceededLimitError(limits.maxSat.toInt());
+      throw PaymentExceedsLimitError(limits.maxSat.toInt());
     }
     if (amount < limits.minSat) {
       throw PaymentBelowLimitError(limits.minSat.toInt());

--- a/lib/cubit/lnurl/lnurl_cubit.dart
+++ b/lib/cubit/lnurl/lnurl_cubit.dart
@@ -70,7 +70,7 @@ class LnUrlCubit extends Cubit<LnUrlState> {
     }
     final Limits limits = outgoing ? lightningLimits.send : lightningLimits.receive;
     if (amount > limits.maxSat) {
-      throw PaymentExceededLimitError(limits.maxSat.toInt());
+      throw PaymentExceedsLimitError(limits.maxSat.toInt());
     }
     if (amount < limits.minSat) {
       throw PaymentBelowLimitError(limits.minSat.toInt());

--- a/lib/cubit/payments/models/payment/payment_error.dart
+++ b/lib/cubit/payments/models/payment/payment_error.dart
@@ -16,51 +16,9 @@ class PaymentBelowLimitError implements Exception {
   String toString() => 'Payment amount is below the minimum limit of $limitSat satoshis.';
 }
 
-class PaymentBelowReserveError implements Exception {
-  final int reserveAmount;
-
-  const PaymentBelowReserveError(this.reserveAmount);
-
-  @override
-  String toString() => 'Payment amount is below the reserve amount of $reserveAmount satoshis.';
-}
-
 class InsufficientLocalBalanceError implements Exception {
   const InsufficientLocalBalanceError();
 
   @override
   String toString() => 'Insufficient local balance to process the payment.';
-}
-
-class PaymentBelowSetupFeesError implements Exception {
-  final int setupFees;
-
-  const PaymentBelowSetupFeesError(this.setupFees);
-
-  @override
-  String toString() => 'Payment amount is below the setup fees of $setupFees satoshis.';
-}
-
-class PaymentExceededLiquidityError implements Exception {
-  final int limitSat;
-
-  const PaymentExceededLiquidityError(this.limitSat);
-
-  @override
-  String toString() => 'Payment amount exceeds the available liquidity of $limitSat satoshis.';
-}
-
-class PaymentExceededLiquidityChannelCreationNotPossibleError implements Exception {
-  final int limitSat;
-
-  const PaymentExceededLiquidityChannelCreationNotPossibleError(this.limitSat);
-
-  @override
-  String toString() =>
-      'Payment amount exceeds available liquidity of $limitSat satoshis, and channel creation is not possible.';
-}
-
-class NoChannelCreationZeroLiquidityError implements Exception {
-  @override
-  String toString() => 'Channel creation is not possible due to zero liquidity.';
 }

--- a/lib/cubit/payments/models/payment/payment_error.dart
+++ b/lib/cubit/payments/models/payment/payment_error.dart
@@ -1,7 +1,7 @@
-class PaymentExceededLimitError implements Exception {
+class PaymentExceedsLimitError implements Exception {
   final int limitSat;
 
-  const PaymentExceededLimitError(this.limitSat);
+  const PaymentExceedsLimitError(this.limitSat);
 
   @override
   String toString() => 'Payment amount exceeds the limit of $limitSat satoshis.';

--- a/lib/cubit/payments/models/payment/payment_error.dart
+++ b/lib/cubit/payments/models/payment/payment_error.dart
@@ -2,40 +2,65 @@ class PaymentExceededLimitError implements Exception {
   final int limitSat;
 
   const PaymentExceededLimitError(this.limitSat);
+
+  @override
+  String toString() => 'Payment amount exceeds the limit of $limitSat satoshis.';
 }
 
 class PaymentBelowLimitError implements Exception {
   final int limitSat;
 
   const PaymentBelowLimitError(this.limitSat);
+
+  @override
+  String toString() => 'Payment amount is below the minimum limit of $limitSat satoshis.';
 }
 
 class PaymentBelowReserveError implements Exception {
   final int reserveAmount;
 
   const PaymentBelowReserveError(this.reserveAmount);
+
+  @override
+  String toString() => 'Payment amount is below the reserve amount of $reserveAmount satoshis.';
 }
 
 class InsufficientLocalBalanceError implements Exception {
   const InsufficientLocalBalanceError();
+
+  @override
+  String toString() => 'Insufficient local balance to process the payment.';
 }
 
 class PaymentBelowSetupFeesError implements Exception {
   final int setupFees;
 
   const PaymentBelowSetupFeesError(this.setupFees);
+
+  @override
+  String toString() => 'Payment amount is below the setup fees of $setupFees satoshis.';
 }
 
-class PaymentExceedededLiquidityError implements Exception {
+class PaymentExceededLiquidityError implements Exception {
   final int limitSat;
 
-  const PaymentExceedededLiquidityError(this.limitSat);
+  const PaymentExceededLiquidityError(this.limitSat);
+
+  @override
+  String toString() => 'Payment amount exceeds the available liquidity of $limitSat satoshis.';
 }
 
 class PaymentExceededLiquidityChannelCreationNotPossibleError implements Exception {
   final int limitSat;
 
   const PaymentExceededLiquidityChannelCreationNotPossibleError(this.limitSat);
+
+  @override
+  String toString() =>
+      'Payment amount exceeds available liquidity of $limitSat satoshis, and channel creation is not possible.';
 }
 
-class NoChannelCreationZeroLiquidityError implements Exception {}
+class NoChannelCreationZeroLiquidityError implements Exception {
+  @override
+  String toString() => 'Channel creation is not possible due to zero liquidity.';
+}

--- a/lib/routes/send_payment/chainswap/send_chainswap_form.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_form.dart
@@ -79,6 +79,9 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
 
   @override
   Widget build(BuildContext context) {
+    final AccountState accountState = context.watch<AccountCubit>().state;
+    final CurrencyState currencyState = context.watch<CurrencyCubit>().state;
+
     final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
@@ -106,7 +109,7 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
             controller: widget.amountController,
             focusNode: _amountFocusNode,
             isDrain: widget.isDrain,
-            balance: widget.paymentLimits.send.maxSat,
+            balance: accountState.walletInfo!.balanceSat,
             policy: WithdrawFundsPolicy(
               WithdrawKind.withdrawFunds,
               widget.paymentLimits.send.minSat,
@@ -135,72 +138,64 @@ class _SendChainSwapFormState extends State<SendChainSwapForm> {
               endIndent: 0.0,
             ),
           ),
-          BlocBuilder<CurrencyCubit, CurrencyState>(
-            builder: (BuildContext context, CurrencyState currencyState) {
-              return BlocBuilder<AccountCubit, AccountState>(
-                builder: (BuildContext context, AccountState accountState) {
-                  return ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    dense: true,
-                    minTileHeight: 0,
-                    title: Text(
-                      texts.withdraw_funds_use_all_funds,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 18.0,
-                        height: 1.208,
-                        fontWeight: FontWeight.w400,
-                        fontFamily: 'IBMPlexSans',
-                      ),
-                    ),
-                    subtitle: Padding(
-                      padding: const EdgeInsets.only(top: 8.0),
-                      child: Text(
-                        '${texts.available_balance_label} ${currencyState.bitcoinCurrency.format(
-                          accountState.walletInfo!.balanceSat.toInt(),
-                        )}',
-                        style: const TextStyle(
-                          color: Color.fromRGBO(182, 188, 193, 1),
-                          fontSize: 16,
-                          height: 1.182,
-                          fontWeight: FontWeight.w400,
-                          fontFamily: 'IBMPlexSans',
-                        ),
-                      ),
-                    ),
-                    trailing: Padding(
-                      padding: const EdgeInsets.only(bottom: 8.0),
-                      child: Switch(
-                        value: widget.isDrain,
-                        activeColor: Colors.white,
-                        activeTrackColor: themeData.primaryColor,
-                        onChanged: (bool value) async {
-                          setState(
-                            () {
-                              widget.onChanged(value);
-                              if (value) {
-                                final String formattedAmount = currencyState.bitcoinCurrency
-                                    .format(
-                                      accountState.walletInfo!.balanceSat.toInt(),
-                                      includeDisplayName: false,
-                                      userInput: true,
-                                    )
-                                    .formatBySatAmountFormFieldFormatter();
-                                setState(() {
-                                  widget.amountController.text = formattedAmount;
-                                });
-                              } else {
-                                widget.amountController.text = '';
-                              }
-                            },
-                          );
-                        },
-                      ),
-                    ),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            minTileHeight: 0,
+            title: Text(
+              texts.withdraw_funds_use_all_funds,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 18.0,
+                height: 1.208,
+                fontWeight: FontWeight.w400,
+                fontFamily: 'IBMPlexSans',
+              ),
+            ),
+            subtitle: Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: Text(
+                '${texts.available_balance_label} ${currencyState.bitcoinCurrency.format(
+                  accountState.walletInfo!.balanceSat.toInt(),
+                )}',
+                style: const TextStyle(
+                  color: Color.fromRGBO(182, 188, 193, 1),
+                  fontSize: 16,
+                  height: 1.182,
+                  fontWeight: FontWeight.w400,
+                  fontFamily: 'IBMPlexSans',
+                ),
+              ),
+            ),
+            trailing: Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Switch(
+                value: widget.isDrain,
+                activeColor: Colors.white,
+                activeTrackColor: themeData.primaryColor,
+                onChanged: (bool value) async {
+                  setState(
+                    () {
+                      widget.onChanged(value);
+                      if (value) {
+                        final String formattedAmount = currencyState.bitcoinCurrency
+                            .format(
+                              accountState.walletInfo!.balanceSat.toInt(),
+                              includeDisplayName: false,
+                              userInput: true,
+                            )
+                            .formatBySatAmountFormFieldFormatter();
+                        setState(() {
+                          widget.amountController.text = formattedAmount;
+                        });
+                      } else {
+                        widget.amountController.text = '';
+                      }
+                    },
                   );
                 },
-              );
-            },
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/routes/send_payment/chainswap/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/send_payment/chainswap/widgets/withdraw_funds_amount_text_form_field.dart
@@ -37,7 +37,7 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
                   throw PaymentBelowLimitError(policy.minValue.toInt());
                 }
                 if (amount > policy.maxValue.toInt()) {
-                  throw PaymentExceededLimitError(policy.maxValue.toInt());
+                  throw PaymentExceedsLimitError(policy.maxValue.toInt());
                 }
               },
             ).validateOutgoing(amount);

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -38,7 +38,7 @@ class PaymentValidator {
 
   String _handleException(Exception e) {
     _logger.warning('Failed to validate payment.', e);
-    if (e is PaymentExceededLimitError) {
+    if (e is PaymentExceedsLimitError) {
       return texts.invoice_payment_validator_error_payment_exceeded_limit(
         currency.format(e.limitSat.toInt()),
       );

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -46,20 +46,8 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_invoice_limit(
         currency.format(e.limitSat.toInt()),
       );
-    } else if (e is PaymentBelowReserveError) {
-      return texts.invoice_payment_validator_error_payment_below_limit(currency.format(e.reserveAmount));
-    } else if (e is PaymentExceededLiquidityError) {
-      return 'Insufficient inbound liquidity (${currency.format(e.limitSat.toInt())})';
     } else if (e is InsufficientLocalBalanceError) {
       return texts.invoice_payment_validator_error_insufficient_local_balance;
-    } else if (e is PaymentBelowSetupFeesError) {
-      return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
-        currency.format(e.setupFees),
-      );
-    } else if (e is PaymentExceededLiquidityChannelCreationNotPossibleError) {
-      return texts.lnurl_fetch_invoice_error_max(currency.format(e.limitSat.toInt()));
-    } else if (e is NoChannelCreationZeroLiquidityError) {
-      return texts.lsp_error_cannot_open_channel;
     } else {
       return texts.invoice_payment_validator_error_unknown(extractExceptionMessage(e, texts));
     }

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -29,41 +29,39 @@ class PaymentValidator {
     _logger.info('Validating for $amount and $outgoing');
     try {
       validatePayment(amount, outgoing);
-    } on PaymentExceededLimitError catch (e) {
-      _logger.info('Got PaymentExceededLimitError', e);
-      return texts.invoice_payment_validator_error_payment_exceeded_limit(
-        currency.format(e.limitSat.toInt()),
-      );
-    } on PaymentBelowLimitError catch (e) {
-      _logger.info('Got PaymentBelowLimitError', e);
-      return texts.invoice_payment_validator_error_payment_below_invoice_limit(
-        currency.format(e.limitSat.toInt()),
-      );
-    } on PaymentBelowReserveError catch (e) {
-      _logger.info('Got PaymentBelowReserveError', e);
-      return texts.invoice_payment_validator_error_payment_below_limit(
-        currency.format(e.reserveAmount),
-      );
-    } on PaymentExceedededLiquidityError catch (e) {
-      return 'Insufficient inbound liquidity (${currency.format(e.limitSat.toInt())})';
-    } on InsufficientLocalBalanceError {
-      return texts.invoice_payment_validator_error_insufficient_local_balance;
-    } on PaymentBelowSetupFeesError catch (e) {
-      _logger.info('Got PaymentBelowSetupFeesError', e);
-      return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
-        currency.format(e.setupFees),
-      );
-    } on PaymentExceededLiquidityChannelCreationNotPossibleError catch (e) {
-      return texts.lnurl_fetch_invoice_error_max(currency.format(e.limitSat.toInt()));
-    } on NoChannelCreationZeroLiquidityError {
-      return texts.lsp_error_cannot_open_channel;
-    } catch (e) {
-      _logger.info('Got Generic error', e);
-      return texts.invoice_payment_validator_error_unknown(
-        extractExceptionMessage(e, texts),
-      );
+    } on Exception catch (e) {
+      return _handleException(e);
     }
 
     return null;
+  }
+
+  String _handleException(Exception e) {
+    _logger.warning('Failed to validate payment.', e);
+    if (e is PaymentExceededLimitError) {
+      return texts.invoice_payment_validator_error_payment_exceeded_limit(
+        currency.format(e.limitSat.toInt()),
+      );
+    } else if (e is PaymentBelowLimitError) {
+      return texts.invoice_payment_validator_error_payment_below_invoice_limit(
+        currency.format(e.limitSat.toInt()),
+      );
+    } else if (e is PaymentBelowReserveError) {
+      return texts.invoice_payment_validator_error_payment_below_limit(currency.format(e.reserveAmount));
+    } else if (e is PaymentExceededLiquidityError) {
+      return 'Insufficient inbound liquidity (${currency.format(e.limitSat.toInt())})';
+    } else if (e is InsufficientLocalBalanceError) {
+      return texts.invoice_payment_validator_error_insufficient_local_balance;
+    } else if (e is PaymentBelowSetupFeesError) {
+      return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
+        currency.format(e.setupFees),
+      );
+    } else if (e is PaymentExceededLiquidityChannelCreationNotPossibleError) {
+      return texts.lnurl_fetch_invoice_error_max(currency.format(e.limitSat.toInt()));
+    } else if (e is NoChannelCreationZeroLiquidityError) {
+      return texts.lsp_error_cannot_open_channel;
+    } else {
+      return texts.invoice_payment_validator_error_unknown(extractExceptionMessage(e, texts));
+    }
   }
 }


### PR DESCRIPTION
This PR utilizes account balance correctly when validating outgoing swap amount.

Misc:
- Added `toString` methods to `PaymentValidator` exceptions.  3d71572
- Refactored `PaymentValidator`
  - Changed & unified log messages
  - Handles exceptions via a helper method, `_handleException`