### PR TITLE
Add missing `toString` methods for SDK objects mainly used on `RefundCubit`

### DIFF
--- a/lib/cubit/model/src/fee_option/fee_option.dart
+++ b/lib/cubit/model/src/fee_option/fee_option.dart
@@ -1,5 +1,6 @@
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 
 enum ProcessingSpeed {
   economy(Duration(minutes: 60)),
@@ -48,6 +49,15 @@ class SendChainSwapFeeOption extends FeeOption {
 
     return preparePayOnchainResponse.isAffordable(balance: balanceSat!);
   }
+
+  @override
+  String toString() {
+    return 'SendChainSwapFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${preparePayOnchainResponse.toFormattedString()}'
+        ')';
+  }
 }
 
 extension PreparePayOnchainResponseAffordable on PreparePayOnchainResponse {
@@ -70,6 +80,15 @@ class RefundFeeOption extends FeeOption {
     assert(balanceSat != null, 'Balance amount must be provided.');
 
     return prepareRefundResponse.isAffordable(balance: balanceSat!);
+  }
+
+  @override
+  String toString() {
+    return 'RefundFeeOption('
+        'processingSpeed: $processingSpeed, '
+        'feeRateSatPerVbyte: $feeRateSatPerVbyte, '
+        'prepareRefundResponse: ${prepareRefundResponse.toFormattedString}'
+        ')';
   }
 }
 

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -5,6 +5,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:logging/logging.dart';
 
