### PR TITLE
chore: Rename `GetInfoResponse` variables for consistency

### DIFF
--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -22,11 +22,11 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
 
   void _listenAccountChanges() {
     _logger.info('Listening to account changes');
-    breezSdkLiquid.walletInfoStream.distinct().listen(
-      (GetInfoResponse infoResponse) {
+    breezSdkLiquid.getInfoResponseStream.distinct().listen(
+      (GetInfoResponse getInfoResponse) {
         final AccountState newState = state.copyWith(
-          walletInfo: infoResponse.walletInfo,
-          blockchainInfo: infoResponse.blockchainInfo,
+          walletInfo: getInfoResponse.walletInfo,
+          blockchainInfo: getInfoResponse.blockchainInfo,
         );
         _logger.info('AccountState changed: $newState');
         emit(newState);

--- a/lib/cubit/chain_swap/chain_swap_cubit.dart
+++ b/lib/cubit/chain_swap/chain_swap_cubit.dart
@@ -18,7 +18,7 @@ class ChainSwapCubit extends Cubit<ChainSwapState> {
   }
 
   void _initializeChainSwapCubit() {
-    _breezSdkLiquid.walletInfoStream.first.then((_) => rescanOnchainSwaps());
+    _breezSdkLiquid.getInfoResponseStream.first.then((_) => rescanOnchainSwaps());
   }
 
   Future<void> rescanOnchainSwaps() async {

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -16,8 +16,8 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyStat
   }
 
   void _initializeCurrencyCubit() {
-    breezSdkLiquid.walletInfoStream.first.then(
-      (GetInfoResponse walletInfo) {
+    breezSdkLiquid.getInfoResponseStream.first.then(
+      (GetInfoResponse getInfoResponse) {
         listFiatCurrencies();
         fetchExchangeRates();
       },

--- a/lib/cubit/payment_limits/payment_limits_cubit.dart
+++ b/lib/cubit/payment_limits/payment_limits_cubit.dart
@@ -34,7 +34,7 @@ class PaymentLimitsCubit extends Cubit<PaymentLimitsState> {
 
   void _fetchPaymentLimits() {
     if (_breezSdkLiquid.instance != null) {
-      _breezSdkLiquid.walletInfoStream.first.then((GetInfoResponse walletInfo) {
+      _breezSdkLiquid.getInfoResponseStream.first.then((GetInfoResponse getInfoResponse) {
         fetchLightningLimits();
         fetchOnchainLimits();
       }).timeout(

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -23,7 +23,7 @@ class RefundCubit extends Cubit<RefundState> {
   }
 
   void _initializeRefundCubit() {
-    _breezSdkLiquid.walletInfoStream.first.then((_) => listRefundables());
+    _breezSdkLiquid.getInfoResponseStream.first.then((_) => listRefundables());
   }
 
   void listRefundables() async {

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -55,9 +55,9 @@ class BreezSDKLiquid {
   }
 
   Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
-    final liquid_sdk.GetInfoResponse walletInfo = await sdk.getInfo();
-    _walletInfoController.add(walletInfo);
-    return walletInfo;
+    final liquid_sdk.GetInfoResponse getInfoResponse = await sdk.getInfo();
+    _getInfoResponseController.add(getInfoResponse);
+    return getInfoResponse;
   }
 
   Future<List<liquid_sdk.Payment>> _listPayments({
@@ -94,10 +94,10 @@ class BreezSDKLiquid {
     _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
   }
 
-  final StreamController<liquid_sdk.GetInfoResponse> _walletInfoController =
+  final StreamController<liquid_sdk.GetInfoResponse> _getInfoResponseController =
       BehaviorSubject<liquid_sdk.GetInfoResponse>();
 
-  Stream<liquid_sdk.GetInfoResponse> get walletInfoStream => _walletInfoController.stream;
+  Stream<liquid_sdk.GetInfoResponse> get getInfoResponseStream => _getInfoResponseController.stream;
 
   final StreamController<List<liquid_sdk.Payment>> _paymentsController =
       BehaviorSubject<List<liquid_sdk.Payment>>();


### PR DESCRIPTION
This PR is a continuation of #287 and renames `GetInfoResponse` variables to `getInfoResponse` for consistency across the codebase.