### PR TITLE
User LN Address or domain information on payment titles

### DIFF
--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -145,12 +145,12 @@ class _PaymentDataFactory {
 
     final String lnAddress = lnurlInfo?.lnAddress ?? '';
     if (lnAddress.isNotEmpty) {
-      return (_payment.paymentType == PaymentType.send ? 'Pay to ' : 'Payment from ') + lnAddress;
+      return (_payment.paymentType == PaymentType.send ? 'Payment to ' : 'Payment from ') + lnAddress;
     }
 
     final String lnurlPayDomain = lnurlInfo?.lnurlPayDomain ?? '';
     if (lnurlPayDomain.isNotEmpty) {
-      return (_payment.paymentType == PaymentType.send ? 'Pay to ' : 'Payment from ') + lnurlPayDomain;
+      return (_payment.paymentType == PaymentType.send ? 'Payment to ' : 'Payment from ') + lnurlPayDomain;
     }
 
     final String description = _payment.details.map(
@@ -159,7 +159,7 @@ class _PaymentDataFactory {
       liquid: (PaymentDetails_Liquid details) => details.description,
       orElse: () => '',
     );
-    if (description.isNotEmpty && !description.containsLiquidNaming) {
+    if (description.isNotEmpty && !description.isDefaultDescription) {
       return description;
     }
 

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -144,10 +144,15 @@ class _PaymentDataFactory {
     );
 
     final String lnAddress = lnurlInfo?.lnAddress ?? '';
-
     if (lnAddress.isNotEmpty) {
-      return lnAddress;
+      return (_payment.paymentType == PaymentType.send ? 'Pay to ' : 'Payment from ') + lnAddress;
     }
+
+    final String lnurlPayDomain = lnurlInfo?.lnurlPayDomain ?? '';
+    if (lnurlPayDomain.isNotEmpty) {
+      return (_payment.paymentType == PaymentType.send ? 'Pay to ' : 'Payment from ') + lnurlPayDomain;
+    }
+
     final String description = _payment.details.map(
       lightning: (PaymentDetails_Lightning details) => details.description,
       bitcoin: (PaymentDetails_Bitcoin details) => details.description,

--- a/lib/utils/extensions/payment_title_extension.dart
+++ b/lib/utils/extensions/payment_title_extension.dart
@@ -1,6 +1,6 @@
 extension PaymentTitleExtension on String {
   // TODO(erdemyerebasmaz): Remove once default descriptions from the SDK is removed
-  bool get containsLiquidNaming {
-    return contains('Send to L-BTC address') || contains('Liquid transfer');
+  bool get isDefaultDescription {
+    return this == 'Send to L-BTC address' || this == 'Liquid transfer' || this == 'Lightning payment';
   }
 }

--- a/packages/breez_preferences/lib/src/breez_preferences.dart
+++ b/packages/breez_preferences/lib/src/breez_preferences.dart
@@ -1,5 +1,7 @@
 import 'package:breez_preferences/src/model/bug_report_behavior.dart';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:shared_preference_app_group/shared_preference_app_group.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final Logger _logger = Logger('BreezPreferences');
@@ -30,6 +32,9 @@ class BreezPreferences {
     _logger.info('Setting BugReportBehavior: $behavior');
     final SharedPreferences prefs = await _preferences;
     await prefs.setInt(_kBugReportBehavior, behavior.index);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setInt(_kBugReportBehavior, behavior.index);
+    }
   }
 
   // Default Profile Name
@@ -45,6 +50,9 @@ class BreezPreferences {
     _logger.info('Setting Default Profile Name: $defaultProfileName');
     final SharedPreferences prefs = await _preferences;
     await prefs.setString(_kDefaultProfileName, defaultProfileName);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setString(_kDefaultProfileName, _kDefaultProfileName);
+    }
   }
 
   // Webhook URL
@@ -56,16 +64,22 @@ class BreezPreferences {
     return url;
   }
 
-  Future<void> setWebhookUrl(String url) async {
-    _logger.info('Setting Webhook URL: $url');
+  Future<void> setWebhookUrl(String webhookUrl) async {
+    _logger.info('Setting Webhook URL: $webhookUrl');
     final SharedPreferences prefs = await _preferences;
-    await prefs.setString(_kWebhookUrl, url);
+    await prefs.setString(_kWebhookUrl, webhookUrl);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setString(_kWebhookUrl, webhookUrl);
+    }
   }
 
   Future<void> removeWebhookUrl() async {
     _logger.info('Removing Webhook URL');
     final SharedPreferences prefs = await _preferences;
     await prefs.remove(_kWebhookUrl);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.remove(_kWebhookUrl);
+    }
   }
 
   // LN URL Webhook Registration
@@ -81,6 +95,9 @@ class BreezPreferences {
     _logger.info('Setting LNURL Webhook as Registered');
     final SharedPreferences prefs = await _preferences;
     await prefs.setBool(_kLnUrlWebhookRegistered, true);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setBool(_kLnUrlWebhookRegistered, true);
+    }
   }
 
   // LN Address Username
@@ -92,9 +109,12 @@ class BreezPreferences {
     return username;
   }
 
-  Future<void> setLnAddressUsername(String username) async {
-    _logger.info('Setting LN Address Username: $username');
+  Future<void> setLnAddressUsername(String lnAddressUsername) async {
+    _logger.info('Setting LN Address Username: $lnAddressUsername');
     final SharedPreferences prefs = await _preferences;
-    await prefs.setString(_kLnAddressUsername, username);
+    await prefs.setString(_kLnAddressUsername, lnAddressUsername);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setString(_kLnAddressUsername, lnAddressUsername);
+    }
   }
 }


### PR DESCRIPTION
- Utilize LN address or domain on payment titles
  - Does not cover payments handled by notification extension
- Save `BreezPreferences` values to `AppGroup` `SharedPreferences` on iOS 
  - Preliminary work to utilize LN Address username as payment description by notification extension
- Add "Lightning payment" to default descriptions