### PR TITLE
Refactor `RefundCubit`

### DIFF
--- a/lib/cubit/model/src/fee_option/fee_option.dart
+++ b/lib/cubit/model/src/fee_option/fee_option.dart
@@ -1,5 +1,6 @@
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 
 enum ProcessingSpeed {
   economy(Duration(minutes: 60)),
@@ -48,6 +49,15 @@ class SendChainSwapFeeOption extends FeeOption {
 
     return preparePayOnchainResponse.isAffordable(balance: balanceSat!);
   }
+
+  @override
+  String toString() {
+    return 'SendChainSwapFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${preparePayOnchainResponse.toFormattedString()}'
+        ')';
+  }
 }
 
 extension PreparePayOnchainResponseAffordable on PreparePayOnchainResponse {
@@ -70,6 +80,15 @@ class RefundFeeOption extends FeeOption {
     assert(balanceSat != null, 'Balance amount must be provided.');
 
     return prepareRefundResponse.isAffordable(balance: balanceSat!);
+  }
+
+  @override
+  String toString() {
+    return 'RefundFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${prepareRefundResponse.toFormattedString}'
+        ')';
   }
 }
 

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -48,10 +48,7 @@ class RefundCubit extends Cubit<RefundState> {
     _paymentEventSubscription = _breezSdkLiquid.paymentEventStream.listen(
       (PaymentEvent paymentEvent) {
         _logger.info('Received payment event: $paymentEvent');
-        if (paymentEvent.sdkEvent is SdkEvent_PaymentRefundable ||
-            paymentEvent.sdkEvent is SdkEvent_PaymentRefundPending ||
-            paymentEvent.sdkEvent is SdkEvent_PaymentRefunded ||
-            (paymentEvent.sdkEvent is SdkEvent_PaymentFailed && state.hasRefundables)) {
+        if (paymentEvent.sdkEvent.isRefundRelated(hasRefundables: state.hasRefundables)) {
           _logger.info('Refund-related event detected. Refreshing refundables.');
           listRefundables();
         }

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -27,11 +27,13 @@ class RefundCubit extends Cubit<RefundState> {
   /// fetching the current list of refundables.
   Future<void> _initializeRefundCubit() async {
     _logger.info('Initializing Refund Cubit');
-    _breezSdkLiquid.getInfoResponseStream.first.then((_) => listRefundables()).catchError(
-      (Object e) {
-        _logger.severe('Failed to initialize Refund Cubit', e);
-      },
-    );
+    try {
+      await _breezSdkLiquid.getInfoResponseStream.first;
+      // Fire-and-forget the list refresh.
+      listRefundables();
+    } catch (e) {
+      _logger.severe('Failed to initialize Refund Cubit', e);
+    }
   }
 
   /// Retrieves refundables from the SDK and emits the updated state.

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -78,20 +78,6 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
-  Future<PrepareRefundResponse> prepareRefund({
-    required PrepareRefundRequest req,
-  }) async {
-    try {
-      _logger.info('Preparing refund for ${req.swapAddress} with fee ${req.feeRateSatPerVbyte}');
-      final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
-      _logger.info('Prepared refund response: $response');
-      return response;
-    } catch (e) {
-      _logger.severe('Failed to prepare refund', e);
-      rethrow;
-    }
-  }
-
   /// Fetches the current recommended fees for a refund transaction.
   Future<List<RefundFeeOption>> fetchRefundFeeOptions({
     required String toAddress,
@@ -135,7 +121,7 @@ class RefundCubit extends Cubit<RefundState> {
             feeRateSatPerVbyte: recommendedFeeList[index].toInt(),
             refundAddress: toAddress,
           );
-          final PrepareRefundResponse prepareRefundResponse = await _prepareRefund(prepareRefundRequest);
+          final PrepareRefundResponse prepareRefundResponse = await prepareRefund(prepareRefundRequest);
 
           return RefundFeeOption(
             processingSpeed: ProcessingSpeed.values[index],
@@ -153,12 +139,12 @@ class RefundCubit extends Cubit<RefundState> {
     }
   }
 
-  Future<PrepareRefundResponse> _prepareRefund(PrepareRefundRequest req) async {
+  Future<PrepareRefundResponse> prepareRefund(PrepareRefundRequest req) async {
     try {
       _logger.info(
         'Preparing refund for swap ${req.swapAddress} to ${req.refundAddress} with fee ${req.feeRateSatPerVbyte}',
       );
-      final PrepareRefundResponse response = await prepareRefund(req: req);
+      final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
       _logger.info('Prepared refund response: $response');
       return response;
     } catch (e) {

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -5,6 +5,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:logging/logging.dart';
 
@@ -41,7 +42,9 @@ class RefundCubit extends Cubit<RefundState> {
     try {
       _logger.info('Refreshing refundables');
       final List<RefundableSwap> refundables = await _breezSdkLiquid.instance!.listRefundables();
-      _logger.info('Fetched refundables: $refundables');
+      _logger.info(
+        'Fetched refundables: ${refundables.map((RefundableSwap r) => r.toFormattedString()).toList()}',
+      );
       emit(state.copyWith(refundables: refundables));
     } catch (e) {
       _logger.severe('Failed to list refundables', e);
@@ -55,7 +58,7 @@ class RefundCubit extends Cubit<RefundState> {
     _logger.info('Listening to refund-related events');
     _paymentEventSubscription = _breezSdkLiquid.paymentEventStream.listen(
       (PaymentEvent paymentEvent) {
-        _logger.info('Received payment event: $paymentEvent');
+        _logger.info('Received payment event: ${paymentEvent.toFormattedString()}');
         if (paymentEvent.sdkEvent.isRefundRelated(hasRefundables: state.hasRefundables)) {
           _logger.info('Refund-related event detected. Refreshing refundables.');
           listRefundables();
@@ -76,7 +79,7 @@ class RefundCubit extends Cubit<RefundState> {
     try {
       _logger.info('Fetching recommended fees');
       final RecommendedFees fees = await _breezSdkLiquid.instance!.recommendedFees();
-      _logger.info('Fetched recommended fees: $fees');
+      _logger.info('Fetched recommended fees: ${fees.toFormattedString()}');
       return fees;
     } catch (e) {
       _logger.severe('Failed to fetch recommended fees', e);

--- a/lib/cubit/refund/refund_state.dart
+++ b/lib/cubit/refund/refund_state.dart
@@ -28,8 +28,9 @@ class RefundState {
   bool get hasRefundables => refundables?.isNotEmpty ?? false;
 }
 
+/// Extension on [SdkEvent] to determine if the event is refund-related.
 extension RefundRelatedSdkEvent on SdkEvent {
-  /// Returns true if the event is related to a refund.
+  /// Returns true if this event is related to a refund.
   ///
   /// For [SdkEvent_PaymentFailed], the [hasRefundables] flag must be true.
   bool isRefundRelated({bool hasRefundables = false}) {

--- a/lib/cubit/refund/refund_state.dart
+++ b/lib/cubit/refund/refund_state.dart
@@ -27,3 +27,20 @@ class RefundState {
 
   bool get hasRefundables => refundables?.isNotEmpty ?? false;
 }
+
+extension RefundRelatedSdkEvent on SdkEvent {
+  /// Returns true if the event is related to a refund.
+  ///
+  /// For [SdkEvent_PaymentFailed], the [hasRefundables] flag must be true.
+  bool isRefundRelated({bool hasRefundables = false}) {
+    if (this is SdkEvent_PaymentRefundable ||
+        this is SdkEvent_PaymentRefundPending ||
+        this is SdkEvent_PaymentRefunded) {
+      return true;
+    }
+    if (this is SdkEvent_PaymentFailed && hasRefundables) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -187,3 +187,48 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
     );
   }
 }
+
+extension PaymentDetailsFormatter on PaymentDetails {
+  String toFormattedString() {
+    if (this is PaymentDetails_Lightning) {
+      final PaymentDetails_Lightning details = this as PaymentDetails_Lightning;
+      return 'PaymentDetails_Lightning('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight}, '
+          'preimage: ${details.preimage ?? "N/A"}, '
+          'invoice: ${details.invoice ?? "N/A"}, '
+          'bolt12Offer: ${details.bolt12Offer ?? "N/A"}, '
+          'paymentHash: ${details.paymentHash ?? "N/A"}, '
+          'destinationPubkey: ${details.destinationPubkey ?? "N/A"}, '
+          'lnurlInfo: ${details.lnurlInfo ?? "N/A"}, '
+          'bip353Address: ${details.bip353Address ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Liquid) {
+      final PaymentDetails_Liquid details = this as PaymentDetails_Liquid;
+      return 'PaymentDetails_Liquid('
+          'destination: ${details.destination}, '
+          'description: ${details.description}, '
+          'assetId: ${details.assetId}, '
+          'assetInfo: ${details.assetInfo ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Bitcoin) {
+      final PaymentDetails_Bitcoin details = this as PaymentDetails_Bitcoin;
+      return 'PaymentDetails_Bitcoin('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'autoAcceptedFees: ${details.autoAcceptedFees}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight ?? "N/A"}, '
+          'bitcoinExpirationBlockheight: ${details.bitcoinExpirationBlockheight ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else {
+      return 'Unknown PaymentDetails';
+    }
+  }
+}

--- a/lib/models/sdk_formatted_string_extensions.dart
+++ b/lib/models/sdk_formatted_string_extensions.dart
@@ -1,0 +1,84 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
+
+extension RefundableSwapFormatter on RefundableSwap {
+  String toFormattedString() => 'RefundableSwap('
+      'swapAddress: $swapAddress, '
+      'timestamp: $timestamp, '
+      'amountSat: $amountSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? "N/A"}'
+      ')';
+}
+
+extension RecommendedFeesFormatter on RecommendedFees {
+  String toFormattedString() => 'RecommendedFees('
+      'fastestFee: $fastestFee, '
+      'halfHourFee: $halfHourFee, '
+      'hourFee: $hourFee, '
+      'economyFee: $economyFee, '
+      'minimumFee: $minimumFee'
+      ')';
+}
+
+extension PaymentEventFormatter on PaymentEvent {
+  String toFormattedString() => 'PaymentEvent('
+      'sdkEvent: ${sdkEvent.toFormattedString()}, '
+      'payment: ${payment.toFormattedString()}'
+      ')';
+}
+
+extension SdkEventFormatter on SdkEvent {
+  String toFormattedString() {
+    if (this is SdkEvent_PaymentFailed) {
+      return 'PaymentFailed(details: ${(this as SdkEvent_PaymentFailed).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentPending) {
+      return 'PaymentPending(details: ${(this as SdkEvent_PaymentPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundable) {
+      return 'PaymentRefundable(details: ${(this as SdkEvent_PaymentRefundable).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefunded) {
+      return 'PaymentRefunded(details: ${(this as SdkEvent_PaymentRefunded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundPending) {
+      return 'PaymentRefundPending(details: ${(this as SdkEvent_PaymentRefundPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentSucceeded) {
+      return 'PaymentSucceeded(details: ${(this as SdkEvent_PaymentSucceeded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingConfirmation) {
+      return 'PaymentWaitingConfirmation(details: ${(this as SdkEvent_PaymentWaitingConfirmation).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingFeeAcceptance) {
+      return 'PaymentWaitingFeeAcceptance(details: ${(this as SdkEvent_PaymentWaitingFeeAcceptance).details.toFormattedString()})';
+    } else if (this is SdkEvent_Synced) {
+      return 'Synced';
+    } else {
+      return 'Unknown SdkEvent';
+    }
+  }
+}
+
+extension PaymentFormatter on Payment {
+  String toFormattedString() => 'Payment('
+      'destination: ${destination ?? "N/A"}, '
+      'txId: ${txId ?? "N/A"}, '
+      'amountSat: $amountSat, '
+      'feesSat: $feesSat, '
+      'swapperFeesSat: ${swapperFeesSat ?? "N/A"}, '
+      'paymentType: $paymentType, '
+      'status: $status'
+      'details: ${details.toFormattedString()}'
+      ')';
+}
+
+extension PreparePayOnchainResponseFormatted on PreparePayOnchainResponse {
+  String toFormattedString() => 'PreparePayOnchainResponse('
+      'receiverAmountSat: $receiverAmountSat, '
+      'claimFeesSat: $claimFeesSat, '
+      'totalFeesSat: $totalFeesSat'
+      ')';
+}
+
+extension PrepareRefundResponseFormatted on PrepareRefundResponse {
+  String toFormattedString() => 'PrepareRefundResponse('
+      'txVsize: $txVsize, '
+      'txFeeSat: $txFeeSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? 'N/A'} '
+      ')';
+}

--- a/lib/routes/refund/refund_confirmation_page.dart
+++ b/lib/routes/refund/refund_confirmation_page.dart
@@ -104,17 +104,27 @@ class RefundConfirmationState extends State<RefundConfirmationPage> {
       toAddress: widget.toAddress,
       swapAddress: widget.swapAddress,
     );
-    _fetchFeeOptionsFuture.then((List<RefundFeeOption> feeOptions) {
-      setState(() {
-        affordableFees = feeOptions
-            .where(
-              (RefundFeeOption f) =>
-                  f.isAffordable(amountSat: widget.amountSat, balanceSat: widget.amountSat),
-            )
-            .toList();
-        selectedFeeIndex = (affordableFees.length / 2).floor();
-      });
-    });
+    _fetchFeeOptionsFuture.then(
+      (List<RefundFeeOption> feeOptions) {
+        setState(() {
+          affordableFees = feeOptions
+              .where(
+                (RefundFeeOption f) => f.isAffordable(
+                  balanceSat: widget.amountSat,
+                  amountSat: widget.amountSat,
+                ),
+              )
+              .toList();
+          selectedFeeIndex = (affordableFees.length / 2).floor();
+        });
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        setState(() {
+          affordableFees = <RefundFeeOption>[];
+          selectedFeeIndex = -1;
+        });
+      },
+    );
   }
 }
 

--- a/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
@@ -110,6 +110,7 @@ class _SendChainSwapConfirmationPageState extends State<SendChainSwapConfirmatio
       onError: (Object error, StackTrace stackTrace) {
         setState(() {
           affordableFees = <SendChainSwapFeeOption>[];
+          selectedFeeIndex = -1;
         });
       },
     );


### PR DESCRIPTION
This PR is a continuation of
- #366 

### Changelist:
- Added missing documentation 4605165
- Added extension on SdkEvent to identify refund-related events 7dde924
- Replaced list-based fee mapping with processingSpeedFeeMap for clarity and extensibility. 88fe726
- Extracted `_prepareRefund` & `_createRefundFeeOption` to reduce duplication and improve structure. d7d0a15 & 88fe726

Now that we're in a more stable state (both app layer & SDK), I plan to make similar changes to help new contributors understand and modify the code more easily. Expect follow-up PRs such as this in the future.