@@ -41,7 +42,9 @@ class RefundCubit extends Cubit<RefundState> {
     try {
       _logger.info('Refreshing refundables');
       final List<RefundableSwap> refundables = await _breezSdkLiquid.instance!.listRefundables();
-      _logger.info('Fetched refundables: $refundables');
+      _logger.info(
+        'Fetched refundables: ${refundables.map((RefundableSwap r) => r.toFormattedString()).toList()}',
+      );
       emit(state.copyWith(refundables: refundables));
     } catch (e) {
       _logger.severe('Failed to list refundables', e);
@@ -55,7 +58,7 @@ class RefundCubit extends Cubit<RefundState> {
     _logger.info('Listening to refund-related events');
     _paymentEventSubscription = _breezSdkLiquid.paymentEventStream.listen(
       (PaymentEvent paymentEvent) {
-        _logger.info('Received payment event: $paymentEvent');
+        _logger.info('Received payment event: ${paymentEvent.toFormattedString()}');
         if (paymentEvent.sdkEvent.isRefundRelated(hasRefundables: state.hasRefundables)) {
           _logger.info('Refund-related event detected. Refreshing refundables.');
           listRefundables();
@@ -76,7 +79,7 @@ class RefundCubit extends Cubit<RefundState> {
     try {
       _logger.info('Fetching recommended fees');
       final RecommendedFees fees = await _breezSdkLiquid.instance!.recommendedFees();
-      _logger.info('Fetched recommended fees: $fees');
+      _logger.info('Fetched recommended fees: ${fees.toFormattedString()}');
       return fees;
     } catch (e) {
       _logger.severe('Failed to fetch recommended fees', e);

--- a/lib/models/payment_details_extension.dart
+++ b/lib/models/payment_details_extension.dart
@@ -187,3 +187,48 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
     );
   }
 }
+
+extension PaymentDetailsFormatter on PaymentDetails {
+  String toFormattedString() {
+    if (this is PaymentDetails_Lightning) {
+      final PaymentDetails_Lightning details = this as PaymentDetails_Lightning;
+      return 'PaymentDetails_Lightning('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight}, '
+          'preimage: ${details.preimage ?? "N/A"}, '
+          'invoice: ${details.invoice ?? "N/A"}, '
+          'bolt12Offer: ${details.bolt12Offer ?? "N/A"}, '
+          'paymentHash: ${details.paymentHash ?? "N/A"}, '
+          'destinationPubkey: ${details.destinationPubkey ?? "N/A"}, '
+          'lnurlInfo: ${details.lnurlInfo ?? "N/A"}, '
+          'bip353Address: ${details.bip353Address ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Liquid) {
+      final PaymentDetails_Liquid details = this as PaymentDetails_Liquid;
+      return 'PaymentDetails_Liquid('
+          'destination: ${details.destination}, '
+          'description: ${details.description}, '
+          'assetId: ${details.assetId}, '
+          'assetInfo: ${details.assetInfo ?? "N/A"}'
+          ')';
+    } else if (this is PaymentDetails_Bitcoin) {
+      final PaymentDetails_Bitcoin details = this as PaymentDetails_Bitcoin;
+      return 'PaymentDetails_Bitcoin('
+          'swapId: ${details.swapId}, '
+          'description: ${details.description}, '
+          'autoAcceptedFees: ${details.autoAcceptedFees}, '
+          'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight ?? "N/A"}, '
+          'bitcoinExpirationBlockheight: ${details.bitcoinExpirationBlockheight ?? "N/A"}, '
+          'claimTxId: ${details.claimTxId ?? "N/A"}, '
+          'refundTxId: ${details.refundTxId ?? "N/A"}, '
+          'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
+          ')';
+    } else {
+      return 'Unknown PaymentDetails';
+    }
+  }
+}

--- a/lib/models/sdk_formatted_string_extensions.dart
+++ b/lib/models/sdk_formatted_string_extensions.dart
@@ -1,0 +1,84 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:l_breez/models/payment_details_extension.dart';
+
+extension RefundableSwapFormatter on RefundableSwap {
+  String toFormattedString() => 'RefundableSwap('
+      'swapAddress: $swapAddress, '
+      'timestamp: $timestamp, '
+      'amountSat: $amountSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? "N/A"}'
+      ')';
+}
+
+extension RecommendedFeesFormatter on RecommendedFees {
+  String toFormattedString() => 'RecommendedFees('
+      'fastestFee: $fastestFee, '
+      'halfHourFee: $halfHourFee, '
+      'hourFee: $hourFee, '
+      'economyFee: $economyFee, '
+      'minimumFee: $minimumFee'
+      ')';
+}
+
+extension PaymentEventFormatter on PaymentEvent {
+  String toFormattedString() => 'PaymentEvent('
+      'sdkEvent: ${sdkEvent.toFormattedString()}, '
+      'payment: ${payment.toFormattedString()}'
+      ')';
+}
+
+extension SdkEventFormatter on SdkEvent {
+  String toFormattedString() {
+    if (this is SdkEvent_PaymentFailed) {
+      return 'PaymentFailed(details: ${(this as SdkEvent_PaymentFailed).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentPending) {
+      return 'PaymentPending(details: ${(this as SdkEvent_PaymentPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundable) {
+      return 'PaymentRefundable(details: ${(this as SdkEvent_PaymentRefundable).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefunded) {
+      return 'PaymentRefunded(details: ${(this as SdkEvent_PaymentRefunded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentRefundPending) {
+      return 'PaymentRefundPending(details: ${(this as SdkEvent_PaymentRefundPending).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentSucceeded) {
+      return 'PaymentSucceeded(details: ${(this as SdkEvent_PaymentSucceeded).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingConfirmation) {
+      return 'PaymentWaitingConfirmation(details: ${(this as SdkEvent_PaymentWaitingConfirmation).details.toFormattedString()})';
+    } else if (this is SdkEvent_PaymentWaitingFeeAcceptance) {
+      return 'PaymentWaitingFeeAcceptance(details: ${(this as SdkEvent_PaymentWaitingFeeAcceptance).details.toFormattedString()})';
+    } else if (this is SdkEvent_Synced) {
+      return 'Synced';
+    } else {
+      return 'Unknown SdkEvent';
+    }
+  }
+}
+
+extension PaymentFormatter on Payment {
+  String toFormattedString() => 'Payment('
+      'destination: ${destination ?? "N/A"}, '
+      'txId: ${txId ?? "N/A"}, '
+      'amountSat: $amountSat, '
+      'feesSat: $feesSat, '
+      'swapperFeesSat: ${swapperFeesSat ?? "N/A"}, '
+      'paymentType: $paymentType, '
+      'status: $status'
+      'details: ${details.toFormattedString()}'
+      ')';
+}
+
+extension PreparePayOnchainResponseFormatted on PreparePayOnchainResponse {
+  String toFormattedString() => 'PreparePayOnchainResponse('
+      'receiverAmountSat: $receiverAmountSat, '
+      'claimFeesSat: $claimFeesSat, '
+      'totalFeesSat: $totalFeesSat'
+      ')';
+}
+
+extension PrepareRefundResponseFormatted on PrepareRefundResponse {
+  String toFormattedString() => 'PrepareRefundResponse('
+      'txVsize: $txVsize, '
+      'txFeeSat: $txFeeSat, '
+      'lastRefundTxId: ${lastRefundTxId ?? 'N/A'} '
+      ')';
+}


### PR DESCRIPTION
This PR is a continuation of https://github.com/breez/misty-breez/pull/357 in our efforts to not miss important data on log statements & increase their readability.

Ideally, we should look into our options on how to handle this on the SDK side.