### PR TITLE
Show payment success sheet after completing LN payments

### DIFF
--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -126,6 +126,7 @@ class InputHandler extends Handler {
     // Show Processing Payment Sheet
     return await showProcessingPaymentSheet(
       context,
+      isLnPayment: true,
       paymentFunc: () async {
         final PaymentsCubit paymentsCubit = context.read<PaymentsCubit>();
         return await paymentsCubit.sendPayment(prepareResponse);
@@ -163,6 +164,7 @@ class InputHandler extends Handler {
     // Show Processing Payment Sheet
     return await showProcessingPaymentSheet(
       context,
+      isLnPayment: true,
       paymentFunc: () async {
         final PaymentsCubit paymentsCubit = context.read<PaymentsCubit>();
         return await paymentsCubit.sendPayment(prepareResponse);

--- a/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/destination_widget.dart
@@ -118,7 +118,7 @@ class _DestinationWidgetState extends State<DestinationWidget> {
   void _trackPaymentEvents(String? destination) {
     final InputCubit inputCubit = context.read<InputCubit>();
     inputCubit
-        .trackPaymentEvents(destination)
+        .trackPaymentEvents(destination, paymentType: PaymentType.receive)
         .then((_) => _onPaymentFinished(true))
         .catchError((Object e) => _onTrackPaymentError(e));
   }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,1 +1,1 @@
-const int maxPaymentAmountSat = 4294967;
+const Duration kPaymentSheetPopDelay = Duration(milliseconds: 2250);

--- a/lib/widgets/payment_status_sheets/payment_received_sheet.dart
+++ b/lib/widgets/payment_status_sheets/payment_received_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:l_breez/routes/routes.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
 Future<dynamic> showPaymentReceivedSheet(BuildContext context) {
@@ -23,7 +24,7 @@ class PaymentReceivedSheetState extends State<PaymentReceivedSheet> {
   void initState() {
     super.initState();
     // Close the bottom sheet after 2.25 seconds
-    Future<void>.delayed(const Duration(milliseconds: 2250), () {
+    Future<void>.delayed(kPaymentSheetPopDelay, () {
       if (mounted) {
         Navigator.of(context).popUntil(
           (Route<dynamic> route) => route.settings.name == Home.routeName,

--- a/lib/widgets/payment_status_sheets/payment_sent_sheet.dart
+++ b/lib/widgets/payment_status_sheets/payment_sent_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
 Future<dynamic> showPaymentSentSheet(BuildContext context) {
@@ -22,7 +23,7 @@ class PaymentSentSheetState extends State<PaymentSentSheet> {
   void initState() {
     super.initState();
     // Close the bottom sheet after 2.25 seconds
-    Future<void>.delayed(const Duration(milliseconds: 2250), () {
+    Future<void>.delayed(kPaymentSheetPopDelay, () {
       if (mounted) {
         Navigator.of(context).pop();
       }

--- a/lib/widgets/payment_status_sheets/processing_payment_sheet.dart
+++ b/lib/widgets/payment_status_sheets/processing_payment_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/routes.dart';
+import 'package:l_breez/utils/constants.dart';
 import 'package:l_breez/utils/exceptions.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -132,8 +133,11 @@ class ProcessingPaymentSheetState extends State<ProcessingPaymentSheet> {
       return;
     }
 
-    setState(() => _showPaymentSent = true);
-    Future<void>.delayed(const Duration(milliseconds: 2250), () {
+    setState(() {
+      _showPaymentSent = true;
+    });
+    // Close the bottom sheet after 2.25 seconds
+    Future<void>.delayed(kPaymentSheetPopDelay, () {
       if (mounted) {
         Navigator.of(context).pop(payResult);
       }


### PR DESCRIPTION
Fixes #362

---

This PR adds payment event tracking for outgoing payments.

After sending a LN payment*, `ProcessingPaymentSheet` waits at least 10 seconds for a `PaymentSucceeded` event for the corresponding LN payment and then:
- shows the payment sent content if the payment is successful.
- pops early if an error occurs.

#### Changelist:
- feat: Track outgoing payments in `trackPaymentEvents` 62d970c
- feat: Show payment sent sheet after completing LN payments f943a83
  - ⚠️ There are several refactoring changes in this PR, which might make it difficult to review everything. I recommend focusing only on `isLnPayment` related logic, or simply test the behavior on the online build.

_*: Ln Payments are of type`LNInvoice` & `LNOffer`._