### PR TITLE
Fix refund fees validation

### DIFF
--- a/lib/cubit/model/src/fee_option/fee_option.dart
+++ b/lib/cubit/model/src/fee_option/fee_option.dart
@@ -44,7 +44,7 @@ class SendChainSwapFeeOption extends FeeOption {
 
   @override
   bool isAffordable({required int amountSat, int? balanceSat, int? walletBalanceSat}) {
-    assert(balanceSat != null);
+    assert(balanceSat != null, 'Balance amount must be provided.');
 
     return preparePayOnchainResponse.isAffordable(balance: balanceSat!);
   }
@@ -67,7 +67,7 @@ class RefundFeeOption extends FeeOption {
 
   @override
   bool isAffordable({required int amountSat, int? balanceSat, int? walletBalanceSat}) {
-    assert(balanceSat != null);
+    assert(balanceSat != null, 'Balance amount must be provided.');
 
     return prepareRefundResponse.isAffordable(balance: balanceSat!);
   }

--- a/lib/cubit/model/src/fee_option/fee_option.dart
+++ b/lib/cubit/model/src/fee_option/fee_option.dart
@@ -1,5 +1,6 @@
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 
 enum ProcessingSpeed {
   economy(Duration(minutes: 60)),
@@ -48,6 +49,15 @@ class SendChainSwapFeeOption extends FeeOption {
 
     return preparePayOnchainResponse.isAffordable(balance: balanceSat!);
   }
+
+  @override
+  String toString() {
+    return 'SendChainSwapFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${preparePayOnchainResponse.toFormattedString()}'
+        ')';
+  }
 }
 
 extension PreparePayOnchainResponseAffordable on PreparePayOnchainResponse {
@@ -70,6 +80,15 @@ class RefundFeeOption extends FeeOption {
     assert(balanceSat != null, 'Balance amount must be provided.');
 
     return prepareRefundResponse.isAffordable(balance: balanceSat!);
+  }
+
+  @override
+  String toString() {
+    return 'RefundFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${prepareRefundResponse.toFormattedString}'
+        ')';
   }
 }
 

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -44,7 +44,8 @@ class RefundCubit extends Cubit<RefundState> {
       (PaymentEvent paymentEvent) {
         if (paymentEvent.sdkEvent is SdkEvent_PaymentRefundable ||
             paymentEvent.sdkEvent is SdkEvent_PaymentRefundPending ||
-            paymentEvent.sdkEvent is SdkEvent_PaymentRefunded) {
+            paymentEvent.sdkEvent is SdkEvent_PaymentRefunded ||
+            (paymentEvent.sdkEvent is SdkEvent_PaymentFailed && state.hasRefundables)) {
           listRefundables();
         }
       },

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -5,6 +5,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:logging/logging.dart';
 
@@ -12,6 +13,7 @@ export 'refund_state.dart';
 
 final Logger _logger = Logger('RefundCubit');
 
+/// Cubit that handles refund operations.
 class RefundCubit extends Cubit<RefundState> {
   StreamSubscription<PaymentEvent>? _paymentEventSubscription;
 
@@ -22,20 +24,27 @@ class RefundCubit extends Cubit<RefundState> {
     _listenRefundEvents();
   }
 
-  void _initializeRefundCubit() {
+  /// Initializes the cubit by waiting for initial SDK info and then
+  /// fetching the current list of refundables.
+  Future<void> _initializeRefundCubit() async {
     _logger.info('Initializing Refund Cubit');
-    _breezSdkLiquid.getInfoResponseStream.first.then((_) => listRefundables()).catchError(
-      (Object e) {
-        _logger.severe('Failed to initialize Refund Cubit', e);
-      },
-    );
+    try {
+      await _breezSdkLiquid.getInfoResponseStream.first;
+      // Fire-and-forget the list refresh.
+      listRefundables();
+    } catch (e) {
+      _logger.severe('Failed to initialize Refund Cubit', e);
+    }
   }
 
-  void listRefundables() async {
+  /// Retrieves refundables from the SDK and emits the updated state.
+  Future<void> listRefundables() async {
     try {
       _logger.info('Refreshing refundables');
       final List<RefundableSwap> refundables = await _breezSdkLiquid.instance!.listRefundables();
-      _logger.info('Fetched refundables: $refundables');
+      _logger.info(
+        'Fetched refundables: ${refundables.map((RefundableSwap r) => r.toFormattedString()).toList()}',
+      );
       emit(state.copyWith(refundables: refundables));
     } catch (e) {
       _logger.severe('Failed to list refundables', e);
@@ -43,15 +52,14 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
+  /// Subscribes to payment events and refreshes refundables when a refund-
+  /// related event is detected.
   void _listenRefundEvents() {
-    _logger.info('Listening to Refund-related events');
+    _logger.info('Listening to refund-related events');
     _paymentEventSubscription = _breezSdkLiquid.paymentEventStream.listen(
       (PaymentEvent paymentEvent) {
-        _logger.info('Received payment event: $paymentEvent');
-        if (paymentEvent.sdkEvent is SdkEvent_PaymentRefundable ||
-            paymentEvent.sdkEvent is SdkEvent_PaymentRefundPending ||
-            paymentEvent.sdkEvent is SdkEvent_PaymentRefunded ||
-            (paymentEvent.sdkEvent is SdkEvent_PaymentFailed && state.hasRefundables)) {
+        _logger.info('Received payment event: ${paymentEvent.toFormattedString()}');
+        if (paymentEvent.sdkEvent.isRefundRelated(hasRefundables: state.hasRefundables)) {
           _logger.info('Refund-related event detected. Refreshing refundables.');
           listRefundables();
         }
@@ -66,11 +74,12 @@ class RefundCubit extends Cubit<RefundState> {
     return super.close();
   }
 
+  /// Fetches the recommended fees from the SDK.
   Future<RecommendedFees> _recommendedFees() async {
     try {
       _logger.info('Fetching recommended fees');
       final RecommendedFees fees = await _breezSdkLiquid.instance!.recommendedFees();
-      _logger.info('Fetched recommended fees: $fees');
+      _logger.info('Fetched recommended fees: ${fees.toFormattedString()}');
       return fees;
     } catch (e) {
       _logger.severe('Failed to fetch recommended fees', e);
@@ -78,27 +87,15 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
-  Future<PrepareRefundResponse> prepareRefund({
-    required PrepareRefundRequest req,
-  }) async {
-    try {
-      _logger.info('Preparing refund for ${req.swapAddress} with fee ${req.feeRateSatPerVbyte}');
-      final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
-      _logger.info('Prepared refund response: $response');
-      return response;
-    } catch (e) {
-      _logger.severe('Failed to prepare refund', e);
-      rethrow;
-    }
-  }
-
-  /// Fetches the current recommended fees for a refund transaction.
+  /// Fetches refund fee options for a given [swapAddress] and [toAddress].
+  ///
+  /// Returns a list of [RefundFeeOption] representing different fee rates.
   Future<List<RefundFeeOption>> fetchRefundFeeOptions({
     required String toAddress,
     required String swapAddress,
   }) async {
     try {
-      _logger.info('Fetching refund fee options for swapAddress: $swapAddress toAddress: $toAddress');
+      _logger.info('Fetching refund fee options for swapAddress: $swapAddress, toAddress: $toAddress');
       final RecommendedFees recommendedFees = await _recommendedFees();
       final List<RefundFeeOption> feeOptions = await _constructFeeOptionList(
         toAddress: toAddress,
@@ -114,6 +111,9 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
+  /// Constructs a list of refund fee options using [recommendedFees].
+  ///
+  /// Each option corresponds to a different processing speed.
   Future<List<RefundFeeOption>> _constructFeeOptionList({
     required String toAddress,
     required String swapAddress,
@@ -121,30 +121,24 @@ class RefundCubit extends Cubit<RefundState> {
   }) async {
     _logger.info('Constructing refund fee options for swapAddress: $swapAddress');
 
-    final List<BigInt> recommendedFeeList = <BigInt>[
-      recommendedFees.hourFee,
-      recommendedFees.halfHourFee,
-      recommendedFees.fastestFee,
-    ];
+    // Map each processing speed to its corresponding fee.
+    final Map<ProcessingSpeed, BigInt> processingSpeedToFeeMap = <ProcessingSpeed, BigInt>{
+      ProcessingSpeed.values[0]: recommendedFees.hourFee,
+      ProcessingSpeed.values[1]: recommendedFees.halfHourFee,
+      ProcessingSpeed.values[2]: recommendedFees.fastestFee,
+    };
 
     try {
       final List<RefundFeeOption> feeOptions = await Future.wait(
-        List<Future<RefundFeeOption>>.generate(3, (int index) async {
-          final PrepareRefundRequest prepareRefundRequest = PrepareRefundRequest(
+        processingSpeedToFeeMap.entries.map(
+          (MapEntry<ProcessingSpeed, BigInt> entry) => _createRefundFeeOption(
+            processingSpeed: entry.key,
+            feeRate: entry.value,
             swapAddress: swapAddress,
-            feeRateSatPerVbyte: recommendedFeeList[index].toInt(),
-            refundAddress: toAddress,
-          );
-          final PrepareRefundResponse prepareRefundResponse = await _prepareRefund(prepareRefundRequest);
-
-          return RefundFeeOption(
-            processingSpeed: ProcessingSpeed.values[index],
-            feeRateSatPerVbyte: recommendedFeeList[index],
-            prepareRefundResponse: prepareRefundResponse,
-          );
-        }),
+            toAddress: toAddress,
+          ),
+        ),
       );
-
       _logger.info('Successfully constructed refund fee options: $feeOptions');
       return feeOptions;
     } catch (e) {
@@ -153,12 +147,42 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
-  Future<PrepareRefundResponse> _prepareRefund(PrepareRefundRequest req) async {
+  /// Creates a single refund fee option for the given [processingSpeed] and [feeRate].
+  Future<RefundFeeOption> _createRefundFeeOption({
+    required ProcessingSpeed processingSpeed,
+    required BigInt feeRate,
+    required String swapAddress,
+    required String toAddress,
+  }) async {
+    try {
+      _logger.info('Creating refund fee option for processingSpeed: $processingSpeed, feeRate: $feeRate');
+      final PrepareRefundRequest request = PrepareRefundRequest(
+        swapAddress: swapAddress,
+        feeRateSatPerVbyte: feeRate.toInt(),
+        refundAddress: toAddress,
+      );
+      final PrepareRefundResponse response = await prepareRefund(request);
+      _logger.info('Successfully created refund fee option for $processingSpeed');
+      return RefundFeeOption(
+        processingSpeed: processingSpeed,
+        feeRateSatPerVbyte: feeRate,
+        prepareRefundResponse: response,
+      );
+    } catch (e) {
+      _logger.severe('Error creating refund fee option for processingSpeed: $processingSpeed', e);
+      rethrow;
+    }
+  }
+
+  /// Prepares a refund transaction using the provided [req].
+  ///
+  /// Returns a [PrepareRefundResponse] on success.
+  Future<PrepareRefundResponse> prepareRefund(PrepareRefundRequest req) async {
     try {
       _logger.info(
         'Preparing refund for swap ${req.swapAddress} to ${req.refundAddress} with fee ${req.feeRateSatPerVbyte}',
       );
-      final PrepareRefundResponse response = await prepareRefund(req: req);
+      final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
       _logger.info('Prepared refund response: $response');
       return response;
     } catch (e) {
@@ -167,7 +191,9 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
-  /// Broadcast a refund transaction for a failed/expired swap.
+  /// Broadcasts a refund transaction for a failed or expired swap.
+  ///
+  /// Emits the transaction ID upon success.
   Future<RefundResponse> refund({required RefundRequest req}) async {
     try {
       _logger.info(

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -23,14 +23,19 @@ class RefundCubit extends Cubit<RefundState> {
   }
 
   void _initializeRefundCubit() {
-    _breezSdkLiquid.getInfoResponseStream.first.then((_) => listRefundables());
+    _logger.info('Initializing Refund Cubit');
+    _breezSdkLiquid.getInfoResponseStream.first.then((_) => listRefundables()).catchError(
+      (Object e) {
+        _logger.severe('Failed to initialize Refund Cubit', e);
+      },
+    );
   }
 
   void listRefundables() async {
     try {
       _logger.info('Refreshing refundables');
       final List<RefundableSwap> refundables = await _breezSdkLiquid.instance!.listRefundables();
-      _logger.info('Refundables: $refundables');
+      _logger.info('Fetched refundables: $refundables');
       emit(state.copyWith(refundables: refundables));
     } catch (e) {
       _logger.severe('Failed to list refundables', e);
@@ -39,13 +44,15 @@ class RefundCubit extends Cubit<RefundState> {
   }
 
   void _listenRefundEvents() {
-    _logger.info('Listening to Refund events');
+    _logger.info('Listening to Refund-related events');
     _paymentEventSubscription = _breezSdkLiquid.paymentEventStream.listen(
       (PaymentEvent paymentEvent) {
+        _logger.info('Received payment event: $paymentEvent');
         if (paymentEvent.sdkEvent is SdkEvent_PaymentRefundable ||
             paymentEvent.sdkEvent is SdkEvent_PaymentRefundPending ||
             paymentEvent.sdkEvent is SdkEvent_PaymentRefunded ||
             (paymentEvent.sdkEvent is SdkEvent_PaymentFailed && state.hasRefundables)) {
+          _logger.info('Refund-related event detected. Refreshing refundables.');
           listRefundables();
         }
       },
@@ -59,14 +66,30 @@ class RefundCubit extends Cubit<RefundState> {
     return super.close();
   }
 
-  Future<RecommendedFees> recommendedFees() async {
-    return await _breezSdkLiquid.instance!.recommendedFees();
+  Future<RecommendedFees> _recommendedFees() async {
+    try {
+      _logger.info('Fetching recommended fees');
+      final RecommendedFees fees = await _breezSdkLiquid.instance!.recommendedFees();
+      _logger.info('Fetched recommended fees: $fees');
+      return fees;
+    } catch (e) {
+      _logger.severe('Failed to fetch recommended fees', e);
+      rethrow;
+    }
   }
 
   Future<PrepareRefundResponse> prepareRefund({
     required PrepareRefundRequest req,
   }) async {
-    return await _breezSdkLiquid.instance!.prepareRefund(req: req);
+    try {
+      _logger.info('Preparing refund for ${req.swapAddress} with fee ${req.feeRateSatPerVbyte}');
+      final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
+      _logger.info('Prepared refund response: $response');
+      return response;
+    } catch (e) {
+      _logger.severe('Failed to prepare refund', e);
+      rethrow;
+    }
   }
 
   /// Fetches the current recommended fees for a refund transaction.
@@ -75,13 +98,17 @@ class RefundCubit extends Cubit<RefundState> {
     required String swapAddress,
   }) async {
     try {
-      final RecommendedFees recommendedFees = await this.recommendedFees();
-      return await _constructFeeOptionList(
+      _logger.info('Fetching refund fee options for swapAddress: $swapAddress toAddress: $toAddress');
+      final RecommendedFees recommendedFees = await _recommendedFees();
+      final List<RefundFeeOption> feeOptions = await _constructFeeOptionList(
         toAddress: toAddress,
         swapAddress: swapAddress,
         recommendedFees: recommendedFees,
       );
+      _logger.info('Constructed fee options: $feeOptions');
+      return feeOptions;
     } catch (e) {
+      _logger.severe('Failed to fetch refund fee options', e);
       emit(RefundState(error: extractExceptionMessage(e, getSystemAppLocalizations())));
       rethrow;
     }
@@ -92,29 +119,38 @@ class RefundCubit extends Cubit<RefundState> {
     required String swapAddress,
     required RecommendedFees recommendedFees,
   }) async {
+    _logger.info('Constructing refund fee options for swapAddress: $swapAddress');
+
     final List<BigInt> recommendedFeeList = <BigInt>[
       recommendedFees.hourFee,
       recommendedFees.halfHourFee,
       recommendedFees.fastestFee,
     ];
-    final List<RefundFeeOption> feeOptions = await Future.wait(
-      List<Future<RefundFeeOption>>.generate(3, (int index) async {
-        final PrepareRefundRequest prepareRefundRequest = PrepareRefundRequest(
-          swapAddress: swapAddress,
-          feeRateSatPerVbyte: recommendedFeeList[index].toInt(),
-          refundAddress: toAddress,
-        );
-        final PrepareRefundResponse prepareRefundResponse = await _prepareRefund(prepareRefundRequest);
 
-        return RefundFeeOption(
-          processingSpeed: ProcessingSpeed.values[index],
-          feeRateSatPerVbyte: recommendedFeeList[index],
-          prepareRefundResponse: prepareRefundResponse,
-        );
-      }),
-    );
+    try {
+      final List<RefundFeeOption> feeOptions = await Future.wait(
+        List<Future<RefundFeeOption>>.generate(3, (int index) async {
+          final PrepareRefundRequest prepareRefundRequest = PrepareRefundRequest(
+            swapAddress: swapAddress,
+            feeRateSatPerVbyte: recommendedFeeList[index].toInt(),
+            refundAddress: toAddress,
+          );
+          final PrepareRefundResponse prepareRefundResponse = await _prepareRefund(prepareRefundRequest);
 
-    return feeOptions;
+          return RefundFeeOption(
+            processingSpeed: ProcessingSpeed.values[index],
+            feeRateSatPerVbyte: recommendedFeeList[index],
+            prepareRefundResponse: prepareRefundResponse,
+          );
+        }),
+      );
+
+      _logger.info('Successfully constructed refund fee options: $feeOptions');
+      return feeOptions;
+    } catch (e) {
+      _logger.severe('Failed to construct refund fee options', e);
+      rethrow;
+    }
   }
 
   Future<PrepareRefundResponse> _prepareRefund(PrepareRefundRequest req) async {
@@ -122,7 +158,9 @@ class RefundCubit extends Cubit<RefundState> {
       _logger.info(
         'Preparing refund for swap ${req.swapAddress} to ${req.refundAddress} with fee ${req.feeRateSatPerVbyte}',
       );
-      return await prepareRefund(req: req);
+      final PrepareRefundResponse response = await prepareRefund(req: req);
+      _logger.info('Prepared refund response: $response');
+      return response;
     } catch (e) {
       _logger.severe('Failed to prepare refund', e);
       rethrow;
@@ -136,7 +174,7 @@ class RefundCubit extends Cubit<RefundState> {
         'Refunding swap ${req.swapAddress} to ${req.refundAddress} with fee ${req.feeRateSatPerVbyte}',
       );
       final RefundResponse refundResponse = await _breezSdkLiquid.instance!.refund(req: req);
-      _logger.info('Refund txId: ${refundResponse.refundTxId}');
+      _logger.info('Refund succeeded. txId: ${refundResponse.refundTxId}');
       emit(state.copyWith(refundTxId: refundResponse.refundTxId, error: ''));
       return refundResponse;
     } catch (e) {

--- a/lib/cubit/refund/refund_state.dart
+++ b/lib/cubit/refund/refund_state.dart
@@ -27,3 +27,21 @@ class RefundState {
 
   bool get hasRefundables => refundables?.isNotEmpty ?? false;
 }
+
+/// Extension on [SdkEvent] to determine if the event is refund-related.
+extension RefundRelatedSdkEvent on SdkEvent {
+  /// Returns true if this event is related to a refund.
+  ///
+  /// For [SdkEvent_PaymentFailed], the [hasRefundables] flag must be true.
+  bool isRefundRelated({bool hasRefundables = false}) {
+    if (this is SdkEvent_PaymentRefundable ||
+        this is SdkEvent_PaymentRefundPending ||
+        this is SdkEvent_PaymentRefunded) {
+      return true;
+    }
+    if (this is SdkEvent_PaymentFailed && hasRefundables) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -187,3 +187,48 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
     );
   }
 }
+
+extension PaymentDetailsFormatter on PaymentDetails {
+  String toFormattedString() {
+    if (this is PaymentDetails_Lightning) {
+      final PaymentDetails_Lightning details = this as PaymentDetails_Lightning;
+      return 'PaymentDetails_Lightning('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight}, '
+          'preimage: ${details.preimage ?? "N/A"}, '
+          'invoice: ${details.invoice ?? "N/A"}, '
+          'bolt12Offer: ${details.bolt12Offer ?? "N/A"}, '
+          'paymentHash: ${details.paymentHash ?? "N/A"}, '
+          'destinationPubkey: ${details.destinationPubkey ?? "N/A"}, '
+          'lnurlInfo: ${details.lnurlInfo ?? "N/A"}, '
+          'bip353Address: ${details.bip353Address ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Liquid) {
+      final PaymentDetails_Liquid details = this as PaymentDetails_Liquid;
+      return 'PaymentDetails_Liquid('
+          'destination: ${details.destination}, '
+          'description: ${details.description}, '
+          'assetId: ${details.assetId}, '
+          'assetInfo: ${details.assetInfo ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Bitcoin) {
+      final PaymentDetails_Bitcoin details = this as PaymentDetails_Bitcoin;
+      return 'PaymentDetails_Bitcoin('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'autoAcceptedFees: ${details.autoAcceptedFees}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight ?? "N/A"}, '
+          'bitcoinExpirationBlockheight: ${details.bitcoinExpirationBlockheight ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else {
+      return 'Unknown PaymentDetails';
+    }
+  }
+}

--- a/lib/models/sdk_formatted_string_extensions.dart
+++ b/lib/models/sdk_formatted_string_extensions.dart
@@ -1,0 +1,84 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
+
+extension RefundableSwapFormatter on RefundableSwap {
+  String toFormattedString() => 'RefundableSwap('
+      'swapAddress: $swapAddress, '
+      'timestamp: $timestamp, '
+      'amountSat: $amountSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? "N/A"}'
+      ')';
+}
+
+extension RecommendedFeesFormatter on RecommendedFees {
+  String toFormattedString() => 'RecommendedFees('
+      'fastestFee: $fastestFee, '
+      'halfHourFee: $halfHourFee, '
+      'hourFee: $hourFee, '
+      'economyFee: $economyFee, '
+      'minimumFee: $minimumFee'
+      ')';
+}
+
+extension PaymentEventFormatter on PaymentEvent {
+  String toFormattedString() => 'PaymentEvent('
+      'sdkEvent: ${sdkEvent.toFormattedString()}, '
+      'payment: ${payment.toFormattedString()}'
+      ')';
+}
+
+extension SdkEventFormatter on SdkEvent {
+  String toFormattedString() {
+    if (this is SdkEvent_PaymentFailed) {
+      return 'PaymentFailed(details: ${(this as SdkEvent_PaymentFailed).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentPending) {
+      return 'PaymentPending(details: ${(this as SdkEvent_PaymentPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundable) {
+      return 'PaymentRefundable(details: ${(this as SdkEvent_PaymentRefundable).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefunded) {
+      return 'PaymentRefunded(details: ${(this as SdkEvent_PaymentRefunded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundPending) {
+      return 'PaymentRefundPending(details: ${(this as SdkEvent_PaymentRefundPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentSucceeded) {
+      return 'PaymentSucceeded(details: ${(this as SdkEvent_PaymentSucceeded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingConfirmation) {
+      return 'PaymentWaitingConfirmation(details: ${(this as SdkEvent_PaymentWaitingConfirmation).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingFeeAcceptance) {
+      return 'PaymentWaitingFeeAcceptance(details: ${(this as SdkEvent_PaymentWaitingFeeAcceptance).details.toFormattedString()})';
+    } else if (this is SdkEvent_Synced) {
+      return 'Synced';
+    } else {
+      return 'Unknown SdkEvent';
+    }
+  }
+}
+
+extension PaymentFormatter on Payment {
+  String toFormattedString() => 'Payment('
+      'destination: ${destination ?? "N/A"}, '
+      'txId: ${txId ?? "N/A"}, '
+      'amountSat: $amountSat, '
+      'feesSat: $feesSat, '
+      'swapperFeesSat: ${swapperFeesSat ?? "N/A"}, '
+      'paymentType: $paymentType, '
+      'status: $status'
+      'details: ${details.toFormattedString()}'
+      ')';
+}
+
+extension PreparePayOnchainResponseFormatted on PreparePayOnchainResponse {
+  String toFormattedString() => 'PreparePayOnchainResponse('
+      'receiverAmountSat: $receiverAmountSat, '
+      'claimFeesSat: $claimFeesSat, '
+      'totalFeesSat: $totalFeesSat'
+      ')';
+}
+
+extension PrepareRefundResponseFormatted on PrepareRefundResponse {
+  String toFormattedString() => 'PrepareRefundResponse('
+      'txVsize: $txVsize, '
+      'txFeeSat: $txFeeSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? 'N/A'} '
+      ')';
+}

--- a/lib/routes/refund/refund_confirmation_page.dart
+++ b/lib/routes/refund/refund_confirmation_page.dart
@@ -104,17 +104,27 @@ class RefundConfirmationState extends State<RefundConfirmationPage> {
       toAddress: widget.toAddress,
       swapAddress: widget.swapAddress,
     );
-    _fetchFeeOptionsFuture.then((List<RefundFeeOption> feeOptions) {
-      setState(() {
-        affordableFees = feeOptions
-            .where(
-              (RefundFeeOption f) =>
-                  f.isAffordable(amountSat: widget.amountSat, balanceSat: widget.amountSat),
-            )
-            .toList();
-        selectedFeeIndex = (affordableFees.length / 2).floor();
-      });
-    });
+    _fetchFeeOptionsFuture.then(
+      (List<RefundFeeOption> feeOptions) {
+        setState(() {
+          affordableFees = feeOptions
+              .where(
+                (RefundFeeOption f) => f.isAffordable(
+                  balanceSat: widget.amountSat,
+                  amountSat: widget.amountSat,
+                ),
+              )
+              .toList();
+          selectedFeeIndex = (affordableFees.length / 2).floor();
+        });
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        setState(() {
+          affordableFees = <RefundFeeOption>[];
+          selectedFeeIndex = -1;
+        });
+      },
+    );
   }
 }
 

--- a/lib/routes/refund/refund_confirmation_page.dart
+++ b/lib/routes/refund/refund_confirmation_page.dart
@@ -108,7 +108,8 @@ class RefundConfirmationState extends State<RefundConfirmationPage> {
       setState(() {
         affordableFees = feeOptions
             .where(
-              (RefundFeeOption f) => f.isAffordable(amountSat: widget.amountSat),
+              (RefundFeeOption f) =>
+                  f.isAffordable(amountSat: widget.amountSat, balanceSat: widget.amountSat),
             )
             .toList();
         selectedFeeIndex = (affordableFees.length / 2).floor();

--- a/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
@@ -110,6 +110,7 @@ class _SendChainSwapConfirmationPageState extends State<SendChainSwapConfirmatio
       onError: (Object error, StackTrace stackTrace) {
         setState(() {
           affordableFees = <SendChainSwapFeeOption>[];
+          selectedFeeIndex = -1;
         });
       },
     );


### PR DESCRIPTION
This PR:
- Uses the refundable amount to validate if affordable
- Updates the refundables list when we have refundables and receive a PaymentFailed event (happens after PaymentRefundPending when the refund is confirmed)

**Testing notes:**
- Should correctly validate if the calculated fees are within the refund amount
- Should remove the "Get Refund" option once the refund is confirmed