### PR TITLE
Recover LN Address with Registration Fallback

### DIFF
--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -60,7 +60,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     );
 
     try {
-      final RegisterLnurlPayResponse registrationResponse = await _setupAndRegisterLnAddress(
+      final RegisterRecoverLnurlPayResponse registrationResponse = await _setupAndRegisterLnAddress(
         baseUsername: baseUsername,
       );
 
@@ -106,7 +106,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
   ///
   /// - If [baseUsername] is provided, it updates the existing registration.
   /// - Otherwise, it determines a suitable username and registers a new webhook.
-  Future<RegisterLnurlPayResponse> _setupAndRegisterLnAddress({String? baseUsername}) async {
+  Future<RegisterRecoverLnurlPayResponse> _setupAndRegisterLnAddress({String? baseUsername}) async {
     final WalletInfo walletInfo = await _getWalletInfo();
     final String webhookUrl = await _setupWebhook(walletInfo.pubkey);
     final String? username = baseUsername ?? await _resolveUsername();
@@ -164,7 +164,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     final String message = '$time-$webhookUrl';
     final String signature = await _signMessage(message);
 
-    final UnregisterLnurlPayRequest invalidateWebhookRequest = UnregisterLnurlPayRequest(
+    final UnregisterRecoverLnurlPayRequest invalidateWebhookRequest = UnregisterRecoverLnurlPayRequest(
       time: time,
       webhookUrl: webhookUrl,
       signature: signature,
@@ -223,11 +223,11 @@ class LnAddressCubit extends Cubit<LnAddressState> {
   ///
   ///  - Saves the username to [BreezPreferences] if present and
   ///  - Sets webhook as registered on [BreezPreferences] if succeeds
-  Future<RegisterLnurlPayResponse> _registerLnurlWebhook({
+  Future<RegisterRecoverLnurlPayResponse> _registerLnurlWebhook({
     required String pubKey,
     required RegisterLnurlPayRequest request,
   }) async {
-    final RegisterLnurlPayResponse registrationResponse = await lnAddressService.register(
+    final RegisterRecoverLnurlPayResponse registrationResponse = await lnAddressService.register(
       pubKey: pubKey,
       request: request,
     );

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -63,7 +63,11 @@ class LnAddressCubit extends Cubit<LnAddressState> {
   /// - If [isRecover] is true, it attempts to recover the LNURL Webhook. Fallbacks to registration on failure.
   /// - If [baseUsername] is provided, the function updates the Lightning Address username.
   /// - Otherwise, it initializes a new Lightning Address or refreshes an existing one.
-  Future<void> setupLightningAddress({String? pubKey, bool isRecover = false, String? baseUsername}) async {
+  Future<void> setupLightningAddress({
+    String? pubKey,
+    bool isRecover = false,
+    String? baseUsername,
+  }) async {
     final bool isUpdating = baseUsername != null;
     final String actionMessage = isRecover
         ? 'Recovering Lightning Address'
@@ -189,14 +193,17 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     final String? existingWebhook = await breezPreferences.webhookUrl;
     if (existingWebhook != null && existingWebhook != webhookUrl) {
       _logger.info('Unregistering existing webhook: $existingWebhook');
-      await _unregisterWebhook(existingWebhook, pubKey);
+      await _unregisterWebhook(pubKey: pubKey, webhookUrl: existingWebhook);
       breezPreferences.removeWebhookUrl();
       _logger.info('Successfully registered existing webhook.');
     }
   }
 
   /// Unregisters a webhook for a given public key.
-  Future<void> _unregisterWebhook(String webhookUrl, String pubKey) async {
+  Future<void> _unregisterWebhook({
+    required String pubKey,
+    required String webhookUrl,
+  }) async {
     _logger.info('Prepared unregister LNURL Webhook request.');
     final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
@@ -250,7 +257,11 @@ class LnAddressCubit extends Cubit<LnAddressState> {
   }
 
   /// Signs a webhook request message for authentication and validation purposes.
-  Future<String> _generateWebhookSignature(int time, String webhookUrl, String? username) async {
+  Future<String> _generateWebhookSignature({
+    required int time,
+    required String webhookUrl,
+    String? username,
+  }) async {
     _logger.info('Generating webhook signature');
     final String usernameComponent = username?.isNotEmpty == true ? '-$username' : '';
     final String message = '$time-$webhookUrl$usernameComponent';
@@ -320,7 +331,11 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     final String? username = baseUsername ?? await _resolveUsername();
 
     final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final String signature = await _generateWebhookSignature(time, webhookUrl, username);
+    final String signature = await _generateWebhookSignature(
+      time: time,
+      webhookUrl: webhookUrl,
+      username: username,
+    );
 
     final RegisterLnurlPayRequest registerRequest = RegisterLnurlPayRequest(
       time: time,

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -55,8 +55,8 @@ class LnAddressCubit extends Cubit<LnAddressState> {
         _logger.info('Received wallet info, setting up Lightning Address.');
         setupLightningAddress(pubKey: getInfoResponse.walletInfo.pubkey, isRecover: true);
       },
-    ).catchError((Object e, StackTrace stackTrace) {
-      _logger.severe('Failed to initialize Lightning Address Cubit', e, stackTrace);
+    ).catchError((Object e) {
+      _logger.severe('Failed to initialize Lightning Address Cubit', e);
     });
   }
 
@@ -315,8 +315,8 @@ class LnAddressCubit extends Cubit<LnAddressState> {
 
       await breezPreferences.setLnUrlWebhookRegistered();
       return recoverResponse;
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to recover LNURL Webhook.', e, stackTrace);
+    } catch (e) {
+      _logger.severe('Failed to recover LNURL Webhook.', e);
       rethrow;
     }
   }
@@ -376,8 +376,8 @@ class LnAddressCubit extends Cubit<LnAddressState> {
       } on UsernameConflictException {
         _logger.warning('Username conflict for: $username.');
         username = UsernameGenerator.generateUsername(username, retryCount);
-      } catch (e, stackTrace) {
-        _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e, stackTrace);
+      } catch (e) {
+        _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e);
         if (retryCount == _maxRetries - 1) {
           _logger.severe('Max retries exceeded for username registration');
           throw MaxRetriesExceededException();
@@ -394,6 +394,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     required String webhookUrl,
     String? username,
   }) async {
+    _logger.info('Prepared register LNURL Webhook request.');
     final RegisterLnurlPayRequest request = await _prepareRegisterLnurlPayRequest(
       pubKey: pubKey,
       webhookUrl: webhookUrl,
@@ -451,8 +452,8 @@ class LnAddressCubit extends Cubit<LnAddressState> {
 
       await breezPreferences.setLnUrlWebhookRegistered();
       return registrationResponse;
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to register LNURL Webhook.', e, stackTrace);
+    } catch (e) {
+      _logger.severe('Failed to register LNURL Webhook.', e);
       rethrow;
     }
   }

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -147,7 +147,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
           pubKey: pubKey,
           webhookUrl: webhookUrl,
         );
-      } on RecoverLnurlPayException {
+      } on WebhookNotFoundException {
         // Fallback to register a new webhook if recovery fails
         _logger.info('Failed to recover LNURL Webhook. Falling back to registration.');
         return await _prepareAndRegisterLnurlWebhook(

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -159,18 +159,19 @@ class LnAddressCubit extends Cubit<LnAddressState> {
 
   /// Unregisters a webhook for a given public key.
   Future<void> _unregisterWebhook(String webhookUrl, String pubKey) async {
+    _logger.info('Prepared unregister LNURL Webhook request.');
     final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
     final String message = '$time-$webhookUrl';
     final String signature = await _signMessage(message);
 
-    final UnregisterRecoverLnurlPayRequest invalidateWebhookRequest = UnregisterRecoverLnurlPayRequest(
+    final UnregisterRecoverLnurlPayRequest unregisterRequest = UnregisterRecoverLnurlPayRequest(
       time: time,
       webhookUrl: webhookUrl,
       signature: signature,
     );
-
-    await lnAddressService.unregister(pubKey, invalidateWebhookRequest);
+    _logger.info('Prepared unregister LNURL Webhook request.');
+    await lnAddressService.unregister(pubKey: pubKey, request: unregisterRequest);
   }
 
   /// Signs the given message with the private key.

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -379,15 +379,12 @@ class LnAddressCubit extends Cubit<LnAddressState> {
         username = UsernameGenerator.generateUsername(baseUsername, retryCount);
       } catch (e) {
         _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e);
-        if (retryCount == _maxRetries - 1) {
-          _logger.severe('Max retries exceeded for username registration');
-          throw MaxRetriesExceededException();
-        }
         rethrow;
       }
     }
 
-    throw RegisterLnurlPayException('Failed to register LNURL Webhook.');
+    _logger.severe('Max retries exceeded for username registration');
+    throw MaxRetriesExceededException();
   }
 
   Future<RegisterRecoverLnurlPayResponse> _attemptRegisterLnurlWebhook({

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -365,6 +365,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     required String webhookUrl,
     required String username,
   }) async {
+    final String baseUsername = username;
     for (int retryCount = 1; retryCount <= _maxRetries; retryCount++) {
       try {
         _logger.info('Attempt $retryCount/$_maxRetries with username: $username');
@@ -375,7 +376,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
         );
       } on UsernameConflictException {
         _logger.warning('Username conflict for: $username.');
-        username = UsernameGenerator.generateUsername(username, retryCount);
+        username = UsernameGenerator.generateUsername(baseUsername, retryCount);
       } catch (e) {
         _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e);
         if (retryCount == _maxRetries - 1) {

--- a/lib/cubit/ln_address/models/exceptions.dart
+++ b/lib/cubit/ln_address/models/exceptions.dart
@@ -1,3 +1,15 @@
+class RecoverLnurlPayException implements Exception {
+  final String message;
+  final int? statusCode;
+  final String? responseBody;
+
+  RecoverLnurlPayException(this.message, {this.statusCode, this.responseBody});
+
+  @override
+  String toString() =>
+      'RecoverLnurlPayException: $message${statusCode != null ? ' (Status: $statusCode)' : ''}';
+}
+
 class RegisterLnurlPayException implements Exception {
   final String message;
   final int? statusCode;

--- a/lib/cubit/ln_address/models/exceptions.dart
+++ b/lib/cubit/ln_address/models/exceptions.dart
@@ -10,6 +10,11 @@ class RecoverLnurlPayException implements Exception {
       'RecoverLnurlPayException: $message${statusCode != null ? ' (Status: $statusCode)' : ''}';
 }
 
+class WebhookNotFoundException implements Exception {
+  @override
+  String toString() => 'No associated webhook found for given public key.';
+}
+
 class RegisterLnurlPayException implements Exception {
   final String message;
   final int? statusCode;

--- a/lib/cubit/ln_address/models/lnurl_pay_registration.dart
+++ b/lib/cubit/ln_address/models/lnurl_pay_registration.dart
@@ -38,17 +38,17 @@ class RegisterLnurlPayRequest {
   String toString() => 'username=$username, time=$time, webhook_url=$webhookUrl, signature=$signature';
 }
 
-class RegisterLnurlPayResponse {
+class RegisterRecoverLnurlPayResponse {
   final String lnurl;
   final String lightningAddress;
 
-  const RegisterLnurlPayResponse({
+  const RegisterRecoverLnurlPayResponse({
     required this.lnurl,
     required this.lightningAddress,
   });
 
-  factory RegisterLnurlPayResponse.fromJson(Map<String, dynamic> json) {
-    return RegisterLnurlPayResponse(
+  factory RegisterRecoverLnurlPayResponse.fromJson(Map<String, dynamic> json) {
+    return RegisterRecoverLnurlPayResponse(
       lnurl: json['lnurl'] as String,
       lightningAddress: json['lightning_address'] as String? ?? '',
     );
@@ -58,12 +58,12 @@ class RegisterLnurlPayResponse {
   String toString() => 'lnurl=$lnurl, lightning_address=$lightningAddress';
 }
 
-class UnregisterLnurlPayRequest {
+class UnregisterRecoverLnurlPayRequest {
   final int time;
   final String webhookUrl;
   final String signature;
 
-  const UnregisterLnurlPayRequest({
+  const UnregisterRecoverLnurlPayRequest({
     required this.time,
     required this.webhookUrl,
     required this.signature,

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -132,7 +132,10 @@ class LnUrlPayService {
     }
   }
 
-  Future<void> unregister(String pubKey, UnregisterRecoverLnurlPayRequest request) async {
+  Future<void> unregister({
+    required String pubKey,
+    required UnregisterRecoverLnurlPayRequest request,
+  }) async {
     _logger.info('Unregistering webhook: ${request.webhookUrl}');
     final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey');
 
@@ -147,9 +150,9 @@ class LnUrlPayService {
         throw UnregisterLnurlPayException(response.body);
       }
 
-      _logger.info('Successfully unregistered webhook');
+      _logger.info('Successfully unregistered webhook.');
     } catch (e, stackTrace) {
-      _logger.severe('Failed to unregister webhook', e, stackTrace);
+      _logger.severe('Failed to unregister webhook.', e, stackTrace);
       throw UnregisterLnurlPayException(e.toString());
     }
   }

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -41,8 +41,8 @@ class LnUrlPayService {
         statusCode: response.statusCode,
         responseBody: response.body,
       );
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to register webhook.', e, stackTrace);
+    } catch (e) {
+      _logger.severe('Failed to register webhook.', e);
       rethrow;
     }
   }
@@ -76,8 +76,8 @@ class LnUrlPayService {
         statusCode: response.statusCode,
         responseBody: response.body,
       );
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to recover webhook.', e, stackTrace);
+    } catch (e) {
+      _logger.severe('Failed to recover webhook.', e);
       rethrow;
     }
   }
@@ -101,8 +101,8 @@ class LnUrlPayService {
       }
 
       _logger.info('Successfully unregistered webhook.');
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to unregister webhook.', e, stackTrace);
+    } catch (e) {
+      _logger.severe('Failed to unregister webhook.', e);
       rethrow;
     }
   }

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -117,6 +117,10 @@ class LnUrlPayService {
         );
       }
 
+      if (response.statusCode == 404) {
+        throw WebhookNotFoundException();
+      }
+
       throw RecoverLnurlPayException(
         'Server returned error response',
         statusCode: response.statusCode,

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -58,41 +58,6 @@ class LnUrlPayService {
     throw MaxRetriesExceededException();
   }
 
-  Future<RegisterRecoverLnurlPayResponse> recover({
-    required String pubKey,
-    required UnregisterRecoverLnurlPayRequest request,
-  }) async {
-    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey/recover');
-    _logger.fine('Sending recover request to: $uri');
-
-    try {
-      final http.Response response = await _client.post(
-        uri,
-        body: jsonEncode(request.toJson()),
-      );
-      _logHttpResponse(response);
-
-      if (response.statusCode == 200) {
-        return RegisterRecoverLnurlPayResponse.fromJson(
-          jsonDecode(response.body) as Map<String, dynamic>,
-        );
-      }
-
-      throw RecoverLnurlPayException(
-        'Server returned error response',
-        statusCode: response.statusCode,
-        responseBody: response.body,
-      );
-    } catch (e, stackTrace) {
-      if (e is RecoverLnurlPayException) {
-        rethrow;
-      }
-
-      _logger.severe('Recovery failed', e, stackTrace);
-      throw RecoverLnurlPayException(e.toString());
-    }
-  }
-
   Future<RegisterRecoverLnurlPayResponse> _register({
     required String pubKey,
     required RegisterLnurlPayRequest request,
@@ -127,8 +92,43 @@ class LnUrlPayService {
         rethrow;
       }
 
-      _logger.severe('Registration failed', e, stackTrace);
+      _logger.severe('Failed to register webhook.', e, stackTrace);
       throw RegisterLnurlPayException(e.toString());
+    }
+  }
+
+  Future<RegisterRecoverLnurlPayResponse> recover({
+    required String pubKey,
+    required UnregisterRecoverLnurlPayRequest request,
+  }) async {
+    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey/recover');
+    _logger.fine('Sending recover request to: $uri');
+
+    try {
+      final http.Response response = await _client.post(
+        uri,
+        body: jsonEncode(request.toJson()),
+      );
+      _logHttpResponse(response);
+
+      if (response.statusCode == 200) {
+        return RegisterRecoverLnurlPayResponse.fromJson(
+          jsonDecode(response.body) as Map<String, dynamic>,
+        );
+      }
+
+      throw RecoverLnurlPayException(
+        'Server returned error response',
+        statusCode: response.statusCode,
+        responseBody: response.body,
+      );
+    } catch (e, stackTrace) {
+      if (e is RecoverLnurlPayException) {
+        rethrow;
+      }
+
+      _logger.severe('Failed to recover webhook.', e, stackTrace);
+      throw RecoverLnurlPayException(e.toString());
     }
   }
 

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -58,6 +58,41 @@ class LnUrlPayService {
     throw MaxRetriesExceededException();
   }
 
+  Future<RegisterRecoverLnurlPayResponse> recover({
+    required String pubKey,
+    required UnregisterRecoverLnurlPayRequest request,
+  }) async {
+    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey/recover');
+    _logger.fine('Sending recover request to: $uri');
+
+    try {
+      final http.Response response = await _client.post(
+        uri,
+        body: jsonEncode(request.toJson()),
+      );
+      _logHttpResponse(response);
+
+      if (response.statusCode == 200) {
+        return RegisterRecoverLnurlPayResponse.fromJson(
+          jsonDecode(response.body) as Map<String, dynamic>,
+        );
+      }
+
+      throw RecoverLnurlPayException(
+        'Server returned error response',
+        statusCode: response.statusCode,
+        responseBody: response.body,
+      );
+    } catch (e, stackTrace) {
+      if (e is RecoverLnurlPayException) {
+        rethrow;
+      }
+
+      _logger.severe('Recovery failed', e, stackTrace);
+      throw RecoverLnurlPayException(e.toString());
+    }
+  }
+
   Future<RegisterRecoverLnurlPayResponse> _register({
     required String pubKey,
     required RegisterLnurlPayRequest request,

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -88,12 +88,8 @@ class LnUrlPayService {
         responseBody: response.body,
       );
     } catch (e, stackTrace) {
-      if (e is UsernameConflictException || e is RegisterLnurlPayException) {
-        rethrow;
-      }
-
       _logger.severe('Failed to register webhook.', e, stackTrace);
-      throw RegisterLnurlPayException(e.toString());
+      rethrow;
     }
   }
 
@@ -127,12 +123,8 @@ class LnUrlPayService {
         responseBody: response.body,
       );
     } catch (e, stackTrace) {
-      if (e is RecoverLnurlPayException) {
-        rethrow;
-      }
-
       _logger.severe('Failed to recover webhook.', e, stackTrace);
-      throw RecoverLnurlPayException(e.toString());
+      rethrow;
     }
   }
 
@@ -157,7 +149,7 @@ class LnUrlPayService {
       _logger.info('Successfully unregistered webhook.');
     } catch (e, stackTrace) {
       _logger.severe('Failed to unregister webhook.', e, stackTrace);
-      throw UnregisterLnurlPayException(e.toString());
+      rethrow;
     }
   }
 

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -12,7 +12,7 @@ class LnUrlPayService {
   static final http.Client _client = http.Client();
 
   // TODO(erdemyerebasmaz): Handle multiple device setup case
-  Future<RegisterLnurlPayResponse> register({
+  Future<RegisterRecoverLnurlPayResponse> register({
     required String pubKey,
     required RegisterLnurlPayRequest request,
   }) async {
@@ -36,7 +36,7 @@ class LnUrlPayService {
   // - Explicit handling of [UsernameConflictException] and LNURL server connectivity issues
   // - Randomizing the default profile name itself after a set number of failures
   // - Adding additional digits to the discriminator
-  Future<RegisterLnurlPayResponse> _registerWithRetries({
+  Future<RegisterRecoverLnurlPayResponse> _registerWithRetries({
     required String pubKey,
     required String username,
     required RegisterLnurlPayRequest request,
@@ -58,7 +58,7 @@ class LnUrlPayService {
     throw MaxRetriesExceededException();
   }
 
-  Future<RegisterLnurlPayResponse> _register({
+  Future<RegisterRecoverLnurlPayResponse> _register({
     required String pubKey,
     required RegisterLnurlPayRequest request,
   }) async {
@@ -73,7 +73,7 @@ class LnUrlPayService {
       _logHttpResponse(response);
 
       if (response.statusCode == 200) {
-        return RegisterLnurlPayResponse.fromJson(
+        return RegisterRecoverLnurlPayResponse.fromJson(
           jsonDecode(response.body) as Map<String, dynamic>,
         );
       }
@@ -97,7 +97,7 @@ class LnUrlPayService {
     }
   }
 
-  Future<void> unregister(String pubKey, UnregisterLnurlPayRequest request) async {
+  Future<void> unregister(String pubKey, UnregisterRecoverLnurlPayRequest request) async {
     _logger.info('Unregistering webhook: ${request.webhookUrl}');
     final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey');
 

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -19,17 +19,6 @@ class ReceiveLightningAddressPage extends StatefulWidget {
 
 class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage> {
   @override
-  void initState() {
-    super.initState();
-    setupLightningAddress();
-  }
-
-  void setupLightningAddress() {
-    final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
-    lnAddressCubit.setupLightningAddress();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
@@ -95,7 +84,8 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
   VoidCallback _handleRetry(LnAddressState state, PaymentLimitsState limitsState) {
     return () {
       if (state.status == LnAddressStatus.error) {
-        setupLightningAddress();
+        final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
+        lnAddressCubit.setupLightningAddress(isRecover: true);
       } else if (limitsState.hasError) {
         final PaymentLimitsCubit paymentLimitsCubit = context.read<PaymentLimitsCubit>();
         paymentLimitsCubit.fetchLightningLimits();

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -132,15 +132,15 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
                           border: const OutlineInputBorder(),
                           errorText: isConflict ? 'Username is already taken' : null,
                         ),
-                        // 64 is the maximum allowed length for a username
-                        // but a %12.5 margin of error is added for good measure,
-                        // which is likely to get sanitized by the UsernameFormatter
-                        maxLength: 64 + 8,
                         keyboardType: TextInputType.emailAddress,
                         autofocus: true,
                         validator: _validateUsername,
                         inputFormatters: <TextInputFormatter>[
                           UsernameInputFormatter(),
+                          // 64 is the maximum allowed length for a username
+                          // but a %12.5 margin of error is added for good measure,
+                          // which is likely to get sanitized by the UsernameFormatter
+                          LengthLimitingTextInputFormatter(72),
                         ],
                         onEditingComplete: () => _usernameFocusNode.unfocus(),
                       );


### PR DESCRIPTION
Fixes #345

---
Depends on:
-  https://github.com/breez/breez-lnurl/pull/12
---

Opted to a more general approach and will attempt to recover at all times and fallback to registration if recovery fails, instead of communicating wallet state between cubits.

### Changelist:
- Added recover APIs to `LnAddressCubit` & `LnUrlPayService`
  - Attempt to recover LN `Address` on initializing `LnAddressCubit` with registration fallback
  - Do not refresh LN Address on opening `ReceiveLightningAddressPage`
  - Applied renaming of the request & response objects on the LNURL service
- Made changes to comments & logs so they are more consistent, additional error handling is added to pinpoint the source of errors and used named params where applicable.