### PR TITLE
Improve Payment Title and LNURLp Metadata Handling

### DIFF
--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -150,7 +150,7 @@ class _PaymentDataFactory {
         '';
 
     if (bip353Address.isNotEmpty) {
-      return (_payment.paymentType == PaymentType.send ? 'Payment to ' : 'Payment from ') + bip353Address;
+      return bip353Address;
     }
 
     final LnUrlInfo? lnurlInfo = _payment.details.map(

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -134,6 +134,11 @@ class PaymentData {
   bool get isRefunded => refundTxAmountSat > 0 && status == PaymentState.failed;
 
   int get actualFeeSat => isRefunded ? amountSat - refundTxAmountSat : feeSat;
+
+  String? get lnurlMetadataImage {
+    final Map<String, dynamic> metadataMap = getLnurlPayMetadata(details);
+    return metadataMap['image/png;base64'] ?? metadataMap['image/jpeg;base64'];
+  }
 }
 
 class _PaymentDataFactory {

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -158,14 +158,21 @@ class _PaymentDataFactory {
       orElse: () => null,
     );
 
-    final String lnAddress = lnurlInfo?.lnAddress ?? '';
-    if (lnAddress.isNotEmpty) {
-      return (_payment.paymentType == PaymentType.send ? 'Payment to ' : 'Payment from ') + lnAddress;
+    String? lnUrlTitle;
+    if (lnurlInfo != null) {
+      final Map<String, dynamic> metadataMap = getLnurlPayMetadata(_payment.details);
+
+      lnUrlTitle = lnurlInfo.lnAddress?.isNotEmpty == true
+          ? lnurlInfo.lnAddress
+          : metadataMap.isNotEmpty
+              ? metadataMap['text/identifier'] ?? metadataMap['text/email']
+              : lnurlInfo.lnurlPayDomain?.isNotEmpty == true
+                  ? lnurlInfo.lnurlPayDomain
+                  : null;
     }
 
-    final String lnurlPayDomain = lnurlInfo?.lnurlPayDomain ?? '';
-    if (lnurlPayDomain.isNotEmpty) {
-      return (_payment.paymentType == PaymentType.send ? 'Payment to ' : 'Payment from ') + lnurlPayDomain;
+    if (lnUrlTitle != null && lnUrlTitle.isNotEmpty) {
+      return lnUrlTitle;
     }
 
     final String description = _description();
@@ -177,15 +184,56 @@ class _PaymentDataFactory {
   }
 
   String _description() {
+    final String? description = _getDescriptionFromDetails();
+    return _getLnurlDescription() ?? description ?? '';
+  }
+
+  String? _getDescriptionFromDetails() {
     return _payment.details.map(
       lightning: (PaymentDetails_Lightning details) => details.description,
       bitcoin: (PaymentDetails_Bitcoin details) => details.description,
       liquid: (PaymentDetails_Liquid details) => details.description,
-      orElse: () => '',
+      orElse: () => null,
     );
+  }
+
+  String? _getLnurlDescription() {
+    final Map<String, dynamic> metadataMap = getLnurlPayMetadata(_payment.details);
+    return metadataMap['text/long-desc'] ?? metadataMap['text/plain'];
   }
 
   DateTime _paymentTime() {
     return DateTime.fromMillisecondsSinceEpoch(_payment.timestamp * 1000);
+  }
+}
+
+Map<String, dynamic> getLnurlPayMetadata(PaymentDetails details) {
+  final String? lnurlPayMetadata = details.map(
+    lightning: (PaymentDetails_Lightning details) => details.lnurlInfo?.lnurlPayMetadata,
+    orElse: () => null,
+  );
+
+  if (lnurlPayMetadata == null) {
+    return <String, dynamic>{};
+  }
+
+  return _parseLnurlPayMetadata(lnurlPayMetadata);
+}
+
+Map<String, dynamic> _parseLnurlPayMetadata(String lnurlPayMetadata) {
+  try {
+    final dynamic decoded = json.decode(lnurlPayMetadata);
+    if (decoded is! List) {
+      return <String, dynamic>{};
+    }
+
+    return Map<String, dynamic>.fromEntries(
+      decoded
+          .whereType<List<dynamic>>()
+          .where((dynamic item) => item.length == 2 && item[0] is String)
+          .map((dynamic item) => MapEntry<String, dynamic>(item[0] as String, item[1])),
+    );
+  } catch (_) {
+    return <String, dynamic>{};
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_content_title.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_content_title.dart
@@ -24,7 +24,7 @@ class PaymentDetailsSheetContentTitle extends StatelessWidget {
     if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
-      title = 'Payment to ${userProfileState.profileSettings.name}';
+      title = '${userProfileState.profileSettings.name}';
     }
 
     return AutoSizeText(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
@@ -44,7 +44,7 @@ class PaymentDetailsSheetDescription extends StatelessWidget {
                 height: 1.208,
               ),
               textAlign:
-                  description.length > 40 && !description.contains('\n') ? TextAlign.start : TextAlign.center,
+                  description.length > 60 && !description.contains('\n') ? TextAlign.start : TextAlign.center,
             ),
           ),
         ),

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
@@ -20,7 +20,7 @@ class PaymentDetailsSheetDescription extends StatelessWidget {
     if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
-      title = 'Payment to ${userProfileState.profileSettings.name}';
+      title = '${userProfileState.profileSettings.name}';
     }
     final String description = paymentData.description;
     if (description.isEmpty || title == description) {

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_description.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/utils/extensions/payment_title_extension.dart';
 
 class PaymentDetailsSheetDescription extends StatelessWidget {
   final PaymentData paymentData;
@@ -23,7 +24,7 @@ class PaymentDetailsSheetDescription extends StatelessWidget {
       title = '${userProfileState.profileSettings.name}';
     }
     final String description = paymentData.description;
-    if (description.isEmpty || title == description) {
+    if (description.isEmpty || title == description || description.isDefaultDescription) {
       return const SizedBox.shrink();
     }
 

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_avatar.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/user_profile.dart';
+import 'package:l_breez/routes/lnurl/widgets/widgets.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
 class PaymentItemAvatar extends StatelessWidget {
@@ -16,6 +17,19 @@ class PaymentItemAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
+
+    final String? base64String = paymentData.lnurlMetadataImage;
+    if (base64String?.isNotEmpty ?? false) {
+      return CircleAvatar(
+        radius: radius,
+        backgroundColor: Colors.white,
+        child: LNURLMetadataImage(
+          base64String: base64String!,
+          imageSize: radius,
+        ),
+      );
+    }
+
     final String title = paymentData.title;
     if (title == texts.payment_info_title_unknown) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
@@ -26,20 +40,20 @@ class PaymentItemAvatar extends StatelessWidget {
         avatarURL = user.avatarURL;
       }
       return BreezAvatar(avatarURL, radius: radius);
-    } else {
-      return CircleAvatar(
-        radius: radius,
-        backgroundColor: Colors.white,
-        child: Icon(
-          paymentData.isRefunded || paymentData.status == PaymentState.refundable
-              ? Icons.close_rounded
-              : paymentData.paymentType == PaymentType.receive
-                  ? Icons.add_rounded
-                  : Icons.remove_rounded,
-          size: radius,
-          color: const Color(0xb3303234),
-        ),
-      );
     }
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: Colors.white,
+      child: Icon(
+        paymentData.isRefunded || paymentData.status == PaymentState.refundable
+            ? Icons.close_rounded
+            : paymentData.paymentType == PaymentType.receive
+                ? Icons.add_rounded
+                : Icons.remove_rounded,
+        size: radius,
+        color: const Color(0xb3303234),
+      ),
+    );
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_title.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_title.dart
@@ -21,7 +21,7 @@ class PaymentItemTitle extends StatelessWidget {
     if (title == texts.payment_info_title_unknown && paymentData.paymentType == PaymentType.receive) {
       final UserProfileCubit userProfileCubit = context.read<UserProfileCubit>();
       final UserProfileState userProfileState = userProfileCubit.state;
-      title = 'Payment to ${userProfileState.profileSettings.name}';
+      title = '${userProfileState.profileSettings.name}';
     }
     return Text(
       title,

--- a/lib/routes/lnurl/widgets/lnurl_metadata_image.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata_image.dart
@@ -5,22 +5,22 @@ import 'package:flutter/material.dart';
 
 class LNURLMetadataImage extends StatelessWidget {
   final String base64String;
+  final double imageSize;
 
   const LNURLMetadataImage({
     required this.base64String,
+    this.imageSize = 128,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    const double imageSize = 128.0;
-
     final Uint8List imageBytes = base64Decode(base64String);
     if (imageBytes.isEmpty) {
       return const SizedBox.shrink();
     }
     return ConstrainedBox(
-      constraints: const BoxConstraints(
+      constraints: BoxConstraints(
         minHeight: imageSize,
         minWidth: imageSize,
         maxHeight: imageSize,


### PR DESCRIPTION
This PR makes several improvements to payment tile & handling of LNURL pay metadata.

#### Changelist:
- Extracted long description from LNURL pay metadata as description if it's available,
- If `lnAddress` isn't available, use [internet identifiers](https://github.com/lnurl/luds/blob/luds/16.md#paying-to-internet-identifiers-email-like-addresses) from LNURL pay metadata to be used as payment title,
- Removed "Payment to" & "Payment from" prefixes from payment titles,
- Increased description length constraint used for text alignment on payment details sheet,
- Hidden default descriptions,
- LNURL metadata image is used as payment avatar if it's available, per specification.