### PR TITLE
Add input handing for Bolt 12 Offers & LNURL payments resolved from BIP 353 Address

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -127,7 +127,7 @@ Route<dynamic>? onGenerateRoute({
                     builder: (BuildContext context) => BlocProvider<PaymentLimitsCubit>(
                       create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
                       child: LnOfferPaymentPage(
-                        lnOffer: settings.arguments as LNOffer,
+                        lnOfferPaymentArguments: settings.arguments as LnOfferPaymentArguments,
                       ),
                     ),
                     settings: settings,
@@ -137,7 +137,7 @@ Route<dynamic>? onGenerateRoute({
                     builder: (BuildContext context) => BlocProvider<PaymentLimitsCubit>(
                       create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
                       child: LnUrlPaymentPage(
-                        requestData: settings.arguments as LnUrlPayRequestData,
+                        lnUrlPaymentArguments: settings.arguments as LnUrlPaymentArguments,
                       ),
                     ),
                     settings: settings,

--- a/lib/cubit/input/input_cubit.dart
+++ b/lib/cubit/input/input_cubit.dart
@@ -87,9 +87,9 @@ class InputCubit extends Cubit<InputState> {
     if (parsedInput is InputType_Bolt11) {
       result = await handlePaymentRequest(parsedInput, source);
     } else if (parsedInput is InputType_Bolt12Offer) {
-      result = InputState.bolt12Offer(parsedInput.offer, source);
+      result = InputState.bolt12Offer(parsedInput.offer, parsedInput.bip353Address, source);
     } else if (parsedInput is InputType_LnUrlPay) {
-      result = InputState.lnUrlPay(parsedInput.data, source);
+      result = InputState.lnUrlPay(parsedInput.data, parsedInput.bip353Address, source);
     } else if (parsedInput is InputType_LnUrlWithdraw) {
       result = InputState.lnUrlWithdraw(parsedInput.data, source);
     } else if (parsedInput is InputType_LnUrlAuth) {

--- a/lib/cubit/input/input_state.dart
+++ b/lib/cubit/input/input_state.dart
@@ -27,11 +27,13 @@ class InputState {
 
   const factory InputState.bolt12Offer(
     LNOffer lnOffer,
+    String? bip353Address,
     InputSource source,
   ) = LnOfferInputState;
 
   const factory InputState.lnUrlPay(
     LnUrlPayRequestData data,
+    String? bip353Address,
     InputSource source,
   ) = LnUrlPayInputState;
 
@@ -127,10 +129,12 @@ class LnInvoiceInputState extends InputState {
 class LnOfferInputState extends InputState {
   const LnOfferInputState(
     this.lnOffer,
+    this.bip353Address,
     this.source,
   ) : super._();
 
   final LNOffer lnOffer;
+  final String? bip353Address;
   final InputSource source;
 
   @override
@@ -153,10 +157,12 @@ class LnOfferInputState extends InputState {
 class LnUrlPayInputState extends InputState {
   const LnUrlPayInputState(
     this.data,
+    this.bip353Address,
     this.source,
   ) : super._();
 
   final LnUrlPayRequestData data;
+  final String? bip353Address;
   final InputSource source;
 
   @override

--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -85,9 +85,18 @@ class InputHandler extends Handler {
     if (inputState is LnInvoiceInputState) {
       return handleLnInvoice(context, inputState.lnInvoice);
     } else if (inputState is LnOfferInputState) {
-      return handleLnOffer(context, inputState.lnOffer);
+      return handleLnOffer(
+        context,
+        inputState.lnOffer,
+        bip353Address: inputState.bip353Address,
+      );
     } else if (inputState is LnUrlPayInputState) {
-      return handlePayRequest(context, firstPaymentItemKey, inputState.data);
+      return handlePayRequest(
+        context,
+        firstPaymentItemKey,
+        inputState.data,
+        bip353Address: inputState.bip353Address,
+      );
     } else if (inputState is LnUrlWithdrawInputState) {
       return handleWithdrawRequest(context, inputState.data);
     } else if (inputState is LnUrlAuthInputState) {
@@ -132,12 +141,20 @@ class InputHandler extends Handler {
     });
   }
 
-  Future<dynamic> handleLnOffer(BuildContext context, LNOffer lnOffer) async {
+  Future<dynamic> handleLnOffer(
+    BuildContext context,
+    LNOffer lnOffer, {
+    String? bip353Address,
+  }) async {
     _logger.info('handle LNOffer $lnOffer');
     final NavigatorState navigator = Navigator.of(context);
+    final LnOfferPaymentArguments arguments = LnOfferPaymentArguments(
+      lnOffer: lnOffer,
+      bip353Address: bip353Address,
+    );
     final PrepareSendResponse? prepareResponse = await navigator.pushNamed<PrepareSendResponse?>(
       LnOfferPaymentPage.routeName,
-      arguments: lnOffer,
+      arguments: arguments,
     );
     if (prepareResponse == null || !context.mounted) {
       return Future<dynamic>.value();

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/payment_details_extension.dart';
+import 'package:l_breez/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart';
 import 'package:l_breez/routes/home/widgets/widgets.dart';
 import 'package:logging/logging.dart';
@@ -80,6 +81,12 @@ class PaymentDetailsSheet extends StatelessWidget {
       lightning: (PaymentDetails_Lightning details) => details.swapId,
       orElse: () => '',
     );
+
+    final String bip353Address = paymentData.details.map(
+          lightning: (PaymentDetails_Lightning details) => details.bip353Address,
+          orElse: () => null,
+        ) ??
+        '';
 
     final LnUrlInfo? lnurlInfo = paymentData.details.map(
       lightning: (PaymentDetails_Lightning details) => details.lnurlInfo,
@@ -174,6 +181,9 @@ class PaymentDetailsSheet extends StatelessWidget {
                           expiryDate: expiryDate,
                           labelAutoSizeGroup: _labelGroup,
                         ),
+                      ],
+                      if (bip353Address.isNotEmpty) ...<Widget>[
+                        PaymentDetailsSheetBip353Address(bip353Address: bip353Address),
                       ],
                       if (lnAddress.isNotEmpty) ...<Widget>[
                         PaymentDetailsSheetLnUrlLnAddress(lnAddress: lnAddress),

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart
@@ -1,0 +1,27 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/material.dart';
+import 'package:l_breez/widgets/widgets.dart';
+
+class PaymentDetailsSheetBip353Address extends StatelessWidget {
+  final String bip353Address;
+
+  const PaymentDetailsSheetBip353Address({required this.bip353Address, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
+
+    return ShareablePaymentRow(
+      tilePadding: EdgeInsets.zero,
+      dividerColor: Colors.transparent,
+      title: '${texts.payment_details_dialog_share_lightning_address}:',
+      titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
+        fontSize: 18.0,
+        color: Colors.white,
+      ),
+      sharedValue: bip353Address,
+    );
+  }
+}

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -11,12 +11,16 @@ final Logger _logger = Logger('HandleLNURLPayRequest');
 Future<LNURLPageResult?> handlePayRequest(
   BuildContext context,
   GlobalKey firstPaymentItemKey,
-  LnUrlPayRequestData data,
-) async {
+  LnUrlPayRequestData requestData, {
+  String? bip353Address,
+}) async {
   final NavigatorState navigator = Navigator.of(context);
   final PrepareLnUrlPayResponse? prepareResponse = await navigator.pushNamed<PrepareLnUrlPayResponse?>(
     LnUrlPaymentPage.routeName,
-    arguments: data,
+    arguments: LnUrlPaymentArguments(
+      requestData: requestData,
+      bip353Address: bip353Address,
+    ),
   );
   if (prepareResponse == null || !context.mounted) {
     return Future<LNURLPageResult?>.value();


### PR DESCRIPTION
[![Run CI](https://github.com/breez/misty-breez/actions/workflows/CI.yml/badge.svg?branch=bip353_payment_data)](https://github.com/breez/misty-breez/actions/workflows/CI.yml)

Fixes #354

Depends on:
- https://github.com/breez/breez-sdk-liquid/pull/718

Handles Bolt 12 Offers & LNURL payments resolved from BIP 353 addresses by reusing existing routes with added `bip353Address` information.