### PR TITLE
Refactor `LnAddressCubit` for improved maintainability

### DIFF
--- a/lib/cubit/ln_address/factories/factories.dart
+++ b/lib/cubit/ln_address/factories/factories.dart
@@ -1,0 +1,1 @@
+export 'ln_address_cubit_factory.dart';

--- a/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
+++ b/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
@@ -1,0 +1,30 @@
+import 'package:breez_preferences/breez_preferences.dart';
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:service_injector/service_injector.dart';
+
+class LnAddressCubitFactory {
+  static LnAddressCubit create(ServiceInjector injector) {
+    final BreezSDKLiquid breezSdkLiquid = injector.breezSdkLiquid;
+    final BreezPreferences breezPreferences = injector.breezPreferences;
+    final WebhookService webhookService = WebhookService(breezSdkLiquid, injector.notifications);
+
+    final MessageSigner messageSigner = MessageSigner(breezSdkLiquid);
+    final WebhookRequestBuilder requestBuilder = WebhookRequestBuilder(messageSigner);
+    final UsernameResolver usernameResolver = UsernameResolver(breezPreferences);
+    final LnUrlPayService lnAddressService = LnUrlPayService();
+
+    final LnUrlRegistrationManager registrationManager = LnUrlRegistrationManager(
+      lnAddressService: lnAddressService,
+      breezPreferences: breezPreferences,
+      requestBuilder: requestBuilder,
+      usernameResolver: usernameResolver,
+      webhookService: webhookService,
+    );
+
+    return LnAddressCubit(
+      breezSdkLiquid: breezSdkLiquid,
+      registrationManager: registrationManager,
+    );
+  }
+}

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -153,12 +153,15 @@ class LnAddressCubit extends Cubit<LnAddressState> {
         (throw Exception('Failed to retrieve wallet info'));
   }
 
+  /// Clears any update status errors or messages
   void clearUpdateStatus() {
     _logger.info('Clearing LnAddressUpdateStatus');
-    emit(
-      state.copyWith(
-        updateStatus: const LnAddressUpdateStatus(),
-      ),
-    );
+    emit(state.clearUpdateStatus());
+  }
+
+  /// Clears any error state
+  void clearError() {
+    _logger.info('Clearing LnAddress error state');
+    emit(state.clearError());
   }
 }

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -1,11 +1,10 @@
-import 'package:breez_preferences/breez_preferences.dart';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:logging/logging.dart';
-import 'package:service_injector/service_injector.dart';
 
+export 'factories/factories.dart';
 export 'ln_address_state.dart';
 export 'models/models.dart';
 export 'services/services.dart';
@@ -13,35 +12,13 @@ export 'utils/utils.dart';
 
 final Logger _logger = Logger('LnAddressCubit');
 
-class LnAddressCubitFactory {
-  static LnAddressCubit create(ServiceInjector injector) {
-    final BreezSDKLiquid breezSdkLiquid = injector.breezSdkLiquid;
-    final BreezPreferences breezPreferences = injector.breezPreferences;
-
-    final WebhookService webhookService = WebhookService(breezSdkLiquid, injector.notifications);
-
-    return LnAddressCubit(
-      breezSdkLiquid: breezSdkLiquid,
-      breezPreferences: breezPreferences,
-      lnAddressService: LnUrlPayService(),
-      webhookService: webhookService,
-    );
-  }
-}
-
 class LnAddressCubit extends Cubit<LnAddressState> {
-  static const int _maxRetries = 3;
-
   final BreezSDKLiquid breezSdkLiquid;
-  final BreezPreferences breezPreferences;
-  final LnUrlPayService lnAddressService;
-  final WebhookService webhookService;
+  final LnUrlRegistrationManager registrationManager;
 
   LnAddressCubit({
     required this.breezSdkLiquid,
-    required this.breezPreferences,
-    required this.lnAddressService,
-    required this.webhookService,
+    required this.registrationManager,
   }) : super(const LnAddressState()) {
     _initializeLnAddressCubit();
   }
@@ -49,7 +26,6 @@ class LnAddressCubit extends Cubit<LnAddressState> {
   /// Attempts to recover the Lightning Address once pubKey is available
   void _initializeLnAddressCubit() {
     _logger.info('Initializing Lightning Address Cubit.');
-
     breezSdkLiquid.getInfoResponseStream.first.then(
       (GetInfoResponse getInfoResponse) {
         _logger.info('Received wallet info, setting up Lightning Address.');
@@ -70,13 +46,63 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     bool isRecover = false,
     String? baseUsername,
   }) async {
-    final bool isUpdating = baseUsername != null;
-    final String actionMessage = isRecover
-        ? 'Recovering Lightning Address'
-        : isUpdating
-            ? 'Update LN Address Username to: $baseUsername'
-            : 'Setup Lightning Address';
+    final String registrationType = _determineRegistrationType(isRecover, baseUsername);
+    final String actionMessage = _getActionMessage(registrationType, baseUsername);
+
     _logger.info(actionMessage);
+    _updateStateForOperation(registrationType);
+
+    try {
+      pubKey = pubKey ?? await _getPubKey();
+      final String webhookUrl = await registrationManager.setupWebhook(pubKey);
+
+      final RegisterRecoverLnurlPayResponse response = await registrationManager.performRegistration(
+        pubKey: pubKey,
+        webhookUrl: webhookUrl,
+        registrationType: registrationType,
+        baseUsername: baseUsername,
+      );
+
+      emit(
+        state.copyWith(
+          status: LnAddressStatus.success,
+          lnurl: response.lnurl,
+          lnAddress: response.lightningAddress,
+          updateStatus: registrationType == RegistrationType.update
+              ? const LnAddressUpdateStatus(status: UpdateStatus.success)
+              : null,
+        ),
+      );
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to $actionMessage', e, stackTrace);
+      _updateStateForError(e, registrationType, actionMessage);
+    }
+  }
+
+  String _determineRegistrationType(bool isRecover, String? baseUsername) {
+    if (isRecover) {
+      return RegistrationType.recovery;
+    }
+    if (baseUsername != null) {
+      return RegistrationType.update;
+    }
+    return RegistrationType.newRegistration;
+  }
+
+  String _getActionMessage(String registrationType, String? baseUsername) {
+    switch (registrationType) {
+      case RegistrationType.recovery:
+        return 'Recovering Lightning Address';
+      case RegistrationType.update:
+        return 'Update LN Address Username to: $baseUsername';
+      case RegistrationType.newRegistration:
+      default:
+        return 'Setup Lightning Address';
+    }
+  }
+
+  void _updateStateForOperation(String registrationType) {
+    final bool isUpdating = registrationType == RegistrationType.update;
 
     emit(
       state.copyWith(
@@ -84,36 +110,23 @@ class LnAddressCubit extends Cubit<LnAddressState> {
         updateStatus: isUpdating ? const LnAddressUpdateStatus(status: UpdateStatus.loading) : null,
       ),
     );
+  }
 
-    try {
-      final RegisterRecoverLnurlPayResponse registrationResponse = await _setupAndRegisterLnAddress(
-        pubKey: pubKey,
-        isRecover: isRecover,
-        baseUsername: baseUsername,
-      );
+  void _updateStateForError(Object e, String registrationType, String actionMessage) {
+    final bool isUpdating = registrationType == RegistrationType.update;
 
-      emit(
-        state.copyWith(
-          status: LnAddressStatus.success,
-          lnurl: registrationResponse.lnurl,
-          lnAddress: registrationResponse.lightningAddress,
-          updateStatus: isUpdating ? const LnAddressUpdateStatus(status: UpdateStatus.success) : null,
-        ),
-      );
-    } catch (e, stackTrace) {
-      _logger.severe('Failed to $actionMessage', e, stackTrace);
-      final LnAddressStatus status = isUpdating ? state.status : LnAddressStatus.error;
-      final Object? error = isUpdating ? null : e;
-      final LnAddressUpdateStatus? updateStatus =
-          isUpdating ? _createErrorUpdateStatus(e, actionMessage) : null;
-      emit(
-        state.copyWith(
-          status: status,
-          error: error,
-          updateStatus: updateStatus,
-        ),
-      );
-    }
+    final LnAddressStatus status = isUpdating ? state.status : LnAddressStatus.error;
+    final Object? error = isUpdating ? null : e;
+    final LnAddressUpdateStatus? updateStatus =
+        isUpdating ? _createErrorUpdateStatus(e, actionMessage) : null;
+
+    emit(
+      state.copyWith(
+        status: status,
+        error: error,
+        updateStatus: updateStatus,
+      ),
+    );
   }
 
   LnAddressUpdateStatus _createErrorUpdateStatus(Object e, String action) {
@@ -130,380 +143,14 @@ class LnAddressCubit extends Cubit<LnAddressState> {
     );
   }
 
-  /// Registers or updates an LNURL Webhook for a Lightning Address.
-  ///
-  /// - If [isRecover] is true, it attempts to recover the LNURL Webhook. Fallbacks to registration on failure.
-  /// - If [baseUsername] is provided, it updates the existing registration.
-  /// - Otherwise, it determines a suitable username and registers a new webhook.
-  Future<RegisterRecoverLnurlPayResponse> _setupAndRegisterLnAddress({
-    String? pubKey,
-    bool isRecover = false,
-    String? baseUsername,
-  }) async {
-    pubKey = pubKey ?? await _pubKey;
-    final String webhookUrl = await _setupWebhook(pubKey);
-    if (isRecover) {
-      // Recover webhook
-      try {
-        final RegisterRecoverLnurlPayResponse response = await _prepareAndRecoverLnurlWebhook(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          baseUsername: baseUsername,
-        );
-        _logger.info('Recovered LNURL Webhook successfully. Re-registering to transfer device ownership.');
-        return await _prepareAndRegisterLnurlWebhook(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          baseUsername: baseUsername,
-          recoveredLightningAddress: response.lightningAddress,
-          isOwnershipTransfer: true,
-        );
-      } on WebhookNotFoundException {
-        // Fallback to register a new webhook if recovery fails
-        _logger.info('Failed to recover LNURL Webhook. Falling back to registration.');
-        return await _prepareAndRegisterLnurlWebhook(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          baseUsername: baseUsername,
-        );
-      }
-    } else {
-      // Registers a new webhook
-      return await _prepareAndRegisterLnurlWebhook(
-        pubKey: pubKey,
-        webhookUrl: webhookUrl,
-        baseUsername: baseUsername,
-      );
-    }
+  Future<String> _getPubKey() async {
+    final WalletInfo walletInfo = await _getWalletInfo();
+    return walletInfo.pubkey;
   }
 
-  Future<String> get _pubKey async => (await _walletInfo).pubkey;
-
-  Future<WalletInfo> get _walletInfo async =>
-      (await breezSdkLiquid.instance?.getInfo())?.walletInfo ??
-      (throw Exception('Failed to retrieve wallet info'));
-
-  /// Sets up a webhook for the given public key.
-  /// - Generates a new webhook URL, unregisters any existing webhook if needed,
-  /// - Registers the new webhook, and stores the webhook URL in preferences.
-  Future<String> _setupWebhook(String pubKey) async {
-    _logger.info('Setting up webhook for pubKey: $pubKey');
-    final String webhookUrl = await webhookService.generateWebhookUrl();
-    await _unregisterExistingWebhookIfNeeded(pubKey: pubKey, webhookUrl: webhookUrl);
-    await webhookService.register(webhookUrl);
-    await breezPreferences.setWebhookUrl(webhookUrl);
-    _logger.info('Successfully setup webhook setup.');
-    return webhookUrl;
-  }
-
-  /// Checks if there is an existing webhook URL and unregisters it if different from the provided one.
-  Future<void> _unregisterExistingWebhookIfNeeded({
-    required String pubKey,
-    required String webhookUrl,
-  }) async {
-    final String? existingWebhook = await breezPreferences.webhookUrl;
-    if (existingWebhook != null && existingWebhook != webhookUrl) {
-      _logger.info('Unregistering existing webhook: $existingWebhook');
-      await _unregisterWebhook(pubKey: pubKey, webhookUrl: existingWebhook);
-      breezPreferences.removeWebhookUrl();
-      _logger.info('Successfully registered existing webhook.');
-    }
-  }
-
-  /// Unregisters a webhook for a given public key.
-  Future<void> _unregisterWebhook({
-    required String pubKey,
-    required String webhookUrl,
-  }) async {
-    _logger.info('Prepared unregister LNURL Webhook request.');
-    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-
-    final String message = '$time-$webhookUrl';
-    final String signature = await _signMessage(message);
-
-    final UnregisterRecoverLnurlPayRequest unregisterRequest = UnregisterRecoverLnurlPayRequest(
-      time: time,
-      webhookUrl: webhookUrl,
-      signature: signature,
-    );
-    _logger.info('Prepared unregister LNURL Webhook request.');
-    await lnAddressService.unregister(pubKey: pubKey, request: unregisterRequest);
-  }
-
-  /// Signs the given message with the private key.
-  Future<String> _signMessage(String message) async {
-    _logger.info('Signing message: $message');
-
-    final SignMessageResponse? signMessageRes = breezSdkLiquid.instance?.signMessage(
-      req: SignMessageRequest(message: message),
-    );
-
-    if (signMessageRes == null) {
-      _logger.severe('Failed to sign message.');
-      throw Exception('Failed to sign message');
-    }
-
-    _logger.info('Successfully signed message');
-    return signMessageRes.signature;
-  }
-
-  /// Resolves the appropriate username for LNURL registration.
-  ///
-  /// - If [recoveredLightningAddress] is provided, extracts username from it.
-  /// - If the webhook is not yet registered, it utilizes default profile name as username.
-  /// - If the webhook is already registered, it retrieves the stored username from [BreezPreferences].
-  Future<String?> _resolveUsername({
-    required bool isNewRegistration,
-    String? recoveredLightningAddress,
-    String? baseUsername,
-  }) async {
-    // If we have a recovered lightning address, extract the username part
-    if (recoveredLightningAddress != null && recoveredLightningAddress.isNotEmpty) {
-      final String username = recoveredLightningAddress.split('@').first;
-      _logger.info('Using username from recovered Lightning Address: $username');
-      return username;
-    }
-
-    // If baseUsername is provided (during update), use it
-    if (baseUsername != null && baseUsername.isNotEmpty) {
-      _logger.info('Using provided baseUsername: $baseUsername');
-      return baseUsername;
-    }
-
-    if (isNewRegistration) {
-      final String? defaultProfileName = await breezPreferences.defaultProfileName;
-      final String formattedUsername = UsernameFormatter.formatDefaultProfileName(defaultProfileName);
-      _logger.info('Registering LNURL Webhook: Using formatted profile name: $formattedUsername');
-      return formattedUsername;
-    }
-
-    // TODO(erdemyerebasmaz): Add null-handling to revert to the profile name if the stored username is null.
-    // For existing registrations, use stored username
-    final String? storedUsername = await breezPreferences.lnAddressUsername;
-    _logger.info('Refreshing LNURL Webhook: Using stored username: $storedUsername');
-    return storedUsername;
-  }
-
-  /// Signs a webhook request message for authentication and validation purposes.
-  Future<String> _generateWebhookSignature({
-    required int time,
-    required String webhookUrl,
-    String? username,
-  }) async {
-    _logger.info('Generating webhook signature');
-    final String usernameComponent = username?.isNotEmpty == true ? '-$username' : '';
-    final String message = '$time-$webhookUrl$usernameComponent';
-    final String signature = await _signMessage(message);
-    _logger.info('Successfully generated webhook signature');
-    return signature;
-  }
-
-  /// Prepares recover request & recovers a webhook for a given public key.
-  Future<RegisterRecoverLnurlPayResponse> _prepareAndRecoverLnurlWebhook({
-    required String pubKey,
-    required String webhookUrl,
-    required String? baseUsername,
-  }) async {
-    _logger.info('Preparing recover LNURL Webhook request.');
-    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-
-    final String message = '$time-$webhookUrl';
-    final String signature = await _signMessage(message);
-
-    final UnregisterRecoverLnurlPayRequest recoverRequest = UnregisterRecoverLnurlPayRequest(
-      time: time,
-      webhookUrl: webhookUrl,
-      signature: signature,
-    );
-
-    _logger.info('Prepared recover LNURL Webhook request.');
-    return await _recoverLnurlWebhook(pubKey: pubKey, request: recoverRequest, baseUsername: baseUsername);
-  }
-
-  /// Recovers an LNURL Webhook with the provided public key and request.
-  ///
-  ///  - Saves the username to [BreezPreferences] if present and
-  ///  - Sets webhook as registered on [BreezPreferences] if succeeds
-  Future<RegisterRecoverLnurlPayResponse> _recoverLnurlWebhook({
-    required String pubKey,
-    required UnregisterRecoverLnurlPayRequest request,
-    required String? baseUsername,
-  }) async {
-    _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
-    try {
-      final RegisterRecoverLnurlPayResponse recoverResponse = await lnAddressService.recover(
-        pubKey: pubKey,
-        request: request,
-      );
-
-      final String lightningAddress = recoverResponse.lightningAddress;
-      if (lightningAddress.isEmpty) {
-        _logger.warning('Recover response has no Lightning Address. Falling back to registration.');
-        return await _prepareAndRegisterLnurlWebhook(
-          pubKey: pubKey,
-          webhookUrl: request.webhookUrl,
-          baseUsername: baseUsername,
-          registerWithRetries: true,
-        );
-      }
-
-      final String username = recoverResponse.lightningAddress.split('@').first;
-      if (username.isNotEmpty) {
-        await breezPreferences.setLnAddressUsername(username);
-      }
-
-      _logger.info('Successfully recovered LNURL Webhook: $recoverResponse');
-
-      await breezPreferences.setLnUrlWebhookRegistered();
-      return recoverResponse;
-    } catch (e) {
-      _logger.severe('Failed to recover LNURL Webhook.', e);
-      rethrow;
-    }
-  }
-
-  /// Prepares register request & registers a webhook for a given public key.
-  Future<RegisterRecoverLnurlPayResponse> _prepareAndRegisterLnurlWebhook({
-    required String pubKey,
-    required String webhookUrl,
-    required String? baseUsername,
-    bool? registerWithRetries,
-    bool isOwnershipTransfer = false,
-    String? recoveredLightningAddress,
-  }) async {
-    _logger.info('Preparing register LNURL Webhook request.');
-    final bool isUpdating = baseUsername != null;
-    final bool isLnUrlWebhookRegistered = await breezPreferences.isLnUrlWebhookRegistered;
-
-    final bool isNewRegistration =
-        isOwnershipTransfer ? false : registerWithRetries ?? !(isUpdating && isLnUrlWebhookRegistered);
-
-    final String? username = await _resolveUsername(
-      isNewRegistration: isNewRegistration,
-      recoveredLightningAddress: recoveredLightningAddress,
-      baseUsername: baseUsername,
-    );
-
-    // Register without retries if this is an update to existing LNURL Webhook
-    if (!isNewRegistration) {
-      return await _attemptRegisterLnurlWebhook(
-        pubKey: pubKey,
-        webhookUrl: webhookUrl,
-        username: username,
-      );
-    }
-
-    // Register with retries if LNURL Webhook hasn't been registered yet
-    return await _registerWithRetries(
-      pubKey: pubKey,
-      webhookUrl: webhookUrl,
-      username: username!,
-    );
-  }
-
-  // TODO(erdemyerebasmaz): Optimize if current retry logic is insufficient
-  // If initial registration fails, up to [_maxRetries] registration attempts will be made on opening [ReceiveLightningAddressPage].
-  // If these attempts also fail, the user can retry manually via a button, which will trigger another registration attempt with [_maxRetries] retries.
-  //
-  // Future improvements could include:
-  // - Retrying indefinitely with intervals until registration succeeds
-  // - Explicit handling of [UsernameConflictException] and LNURL server connectivity issues
-  // - Randomizing the default profile name itself after a set number of failures
-  // - Adding additional digits to the discriminator
-  Future<RegisterRecoverLnurlPayResponse> _registerWithRetries({
-    required String pubKey,
-    required String webhookUrl,
-    required String username,
-  }) async {
-    final String baseUsername = username;
-    for (int retryCount = 1; retryCount <= _maxRetries; retryCount++) {
-      try {
-        _logger.info('Attempt $retryCount/$_maxRetries with username: $username');
-        return await _attemptRegisterLnurlWebhook(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          username: username,
-        );
-      } on UsernameConflictException {
-        _logger.warning('Username conflict for: $username.');
-        username = UsernameGenerator.generateUsername(baseUsername, retryCount);
-      } catch (e) {
-        _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e);
-        rethrow;
-      }
-    }
-
-    _logger.severe('Max retries exceeded for username registration');
-    throw MaxRetriesExceededException();
-  }
-
-  Future<RegisterRecoverLnurlPayResponse> _attemptRegisterLnurlWebhook({
-    required String pubKey,
-    required String webhookUrl,
-    String? username,
-  }) async {
-    _logger.info('Prepared register LNURL Webhook request.');
-    final RegisterLnurlPayRequest request = await _prepareRegisterLnurlPayRequest(
-      pubKey: pubKey,
-      webhookUrl: webhookUrl,
-      username: username,
-    );
-    _logger.info('Prepared register LNURL Webhook request.');
-    return await _registerLnurlWebhook(
-      pubKey: pubKey,
-      request: request,
-    );
-  }
-
-  /// Attempts to register LNURL Webhook once with the given parameters.
-  Future<RegisterLnurlPayRequest> _prepareRegisterLnurlPayRequest({
-    required String pubKey,
-    required String webhookUrl,
-    required String? username,
-  }) async {
-    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final String signature = await _generateWebhookSignature(
-      time: time,
-      webhookUrl: webhookUrl,
-      username: username,
-    );
-
-    return RegisterLnurlPayRequest(
-      time: time,
-      webhookUrl: webhookUrl,
-      signature: signature,
-      username: username,
-    );
-  }
-
-  /// Registers an LNURL Webhook with the provided public key and request.
-  ///
-  ///  - Saves the username to [BreezPreferences] if present and
-  ///  - Sets webhook as registered on [BreezPreferences] if succeeds
-  Future<RegisterRecoverLnurlPayResponse> _registerLnurlWebhook({
-    required String pubKey,
-    required RegisterLnurlPayRequest request,
-  }) async {
-    _logger.info('Attempting to register LNURL Webhook for pubKey: $pubKey');
-    try {
-      final RegisterRecoverLnurlPayResponse registrationResponse = await lnAddressService.register(
-        pubKey: pubKey,
-        request: request,
-      );
-
-      final String? username = request.username;
-      if (username != null && username.isNotEmpty) {
-        await breezPreferences.setLnAddressUsername(username);
-      }
-
-      _logger.info('Successfully registered LNURL Webhook: $registrationResponse');
-
-      await breezPreferences.setLnUrlWebhookRegistered();
-      return registrationResponse;
-    } catch (e) {
-      _logger.severe('Failed to register LNURL Webhook.', e);
-      rethrow;
-    }
+  Future<WalletInfo> _getWalletInfo() async {
+    return (await breezSdkLiquid.instance?.getInfo())?.walletInfo ??
+        (throw Exception('Failed to retrieve wallet info'));
   }
 
   void clearUpdateStatus() {

--- a/lib/cubit/ln_address/ln_address_state.dart
+++ b/lib/cubit/ln_address/ln_address_state.dart
@@ -1,4 +1,4 @@
-import 'package:l_breez/cubit/cubit.dart';
+import 'package:l_breez/cubit/ln_address/models/ln_address_update_status.dart';
 
 enum LnAddressStatus { initial, loading, success, error }
 

--- a/lib/cubit/ln_address/ln_address_state.dart
+++ b/lib/cubit/ln_address/ln_address_state.dart
@@ -1,14 +1,44 @@
 import 'package:l_breez/cubit/ln_address/models/ln_address_update_status.dart';
 
-enum LnAddressStatus { initial, loading, success, error }
+/// Status of Lightning Address operations
+enum LnAddressStatus {
+  /// Initial state or reset state
+  initial,
 
+  /// Operation in progress
+  loading,
+
+  /// Operation completed successfully
+  success,
+
+  /// Operation failed
+  error
+}
+
+/// Represents the state of a Lightning Address in the application.
+///
+/// This class contains all information related to the current Lightning Address
+/// including its LNURL, address string, operation status, and error information.
 class LnAddressState {
+  /// The LNURL associated with this Lightning Address
   final String? lnurl;
+
+  /// The formatted Lightning Address (username@domain)
   final String? lnAddress;
+
+  /// Current status of Lightning Address operations
   final LnAddressStatus status;
+
+  /// Status information for update operations
   final LnAddressUpdateStatus updateStatus;
+
+  /// Error object if any operation has failed
   final Object? error;
 
+  /// Creates a new Lightning Address state
+  ///
+  /// All parameters are optional. Status defaults to [LnAddressStatus.initial]
+  /// and updateStatus defaults to an empty update status.
   const LnAddressState({
     this.lnurl,
     this.lnAddress,
@@ -17,6 +47,10 @@ class LnAddressState {
     this.error,
   });
 
+  /// Creates a copy of this state with optional updated fields
+  ///
+  /// Returns a new [LnAddressState] with the specified fields updated
+  /// and all other fields maintaining their existing values.
   LnAddressState copyWith({
     String? lnurl,
     String? lnAddress,
@@ -30,6 +64,108 @@ class LnAddressState {
       status: status ?? this.status,
       updateStatus: updateStatus ?? this.updateStatus,
       error: error ?? this.error,
+    );
+  }
+
+  /// Creates a copy of this state with errors cleared
+  ///
+  /// Returns a new [LnAddressState] with error set to null
+  /// and all other fields maintaining their existing values.
+  LnAddressState clearError() {
+    return LnAddressState(
+      lnurl: lnurl,
+      lnAddress: lnAddress,
+      status: status,
+      updateStatus: updateStatus,
+    );
+  }
+
+  /// Creates a copy of this state with update status reset to initial
+  ///
+  /// Useful for clearing previous update operation results.
+  LnAddressState clearUpdateStatus() {
+    return LnAddressState(
+      lnurl: lnurl,
+      lnAddress: lnAddress,
+      status: status,
+      error: error,
+    );
+  }
+
+  /// Determines if this state has a valid Lightning Address
+  ///
+  /// Returns true if the lnAddress is not null and not empty
+  bool get hasValidAddress => lnAddress != null && lnAddress!.isNotEmpty;
+
+  /// Determines if this state has a valid LNURL
+  ///
+  /// Returns true if the lnurl is not null and not empty
+  bool get hasValidLnUrl => lnurl != null && lnurl!.isNotEmpty;
+
+  /// Checks if this state represents an error condition
+  ///
+  /// Returns true if status is [LnAddressStatus.error] or error is not null
+  bool get hasError => status == LnAddressStatus.error || error != null;
+
+  /// Checks if this state is in a loading condition
+  ///
+  /// Returns true if status is [LnAddressStatus.loading]
+  bool get isLoading => status == LnAddressStatus.loading;
+
+  /// Checks if this state represents a successful operation
+  ///
+  /// Returns true if status is [LnAddressStatus.success]
+  bool get isSuccess => status == LnAddressStatus.success;
+
+  /// Extracts the username portion from the Lightning Address
+  ///
+  /// Returns the part before the '@' symbol or null if address is invalid
+  String? get username {
+    if (!hasValidAddress) {
+      return null;
+    }
+    final List<String> parts = lnAddress!.split('@');
+    return parts.isNotEmpty ? parts[0] : null;
+  }
+
+  /// Extracts the domain portion from the Lightning Address
+  ///
+  /// Returns the part after the '@' symbol or null if address is invalid
+  String? get domain {
+    if (!hasValidAddress) {
+      return null;
+    }
+    final List<String> parts = lnAddress!.split('@');
+    return parts.length > 1 ? parts[1] : null;
+  }
+
+  @override
+  String toString() {
+    return 'LnAddressState(lnAddress: $lnAddress, status: $status, '
+        'updateStatus: $updateStatus, hasError: $hasError)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is LnAddressState &&
+        other.lnurl == lnurl &&
+        other.lnAddress == lnAddress &&
+        other.status == status &&
+        other.updateStatus == updateStatus &&
+        other.error == error;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      lnurl,
+      lnAddress,
+      status,
+      updateStatus,
+      error,
     );
   }
 }

--- a/lib/cubit/ln_address/models/lnurl_pay_service_response_error.dart
+++ b/lib/cubit/ln_address/models/lnurl_pay_service_response_error.dart
@@ -1,0 +1,7 @@
+/// Represents an HTTP response error returned from an LnUrl Pay Service endpoint.
+class LnurlPayServiceResponseError {
+  final int statusCode;
+  final String body;
+
+  LnurlPayServiceResponseError(this.statusCode, this.body);
+}

--- a/lib/cubit/ln_address/models/models.dart
+++ b/lib/cubit/ln_address/models/models.dart
@@ -1,3 +1,4 @@
 export 'exceptions.dart';
 export 'ln_address_update_status.dart';
 export 'lnurl_pay_registration.dart';
+export 'registration_types.dart';

--- a/lib/cubit/ln_address/models/models.dart
+++ b/lib/cubit/ln_address/models/models.dart
@@ -2,3 +2,4 @@ export 'exceptions.dart';
 export 'ln_address_update_status.dart';
 export 'lnurl_pay_registration.dart';
 export 'registration_types.dart';
+export 'signed_request_data.dart';

--- a/lib/cubit/ln_address/models/models.dart
+++ b/lib/cubit/ln_address/models/models.dart
@@ -1,5 +1,6 @@
 export 'exceptions.dart';
 export 'ln_address_update_status.dart';
 export 'lnurl_pay_registration.dart';
+export 'lnurl_pay_service_response_error.dart';
 export 'registration_types.dart';
 export 'signed_request_data.dart';

--- a/lib/cubit/ln_address/models/registration_types.dart
+++ b/lib/cubit/ln_address/models/registration_types.dart
@@ -1,0 +1,6 @@
+class RegistrationType {
+  static const String newRegistration = 'new_registration';
+  static const String recovery = 'recovery';
+  static const String update = 'update';
+  static const String ownershipTransfer = 'ownership_transfer';
+}

--- a/lib/cubit/ln_address/models/signed_request_data.dart
+++ b/lib/cubit/ln_address/models/signed_request_data.dart
@@ -1,0 +1,16 @@
+/// Container for signed request data components.
+///
+/// Used internally to hold common data needed for different request types.
+class SignedRequestData {
+  /// Unix timestamp in seconds
+  final int timestamp;
+
+  /// Cryptographic signature of the message
+  final String signature;
+
+  /// Creates a new SignedRequestData instance.
+  SignedRequestData({
+    required this.timestamp,
+    required this.signature,
+  });
+}

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -182,7 +182,7 @@ class LnUrlPayService {
       }
     }
 
-    return _ResponseError(response.statusCode, response.body);
+    return LnurlPayServiceResponseError(response.statusCode, response.body);
   }
 
   /// Logs the HTTP response details.
@@ -213,7 +213,7 @@ class LnUrlPayService {
       try {
         final dynamic result = await operation();
 
-        if (result is _ResponseError) {
+        if (result is LnurlPayServiceResponseError) {
           errorHandler(result.statusCode, result.body);
           // If errorHandler doesn't throw, we'll exit the loop
           break;
@@ -243,12 +243,4 @@ class LnUrlPayService {
     // This should never be reached unless errorHandler doesn't throw
     throw Exception('Failed to $operationName after multiple attempts');
   }
-}
-
-/// Represents an HTTP response error.
-class _ResponseError {
-  final int statusCode;
-  final String body;
-
-  _ResponseError(this.statusCode, this.body);
 }

--- a/lib/cubit/ln_address/services/lnurl_pay_service.dart
+++ b/lib/cubit/ln_address/services/lnurl_pay_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -6,109 +7,248 @@ import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('LnUrlPayService');
 
+/// Service responsible for Lightning URL payment operations.
+///
+/// Handles registration, recovery, and unregistration of LNURL webhooks
+/// by communicating with the Breez server.
 class LnUrlPayService {
-  static const String _baseUrl = 'https://breez.fun';
-  static final http.Client _client = http.Client();
+  static const int _maxRetries = 2;
+  static const Duration _defaultTimeout = Duration(seconds: 30);
 
-  // TODO(erdemyerebasmaz): Handle multiple device setup case
+  static const String _baseUrl = 'https://breez.fun';
+  static const String _lnurlPayEndpoint = '/lnurlpay';
+
+  final http.Client _client;
+
+  /// Creates a new [LnUrlPayService] with an optional HTTP client.
+  ///
+  /// If no client is provided, a new one will be created.
+  LnUrlPayService({http.Client? client}) : _client = client ?? http.Client();
+
+  /// Closes the HTTP client when the service is no longer needed.
+  void dispose() {
+    _client.close();
+  }
+
+  /// Registers a new LNURL webhook for the specified public key.
+  ///
+  /// Returns a [RegisterRecoverLnurlPayResponse] on success.
+  /// Throws [UsernameConflictException] if the username is already taken.
+  /// Throws [RegisterLnurlPayException] for other registration failures.
   Future<RegisterRecoverLnurlPayResponse> register({
     required String pubKey,
     required RegisterLnurlPayRequest request,
+    Duration timeout = _defaultTimeout,
   }) async {
-    _logger.info('Registering lightning address for pubkey: $pubKey with request: $request');
-    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey');
-    _logger.fine('Sending registration request to: $uri');
-
-    try {
-      final http.Response response = await _client.post(
-        uri,
-        body: jsonEncode(request.toJson()),
-      );
-      _logHttpResponse(response);
-
-      if (response.statusCode == 200) {
-        return RegisterRecoverLnurlPayResponse.fromJson(
-          jsonDecode(response.body) as Map<String, dynamic>,
-        );
-      }
-
-      if (response.statusCode == 409) {
-        throw UsernameConflictException();
-      }
-
-      throw RegisterLnurlPayException(
-        'Server returned error response',
-        statusCode: response.statusCode,
-        responseBody: response.body,
-      );
-    } catch (e) {
-      _logger.severe('Failed to register webhook.', e);
-      rethrow;
+    _logger.info('Registering lightning address for pubkey: $pubKey');
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Registration request details: $request');
     }
+
+    final Uri uri = _buildUri('$_lnurlPayEndpoint/$pubKey');
+
+    return _executeWithRetry(
+      () => _post(uri, request.toJson()),
+      timeout: timeout,
+      successHandler: (Map<String, dynamic> response) {
+        return RegisterRecoverLnurlPayResponse.fromJson(response);
+      },
+      errorHandler: (int statusCode, String body) {
+        if (statusCode == 409) {
+          throw UsernameConflictException();
+        }
+        _logger.severe('Failed to register webhook.');
+        throw RegisterLnurlPayException(
+          'Server returned error response',
+          statusCode: statusCode,
+          responseBody: body,
+        );
+      },
+      operationName: 'register webhook',
+    );
   }
 
+  /// Recovers an existing LNURL webhook for the specified public key.
+  ///
+  /// Returns a [RegisterRecoverLnurlPayResponse] on success.
+  /// Throws [WebhookNotFoundException] if the webhook doesn't exist.
+  /// Throws [RecoverLnurlPayException] for other recovery failures.
   Future<RegisterRecoverLnurlPayResponse> recover({
     required String pubKey,
     required UnregisterRecoverLnurlPayRequest request,
+    Duration timeout = _defaultTimeout,
   }) async {
-    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey/recover');
-    _logger.fine('Sending recover request to: $uri');
+    _logger.info('Recovering webhook for pubkey: $pubKey');
+    final Uri uri = _buildUri('$_lnurlPayEndpoint/$pubKey/recover');
 
-    try {
-      final http.Response response = await _client.post(
-        uri,
-        body: jsonEncode(request.toJson()),
-      );
-      _logHttpResponse(response);
-
-      if (response.statusCode == 200) {
-        return RegisterRecoverLnurlPayResponse.fromJson(
-          jsonDecode(response.body) as Map<String, dynamic>,
+    return _executeWithRetry(
+      () => _post(uri, request.toJson()),
+      timeout: timeout,
+      successHandler: (Map<String, dynamic> response) {
+        return RegisterRecoverLnurlPayResponse.fromJson(response);
+      },
+      errorHandler: (int statusCode, String body) {
+        if (statusCode == 404) {
+          throw WebhookNotFoundException();
+        }
+        _logger.severe('Failed to recover webhook.');
+        throw RecoverLnurlPayException(
+          'Server returned error response',
+          statusCode: statusCode,
+          responseBody: body,
         );
-      }
-
-      if (response.statusCode == 404) {
-        throw WebhookNotFoundException();
-      }
-
-      throw RecoverLnurlPayException(
-        'Server returned error response',
-        statusCode: response.statusCode,
-        responseBody: response.body,
-      );
-    } catch (e) {
-      _logger.severe('Failed to recover webhook.', e);
-      rethrow;
-    }
+      },
+      operationName: 'recover webhook',
+    );
   }
 
+  /// Unregisters an existing LNURL webhook for the specified public key.
+  ///
+  /// Throws [UnregisterLnurlPayException] if unregistration fails.
   Future<void> unregister({
     required String pubKey,
     required UnregisterRecoverLnurlPayRequest request,
+    Duration timeout = _defaultTimeout,
   }) async {
     _logger.info('Unregistering webhook: ${request.webhookUrl}');
-    final Uri uri = Uri.parse('$_baseUrl/lnurlpay/$pubKey');
+    final Uri uri = _buildUri('$_lnurlPayEndpoint/$pubKey');
 
-    try {
-      final http.Response response = await _client.delete(
-        uri,
-        body: jsonEncode(request.toJson()),
-      );
-      _logHttpResponse(response);
+    await _executeWithRetry<void>(
+      () => _delete(uri, request.toJson()),
+      timeout: timeout,
+      successHandler: (_) {},
+      errorHandler: (int statusCode, String body) {
+        _logger.severe('Failed to unregister webhook.');
+        throw UnregisterLnurlPayException(body);
+      },
+      operationName: 'unregister webhook',
+    );
 
-      if (response.statusCode != 200) {
-        throw UnregisterLnurlPayException(response.body);
+    _logger.info('Successfully unregistered webhook.');
+  }
+
+  /// Builds a URI for the specified endpoint.
+  Uri _buildUri(String endpoint) {
+    return Uri.parse('$_baseUrl$endpoint');
+  }
+
+  /// Executes a POST request with the given URI and body.
+  Future<dynamic> _post(Uri uri, Map<String, dynamic> body, {Duration? timeout}) async {
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Sending POST request to: $uri');
+    }
+
+    final Map<String, String> headers = <String, String>{'Content-Type': 'application/json'};
+    final http.Response response = await _client
+        .post(
+          uri,
+          body: jsonEncode(body),
+          headers: headers,
+        )
+        .timeout(timeout ?? _defaultTimeout);
+
+    return _processResponse(response);
+  }
+
+  /// Executes a DELETE request with the given URI and body.
+  Future<dynamic> _delete(Uri uri, Map<String, dynamic> body, {Duration? timeout}) async {
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Sending DELETE request to: $uri');
+    }
+
+    final Map<String, String> headers = <String, String>{'Content-Type': 'application/json'};
+    final http.Response response = await _client
+        .delete(
+          uri,
+          body: jsonEncode(body),
+          headers: headers,
+        )
+        .timeout(timeout ?? _defaultTimeout);
+
+    return _processResponse(response);
+  }
+
+  /// Processes the HTTP response and returns the response body.
+  dynamic _processResponse(http.Response response) {
+    _logHttpResponse(response);
+
+    if (response.statusCode == 200) {
+      try {
+        final dynamic decodedBody = jsonDecode(response.body);
+        return decodedBody;
+      } catch (e) {
+        _logger.warning('Failed to decode response body: ${response.body}', e);
+        throw FormatException('Invalid response format', response.body);
       }
+    }
 
-      _logger.info('Successfully unregistered webhook.');
-    } catch (e) {
-      _logger.severe('Failed to unregister webhook.', e);
-      rethrow;
+    return _ResponseError(response.statusCode, response.body);
+  }
+
+  /// Logs the HTTP response details.
+  void _logHttpResponse(http.Response response) {
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Response status: ${response.statusCode}');
+      _logger.fine('Response body: ${response.body}');
     }
   }
 
-  void _logHttpResponse(http.Response response) {
-    _logger.fine('Response status: ${response.statusCode}');
-    _logger.fine('Response body: ${response.body}');
+  /// Executes an operation with retry logic.
+  ///
+  /// [operation] is the async operation to execute
+  /// [successHandler] processes the successful response
+  /// [errorHandler] handles error responses
+  /// [timeout] is the timeout for each attempt
+  /// [operationName] is used for logging
+  Future<T> _executeWithRetry<T>(
+    Future<dynamic> Function() operation, {
+    required T Function(Map<String, dynamic>) successHandler,
+    required void Function(int statusCode, String body) errorHandler,
+    Duration? timeout,
+    String? operationName,
+  }) async {
+    int attempts = 0;
+
+    while (attempts <= _maxRetries) {
+      try {
+        final dynamic result = await operation();
+
+        if (result is _ResponseError) {
+          errorHandler(result.statusCode, result.body);
+          // If errorHandler doesn't throw, we'll exit the loop
+          break;
+        }
+
+        return successHandler(result as Map<String, dynamic>);
+      } on TimeoutException {
+        attempts++;
+        if (attempts <= _maxRetries) {
+          final Duration backoff = Duration(milliseconds: 500 * (1 << attempts));
+          _logger.warning(
+            'Timeout occurred while trying to $operationName. '
+            'Retrying in ${backoff.inMilliseconds}ms (attempt $attempts/$_maxRetries)',
+          );
+          await Future<void>.delayed(backoff);
+        } else {
+          _logger.severe('Max retries exceeded for $operationName due to timeout');
+          rethrow;
+        }
+      } catch (e) {
+        // Don't retry for non-timeout errors
+        _logger.severe('Failed to $operationName.', e);
+        rethrow;
+      }
+    }
+
+    // This should never be reached unless errorHandler doesn't throw
+    throw Exception('Failed to $operationName after multiple attempts');
   }
+}
+
+/// Represents an HTTP response error.
+class _ResponseError {
+  final int statusCode;
+  final String body;
+
+  _ResponseError(this.statusCode, this.body);
 }

--- a/lib/cubit/ln_address/services/message_signer.dart
+++ b/lib/cubit/ln_address/services/message_signer.dart
@@ -1,0 +1,27 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('MessageSigner');
+
+class MessageSigner {
+  final BreezSDKLiquid breezSdkLiquid;
+
+  MessageSigner(this.breezSdkLiquid);
+
+  Future<String> signMessage(String message) async {
+    _logger.info('Signing message: $message');
+
+    final SignMessageResponse? signMessageRes = breezSdkLiquid.instance?.signMessage(
+      req: SignMessageRequest(message: message),
+    );
+
+    if (signMessageRes == null) {
+      _logger.severe('Failed to sign message.');
+      throw Exception('Failed to sign message');
+    }
+
+    _logger.info('Successfully signed message');
+    return signMessageRes.signature;
+  }
+}

--- a/lib/cubit/ln_address/services/registration_manager.dart
+++ b/lib/cubit/ln_address/services/registration_manager.dart
@@ -150,8 +150,10 @@ class LnUrlRegistrationManager {
     String? baseUsername,
   }) async {
     try {
-      final RegisterRecoverLnurlPayResponse response =
-          await _recoverWebhook(pubKey: pubKey, webhookUrl: webhookUrl);
+      final RegisterRecoverLnurlPayResponse response = await _recoverWebhook(
+        pubKey: pubKey,
+        webhookUrl: webhookUrl,
+      );
 
       if (response.lightningAddress.isNotEmpty) {
         if (_logger.isLoggable(Level.INFO)) {
@@ -313,8 +315,9 @@ class LnUrlRegistrationManager {
       _logger.fine('Unregistering webhook: $webhookUrl');
     }
 
-    final UnregisterRecoverLnurlPayRequest request =
-        await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
+    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildRecoverRequest(
+      webhookUrl: webhookUrl,
+    );
     await lnAddressService.unregister(pubKey: pubKey, request: request);
   }
 
@@ -324,8 +327,10 @@ class LnUrlRegistrationManager {
     required String webhookUrl,
     String? username,
   }) async {
-    final RegisterLnurlPayRequest request =
-        await requestBuilder.buildRegisterRequest(webhookUrl: webhookUrl, username: username);
+    final RegisterLnurlPayRequest request = await requestBuilder.buildRegisterRequest(
+      webhookUrl: webhookUrl,
+      username: username,
+    );
 
     if (_logger.isLoggable(Level.INFO)) {
       _logger.info('Attempting to register LNURL Webhook for pubKey: $pubKey');
@@ -423,8 +428,9 @@ class LnUrlRegistrationManager {
       _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
     }
 
-    final UnregisterRecoverLnurlPayRequest request =
-        await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
+    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildRecoverRequest(
+      webhookUrl: webhookUrl,
+    );
 
     try {
       final RegisterRecoverLnurlPayResponse recoverResponse = await lnAddressService.recover(

--- a/lib/cubit/ln_address/services/registration_manager.dart
+++ b/lib/cubit/ln_address/services/registration_manager.dart
@@ -1,0 +1,236 @@
+import 'package:breez_preferences/breez_preferences.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('LnUrlRegistrationManager');
+
+class LnUrlRegistrationManager {
+  static const int maxRetries = 3;
+
+  final LnUrlPayService lnAddressService;
+  final BreezPreferences breezPreferences;
+  final WebhookRequestBuilder requestBuilder;
+  final UsernameResolver usernameResolver;
+  final WebhookService webhookService;
+
+  LnUrlRegistrationManager({
+    required this.lnAddressService,
+    required this.breezPreferences,
+    required this.requestBuilder,
+    required this.usernameResolver,
+    required this.webhookService,
+  });
+
+  Future<String> setupWebhook(String pubKey) async {
+    _logger.info('Setting up webhook for pubKey: $pubKey');
+    final String webhookUrl = await webhookService.generateWebhookUrl();
+    await unregisterExistingWebhookIfNeeded(pubKey: pubKey, webhookUrl: webhookUrl);
+    await webhookService.register(webhookUrl);
+    await breezPreferences.setWebhookUrl(webhookUrl);
+    _logger.info('Successfully setup webhook');
+    return webhookUrl;
+  }
+
+  Future<void> unregisterExistingWebhookIfNeeded({required String pubKey, required String webhookUrl}) async {
+    final String? existingWebhook = await breezPreferences.webhookUrl;
+    if (existingWebhook != null && existingWebhook != webhookUrl) {
+      _logger.info('Unregistering existing webhook: $existingWebhook');
+      await unregisterWebhook(pubKey: pubKey, webhookUrl: existingWebhook);
+      breezPreferences.removeWebhookUrl();
+      _logger.info('Successfully unregistered existing webhook');
+    }
+  }
+
+  Future<void> unregisterWebhook({
+    required String pubKey,
+    required String webhookUrl,
+  }) async {
+    _logger.info('Unregistering webhook: $webhookUrl');
+    final UnregisterRecoverLnurlPayRequest request =
+        await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
+    await lnAddressService.unregister(pubKey: pubKey, request: request);
+  }
+
+  Future<RegisterRecoverLnurlPayResponse> registerWithRetries({
+    required String pubKey,
+    required String webhookUrl,
+    required String username,
+  }) async {
+    final String baseUsername = username;
+    for (int retryCount = 1; retryCount <= maxRetries; retryCount++) {
+      try {
+        _logger.info('Attempt $retryCount/$maxRetries with username: $username');
+        return await attemptRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          username: username,
+        );
+      } on UsernameConflictException {
+        _logger.warning('Username conflict for: $username.');
+        username = UsernameGenerator.generateUsername(baseUsername, retryCount);
+      } catch (e) {
+        _logger.severe('Failed to register LNURL Webhook on attempt $retryCount.', e);
+        if (retryCount == maxRetries) {
+          rethrow;
+        }
+      }
+    }
+
+    _logger.severe('Max retries exceeded for username registration');
+    throw MaxRetriesExceededException();
+  }
+
+  Future<RegisterRecoverLnurlPayResponse> attemptRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    String? username,
+  }) async {
+    final RegisterLnurlPayRequest request =
+        await requestBuilder.buildRegisterRequest(webhookUrl: webhookUrl, username: username);
+
+    _logger.info('Attempting to register LNURL Webhook for pubKey: $pubKey');
+    final RegisterRecoverLnurlPayResponse response = await lnAddressService.register(
+      pubKey: pubKey,
+      request: request,
+    );
+
+    if (username != null && username.isNotEmpty) {
+      await breezPreferences.setLnAddressUsername(username);
+    }
+
+    _logger.info('Successfully registered LNURL Webhook');
+    await breezPreferences.setLnUrlWebhookRegistered();
+    return response;
+  }
+
+  Future<RegisterRecoverLnurlPayResponse> recoverWebhook({
+    required String pubKey,
+    required String webhookUrl,
+  }) async {
+    _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
+    final UnregisterRecoverLnurlPayRequest request =
+        await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
+
+    try {
+      final RegisterRecoverLnurlPayResponse recoverResponse = await lnAddressService.recover(
+        pubKey: pubKey,
+        request: request,
+      );
+
+      final String lightningAddress = recoverResponse.lightningAddress;
+      if (lightningAddress.isEmpty) {
+        _logger.warning('Recover response has no Lightning Address. Will need fallback to registration.');
+        return recoverResponse;
+      }
+
+      final String username = lightningAddress.split('@').first;
+      if (username.isNotEmpty) {
+        await breezPreferences.setLnAddressUsername(username);
+      }
+
+      _logger.info('Successfully recovered LNURL Webhook');
+      await breezPreferences.setLnUrlWebhookRegistered();
+      return recoverResponse;
+    } catch (e) {
+      _logger.severe('Failed to recover LNURL Webhook.', e);
+      rethrow;
+    }
+  }
+
+  // The main orchestrator for all registration operations
+  Future<RegisterRecoverLnurlPayResponse> performRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    required String registrationType,
+    String? baseUsername,
+    String? recoveredLightningAddress,
+  }) async {
+    switch (registrationType) {
+      case RegistrationType.recovery:
+        try {
+          final RegisterRecoverLnurlPayResponse response =
+              await recoverWebhook(pubKey: pubKey, webhookUrl: webhookUrl);
+
+          // If we recovered successfully, we need to re-register to transfer ownership
+          if (response.lightningAddress.isNotEmpty) {
+            _logger.info('Recovered LNURL Webhook successfully. Re-registering to transfer ownership.');
+            return await performRegistration(
+              pubKey: pubKey,
+              webhookUrl: webhookUrl,
+              registrationType: RegistrationType.ownershipTransfer,
+              recoveredLightningAddress: response.lightningAddress,
+            );
+          }
+
+          // If recovery didn't have a lightning address, fall back to new registration
+          _logger.info('Recovery did not return a Lightning Address. Falling back to new registration.');
+          return await performRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            registrationType: RegistrationType.newRegistration,
+            baseUsername: baseUsername,
+          );
+        } on WebhookNotFoundException {
+          // Fallback to register a new webhook if recovery fails
+          _logger.info('Failed to recover LNURL Webhook. Falling back to registration.');
+          return await performRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            registrationType: RegistrationType.newRegistration,
+            baseUsername: baseUsername,
+          );
+        }
+
+      /// Handles re-registration after successful recovery for device ownership transfer.
+      /// Preserves the username from the recovered lightning address.
+      case RegistrationType.ownershipTransfer:
+        final String? username = await usernameResolver.resolveUsername(
+          isNewRegistration: false, // Ownership transfer is not a new registration
+          recoveredLightningAddress: recoveredLightningAddress,
+          baseUsername: baseUsername,
+        );
+        return await attemptRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          username: username,
+        );
+
+      case RegistrationType.update:
+        final bool isLnUrlWebhookRegistered = await breezPreferences.isLnUrlWebhookRegistered;
+        if (!isLnUrlWebhookRegistered) {
+          // If updating a username but no webhook exists, treat as new registration
+          return await performRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            registrationType: RegistrationType.newRegistration,
+            baseUsername: baseUsername,
+          );
+        }
+
+        final String? username = await usernameResolver.resolveUsername(
+          isNewRegistration: false,
+          recoveredLightningAddress: recoveredLightningAddress,
+          baseUsername: baseUsername,
+        );
+        return await attemptRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          username: username,
+        );
+
+      case RegistrationType.newRegistration:
+      default:
+        final String? username = await usernameResolver.resolveUsername(
+          isNewRegistration: true,
+          recoveredLightningAddress: recoveredLightningAddress,
+          baseUsername: baseUsername,
+        );
+
+        return await registerWithRetries(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          username: username!,
+        );
+    }
+  }
+}

--- a/lib/cubit/ln_address/services/registration_manager.dart
+++ b/lib/cubit/ln_address/services/registration_manager.dart
@@ -315,7 +315,7 @@ class LnUrlRegistrationManager {
       _logger.fine('Unregistering webhook: $webhookUrl');
     }
 
-    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildRecoverRequest(
+    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildUnregisterRecoverRequest(
       webhookUrl: webhookUrl,
     );
     await lnAddressService.unregister(pubKey: pubKey, request: request);
@@ -428,7 +428,7 @@ class LnUrlRegistrationManager {
       _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
     }
 
-    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildRecoverRequest(
+    final UnregisterRecoverLnurlPayRequest request = await requestBuilder.buildUnregisterRecoverRequest(
       webhookUrl: webhookUrl,
     );
 

--- a/lib/cubit/ln_address/services/registration_manager.dart
+++ b/lib/cubit/ln_address/services/registration_manager.dart
@@ -3,15 +3,32 @@ import 'package:l_breez/cubit/cubit.dart';
 import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('LnUrlRegistrationManager');
+final RegExp _usernameRegex = RegExp(r'^([^@]+)');
 
+/// Manages Lightning URL address registration workflows.
+///
+/// This service is responsible for coordinating all LNURL registration operations:
+/// - New registrations (with automatic retries for username conflicts)
+/// - Username updates for existing registrations
+/// - Recovery of existing registrations
+/// - Ownership transfer (re-registration after recovery)
+///
+/// It provides a single entry point [performRegistration] that handles all scenarios
+/// based on the provided [RegistrationType].
 class LnUrlRegistrationManager {
   static const int maxRetries = 3;
+  static const Duration _retryBackoff = Duration(milliseconds: 500);
 
   final LnUrlPayService lnAddressService;
   final BreezPreferences breezPreferences;
   final WebhookRequestBuilder requestBuilder;
   final UsernameResolver usernameResolver;
   final WebhookService webhookService;
+
+  // Cached preference values
+  String? _cachedWebhookUrl;
+  String? _cachedUsername;
+  bool? _isWebhookRegistered;
 
   LnUrlRegistrationManager({
     required this.lnAddressService,
@@ -21,66 +38,288 @@ class LnUrlRegistrationManager {
     required this.webhookService,
   });
 
+  /// Initializes cache for frequently accessed preferences.
+  Future<void> _initPreferencesCache() async {
+    _cachedWebhookUrl = await breezPreferences.webhookUrl;
+    _cachedUsername = await breezPreferences.lnAddressUsername;
+    _isWebhookRegistered = await breezPreferences.isLnUrlWebhookRegistered;
+  }
+
+  /// Updates cached preferences and persists changes.
+  Future<void> _updatePreferences({
+    String? webhookUrl,
+    String? username,
+    bool? isRegistered,
+  }) async {
+    // Update cache and persist changes in batch
+    final List<Future<void>> updates = <Future<void>>[];
+
+    if (webhookUrl != null) {
+      _cachedWebhookUrl = webhookUrl;
+      updates.add(breezPreferences.setWebhookUrl(webhookUrl));
+    }
+
+    if (username != null) {
+      _cachedUsername = username;
+      updates.add(breezPreferences.setLnAddressUsername(username));
+    }
+
+    if (isRegistered != null && isRegistered) {
+      _isWebhookRegistered = true;
+      updates.add(breezPreferences.setLnUrlWebhookRegistered());
+    }
+
+    if (updates.isNotEmpty) {
+      await Future.wait(updates);
+    }
+  }
+
+  /// Orchestrates the registration process based on the registration type.
+  Future<RegisterRecoverLnurlPayResponse> performRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    required String registrationType,
+    String? baseUsername,
+    String? recoveredLightningAddress,
+  }) async {
+    // Initialize preference cache for this operation
+    await _initPreferencesCache();
+
+    try {
+      switch (registrationType) {
+        case RegistrationType.recovery:
+          return await _handleRecoveryRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            baseUsername: baseUsername,
+          );
+        case RegistrationType.ownershipTransfer:
+          return await _handleOwnershipTransferRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            baseUsername: baseUsername,
+            recoveredLightningAddress: recoveredLightningAddress,
+          );
+        case RegistrationType.update:
+          return await _handleUpdateRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            baseUsername: baseUsername,
+            recoveredLightningAddress: recoveredLightningAddress,
+          );
+        case RegistrationType.newRegistration:
+        default:
+          return await _handleNewRegistration(
+            pubKey: pubKey,
+            webhookUrl: webhookUrl,
+            baseUsername: baseUsername,
+            recoveredLightningAddress: recoveredLightningAddress,
+          );
+      }
+    } catch (e) {
+      _logger.severe('Registration failed. Type: $registrationType', e);
+      rethrow;
+    }
+  }
+
+  /// Sets up a webhook for the given public key.
   Future<String> setupWebhook(String pubKey) async {
+    await _initPreferencesCache();
     _logger.info('Setting up webhook for pubKey: $pubKey');
+
+    // First, generate the new webhook URL
     final String webhookUrl = await webhookService.generateWebhookUrl();
-    await unregisterExistingWebhookIfNeeded(pubKey: pubKey, webhookUrl: webhookUrl);
-    await webhookService.register(webhookUrl);
-    await breezPreferences.setWebhookUrl(webhookUrl);
+
+    // Then unregister any existing webhook
+    await _unregisterExistingWebhookIfNeeded(pubKey: pubKey, newWebhookUrl: webhookUrl);
+
+    // Finally register the new webhook and update preferences in parallel
+    await Future.wait(<Future<void>>[
+      webhookService.register(webhookUrl),
+      _updatePreferences(webhookUrl: webhookUrl),
+    ]);
+
     _logger.info('Successfully setup webhook');
     return webhookUrl;
   }
 
-  Future<void> unregisterExistingWebhookIfNeeded({required String pubKey, required String webhookUrl}) async {
-    final String? existingWebhook = await breezPreferences.webhookUrl;
-    if (existingWebhook != null && existingWebhook != webhookUrl) {
-      _logger.info('Unregistering existing webhook: $existingWebhook');
-      await unregisterWebhook(pubKey: pubKey, webhookUrl: existingWebhook);
-      breezPreferences.removeWebhookUrl();
-      _logger.info('Successfully unregistered existing webhook');
+  /// Handles the recovery registration flow.
+  Future<RegisterRecoverLnurlPayResponse> _handleRecoveryRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    String? baseUsername,
+  }) async {
+    try {
+      final RegisterRecoverLnurlPayResponse response =
+          await _recoverWebhook(pubKey: pubKey, webhookUrl: webhookUrl);
+
+      if (response.lightningAddress.isNotEmpty) {
+        if (_logger.isLoggable(Level.INFO)) {
+          _logger.info('Recovered LNURL Webhook successfully. Re-registering to transfer ownership.');
+        }
+        return await _handleOwnershipTransferRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          recoveredLightningAddress: response.lightningAddress,
+          baseUsername: baseUsername,
+        );
+      }
+
+      if (_logger.isLoggable(Level.INFO)) {
+        _logger.info('Recovery did not return a Lightning Address. Falling back to new registration.');
+      }
+      return await _handleNewRegistration(
+        pubKey: pubKey,
+        webhookUrl: webhookUrl,
+        baseUsername: baseUsername,
+      );
+    } catch (e) {
+      // Only log and process specific exceptions we can handle
+      if (e is WebhookNotFoundException) {
+        if (_logger.isLoggable(Level.INFO)) {
+          _logger.info('Failed to recover LNURL Webhook. Falling back to registration.');
+        }
+        return await _handleNewRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          baseUsername: baseUsername,
+        );
+      }
+      // Re-throw other exceptions for handling at higher level
+      rethrow;
     }
   }
 
-  Future<void> unregisterWebhook({
+  /// Handles the ownership transfer registration flow after successful recovery.
+  Future<RegisterRecoverLnurlPayResponse> _handleOwnershipTransferRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    String? baseUsername,
+    String? recoveredLightningAddress,
+  }) async {
+    if (_logger.isLoggable(Level.INFO)) {
+      _logger.info('Processing ownership transfer registration');
+    }
+
+    final String? username = await usernameResolver.resolveUsername(
+      isNewRegistration: false, // Ownership transfer preserves existing username
+      recoveredLightningAddress: recoveredLightningAddress,
+      baseUsername: baseUsername,
+    );
+
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Using username for ownership transfer: ${username ?? "null"}');
+    }
+
+    return await _attemptRegistration(
+      pubKey: pubKey,
+      webhookUrl: webhookUrl,
+      username: username,
+    );
+  }
+
+  /// Handles the update registration flow.
+  Future<RegisterRecoverLnurlPayResponse> _handleUpdateRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    String? baseUsername,
+    String? recoveredLightningAddress,
+  }) async {
+    // Use cached values if available
+    final bool isLnUrlWebhookRegistered =
+        _isWebhookRegistered ?? await breezPreferences.isLnUrlWebhookRegistered;
+
+    // Pass cached username as baseUsername if no explicit baseUsername was provided
+    final String? effectiveBaseUsername = baseUsername ?? _cachedUsername;
+
+    if (!isLnUrlWebhookRegistered) {
+      return await _handleNewRegistration(
+        pubKey: pubKey,
+        webhookUrl: webhookUrl,
+        baseUsername: baseUsername,
+      );
+    }
+
+    final String? username = await usernameResolver.resolveUsername(
+      isNewRegistration: false,
+      recoveredLightningAddress: recoveredLightningAddress,
+      baseUsername: effectiveBaseUsername,
+    );
+
+    return await _attemptRegistration(
+      pubKey: pubKey,
+      webhookUrl: webhookUrl,
+      username: username,
+    );
+  }
+
+  /// Handles the new registration flow.
+  Future<RegisterRecoverLnurlPayResponse> _handleNewRegistration({
+    required String pubKey,
+    required String webhookUrl,
+    String? baseUsername,
+    String? recoveredLightningAddress,
+  }) async {
+    final String? username = await usernameResolver.resolveUsername(
+      isNewRegistration: true,
+      recoveredLightningAddress: recoveredLightningAddress,
+      baseUsername: baseUsername,
+    );
+
+    return await _registerWithRetries(
+      pubKey: pubKey,
+      webhookUrl: webhookUrl,
+      username: username!,
+    );
+  }
+
+  /// Unregisters an existing webhook if it exists and differs from the new webhook URL.
+  Future<String?> _unregisterExistingWebhookIfNeeded({
+    required String pubKey,
+    String? newWebhookUrl,
+  }) async {
+    // Use cached webhook URL if available
+    final String? existingWebhook = _cachedWebhookUrl ?? await breezPreferences.webhookUrl;
+
+    if (existingWebhook != null && (newWebhookUrl == null || existingWebhook != newWebhookUrl)) {
+      if (_logger.isLoggable(Level.INFO)) {
+        _logger.info('Unregistering existing webhook: $existingWebhook');
+      }
+
+      try {
+        await _unregisterWebhook(pubKey: pubKey, webhookUrl: existingWebhook);
+        breezPreferences.removeWebhookUrl();
+        _cachedWebhookUrl = null;
+
+        if (_logger.isLoggable(Level.FINE)) {
+          _logger.fine('Successfully unregistered existing webhook');
+        }
+        return existingWebhook;
+      } catch (e) {
+        // Log but don't rethrow - we want to continue even if unregister fails
+        _logger.warning('Failed to unregister existing webhook: $existingWebhook', e);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /// Unregisters a webhook.
+  Future<void> _unregisterWebhook({
     required String pubKey,
     required String webhookUrl,
   }) async {
-    _logger.info('Unregistering webhook: $webhookUrl');
+    if (_logger.isLoggable(Level.FINE)) {
+      _logger.fine('Unregistering webhook: $webhookUrl');
+    }
+
     final UnregisterRecoverLnurlPayRequest request =
         await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
     await lnAddressService.unregister(pubKey: pubKey, request: request);
   }
 
-  Future<RegisterRecoverLnurlPayResponse> registerWithRetries({
-    required String pubKey,
-    required String webhookUrl,
-    required String username,
-  }) async {
-    final String baseUsername = username;
-    for (int retryCount = 1; retryCount <= maxRetries; retryCount++) {
-      try {
-        _logger.info('Attempt $retryCount/$maxRetries with username: $username');
-        return await attemptRegistration(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          username: username,
-        );
-      } on UsernameConflictException {
-        _logger.warning('Username conflict for: $username.');
-        username = UsernameGenerator.generateUsername(baseUsername, retryCount);
-      } catch (e) {
-        _logger.severe('Failed to register LNURL Webhook on attempt $retryCount.', e);
-        if (retryCount == maxRetries) {
-          rethrow;
-        }
-      }
-    }
-
-    _logger.severe('Max retries exceeded for username registration');
-    throw MaxRetriesExceededException();
-  }
-
-  Future<RegisterRecoverLnurlPayResponse> attemptRegistration({
+  /// Attempts to register a webhook with the given username.
+  Future<RegisterRecoverLnurlPayResponse> _attemptRegistration({
     required String pubKey,
     required String webhookUrl,
     String? username,
@@ -88,26 +327,102 @@ class LnUrlRegistrationManager {
     final RegisterLnurlPayRequest request =
         await requestBuilder.buildRegisterRequest(webhookUrl: webhookUrl, username: username);
 
-    _logger.info('Attempting to register LNURL Webhook for pubKey: $pubKey');
+    if (_logger.isLoggable(Level.INFO)) {
+      _logger.info('Attempting to register LNURL Webhook for pubKey: $pubKey');
+    }
+
     final RegisterRecoverLnurlPayResponse response = await lnAddressService.register(
       pubKey: pubKey,
       request: request,
     );
 
-    if (username != null && username.isNotEmpty) {
-      await breezPreferences.setLnAddressUsername(username);
+    // Batch preference updates to minimize disk writes
+    await _updatePreferences(
+      username: username?.isNotEmpty == true ? username : null,
+      isRegistered: true,
+    );
+
+    if (_logger.isLoggable(Level.INFO)) {
+      _logger.info('Successfully registered LNURL Webhook');
     }
 
-    _logger.info('Successfully registered LNURL Webhook');
-    await breezPreferences.setLnUrlWebhookRegistered();
     return response;
   }
 
-  Future<RegisterRecoverLnurlPayResponse> recoverWebhook({
+  /// Attempts to register a webhook with retries for username conflicts.
+  Future<RegisterRecoverLnurlPayResponse> _registerWithRetries({
+    required String pubKey,
+    required String webhookUrl,
+    required String username,
+  }) async {
+    final String baseUsername = username;
+
+    // Pre-generate potential usernames to avoid regenerating on each retry
+    final List<String> alternativeUsernames = <String>[];
+    for (int i = 1; i < maxRetries; i++) {
+      alternativeUsernames.add(UsernameGenerator.generateUsername(baseUsername, i));
+    }
+
+    // Initialize with the base username
+    String currentUsername = username;
+    Exception? lastException;
+
+    for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
+      try {
+        if (_logger.isLoggable(Level.INFO)) {
+          _logger.info('Attempt ${retryCount + 1}/$maxRetries with username: $currentUsername');
+        }
+
+        // Attempt registration
+        return await _attemptRegistration(
+          pubKey: pubKey,
+          webhookUrl: webhookUrl,
+          username: currentUsername,
+        );
+      } on UsernameConflictException {
+        if (_logger.isLoggable(Level.WARNING)) {
+          _logger.warning('Username conflict for: $currentUsername.');
+        }
+
+        if (retryCount < maxRetries - 1) {
+          // Use pre-generated username for next attempt
+          currentUsername = alternativeUsernames[retryCount];
+
+          // Apply exponential backoff
+          final Duration backoffTime = _retryBackoff * (1 << retryCount);
+          await Future<void>.delayed(backoffTime);
+        } else {
+          _logger.severe('Max retries exceeded for username registration');
+          throw MaxRetriesExceededException();
+        }
+      } catch (e) {
+        // For non-username errors, track the last exception
+        _logger.severe('Failed to register LNURL Webhook on attempt ${retryCount + 1}.', e);
+        lastException = e is Exception ? e : Exception(e.toString());
+
+        if (retryCount == maxRetries - 1) {
+          throw lastException;
+        }
+
+        // Apply exponential backoff
+        final Duration backoffTime = _retryBackoff * (1 << retryCount);
+        await Future<void>.delayed(backoffTime);
+      }
+    }
+
+    // Fallback exception if somehow loop exits without returning or throwing
+    throw lastException ?? MaxRetriesExceededException();
+  }
+
+  /// Attempts to recover an existing webhook.
+  Future<RegisterRecoverLnurlPayResponse> _recoverWebhook({
     required String pubKey,
     required String webhookUrl,
   }) async {
-    _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
+    if (_logger.isLoggable(Level.INFO)) {
+      _logger.info('Attempting to recover LNURL Webhook for pubKey: $pubKey');
+    }
+
     final UnregisterRecoverLnurlPayRequest request =
         await requestBuilder.buildRecoverRequest(webhookUrl: webhookUrl);
 
@@ -119,118 +434,43 @@ class LnUrlRegistrationManager {
 
       final String lightningAddress = recoverResponse.lightningAddress;
       if (lightningAddress.isEmpty) {
-        _logger.warning('Recover response has no Lightning Address. Will need fallback to registration.');
+        if (_logger.isLoggable(Level.WARNING)) {
+          _logger.warning('Recover response has no Lightning Address. Will need fallback to registration.');
+        }
         return recoverResponse;
       }
 
-      final String username = lightningAddress.split('@').first;
+      // Use regexp for efficient username extraction
+      final String username = _extractUsernameFromLightningAddress(lightningAddress);
+
+      // Batch preference updates into one call
       if (username.isNotEmpty) {
-        await breezPreferences.setLnAddressUsername(username);
+        await _updatePreferences(
+          username: username,
+          isRegistered: true,
+        );
       }
 
-      _logger.info('Successfully recovered LNURL Webhook');
-      await breezPreferences.setLnUrlWebhookRegistered();
+      if (_logger.isLoggable(Level.INFO)) {
+        _logger.info('Successfully recovered LNURL Webhook');
+      }
+
       return recoverResponse;
     } catch (e) {
-      _logger.severe('Failed to recover LNURL Webhook.', e);
+      if (_logger.isLoggable(Level.SEVERE)) {
+        _logger.severe('Failed to recover LNURL Webhook.', e);
+      }
       rethrow;
     }
   }
 
-  // The main orchestrator for all registration operations
-  Future<RegisterRecoverLnurlPayResponse> performRegistration({
-    required String pubKey,
-    required String webhookUrl,
-    required String registrationType,
-    String? baseUsername,
-    String? recoveredLightningAddress,
-  }) async {
-    switch (registrationType) {
-      case RegistrationType.recovery:
-        try {
-          final RegisterRecoverLnurlPayResponse response =
-              await recoverWebhook(pubKey: pubKey, webhookUrl: webhookUrl);
-
-          // If we recovered successfully, we need to re-register to transfer ownership
-          if (response.lightningAddress.isNotEmpty) {
-            _logger.info('Recovered LNURL Webhook successfully. Re-registering to transfer ownership.');
-            return await performRegistration(
-              pubKey: pubKey,
-              webhookUrl: webhookUrl,
-              registrationType: RegistrationType.ownershipTransfer,
-              recoveredLightningAddress: response.lightningAddress,
-            );
-          }
-
-          // If recovery didn't have a lightning address, fall back to new registration
-          _logger.info('Recovery did not return a Lightning Address. Falling back to new registration.');
-          return await performRegistration(
-            pubKey: pubKey,
-            webhookUrl: webhookUrl,
-            registrationType: RegistrationType.newRegistration,
-            baseUsername: baseUsername,
-          );
-        } on WebhookNotFoundException {
-          // Fallback to register a new webhook if recovery fails
-          _logger.info('Failed to recover LNURL Webhook. Falling back to registration.');
-          return await performRegistration(
-            pubKey: pubKey,
-            webhookUrl: webhookUrl,
-            registrationType: RegistrationType.newRegistration,
-            baseUsername: baseUsername,
-          );
-        }
-
-      /// Handles re-registration after successful recovery for device ownership transfer.
-      /// Preserves the username from the recovered lightning address.
-      case RegistrationType.ownershipTransfer:
-        final String? username = await usernameResolver.resolveUsername(
-          isNewRegistration: false, // Ownership transfer is not a new registration
-          recoveredLightningAddress: recoveredLightningAddress,
-          baseUsername: baseUsername,
-        );
-        return await attemptRegistration(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          username: username,
-        );
-
-      case RegistrationType.update:
-        final bool isLnUrlWebhookRegistered = await breezPreferences.isLnUrlWebhookRegistered;
-        if (!isLnUrlWebhookRegistered) {
-          // If updating a username but no webhook exists, treat as new registration
-          return await performRegistration(
-            pubKey: pubKey,
-            webhookUrl: webhookUrl,
-            registrationType: RegistrationType.newRegistration,
-            baseUsername: baseUsername,
-          );
-        }
-
-        final String? username = await usernameResolver.resolveUsername(
-          isNewRegistration: false,
-          recoveredLightningAddress: recoveredLightningAddress,
-          baseUsername: baseUsername,
-        );
-        return await attemptRegistration(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          username: username,
-        );
-
-      case RegistrationType.newRegistration:
-      default:
-        final String? username = await usernameResolver.resolveUsername(
-          isNewRegistration: true,
-          recoveredLightningAddress: recoveredLightningAddress,
-          baseUsername: baseUsername,
-        );
-
-        return await registerWithRetries(
-          pubKey: pubKey,
-          webhookUrl: webhookUrl,
-          username: username!,
-        );
+  /// Extracts the username part from a lightning address using RegExp.
+  String _extractUsernameFromLightningAddress(String lightningAddress) {
+    if (lightningAddress.isEmpty) {
+      return '';
     }
+
+    final RegExpMatch? match = _usernameRegex.firstMatch(lightningAddress);
+    return match != null ? match.group(1)! : '';
   }
 }

--- a/lib/cubit/ln_address/services/services.dart
+++ b/lib/cubit/ln_address/services/services.dart
@@ -1,2 +1,5 @@
 export 'lnurl_pay_service.dart';
+export 'message_signer.dart';
+export 'registration_manager.dart';
+export 'webhook_request_builder.dart';
 export 'webhook_service.dart';

--- a/lib/cubit/ln_address/services/webhook_request_builder.dart
+++ b/lib/cubit/ln_address/services/webhook_request_builder.dart
@@ -3,40 +3,127 @@ import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('WebhookRequestBuilder');
 
+/// Builds signed webhook requests for Lightning Network services.
+///
+/// This class is responsible for creating properly formatted and signed
+/// webhook requests for LNURL-pay registration, recovery, and unregistration.
 class WebhookRequestBuilder {
+  /// Service used to sign messages with the node's private key
   final MessageSigner messageSigner;
 
+  /// Creates a new WebhookRequestBuilder with the given message signer.
+  ///
+  /// @param messageSigner The service used to create cryptographic signatures
   WebhookRequestBuilder(this.messageSigner);
 
+  /// Builds a request to register a webhook URL with an optional username.
+  ///
+  /// Creates a signed request that can be sent to an LNURL-pay service
+  /// to register a Lightning Address or payment handler.
+  ///
+  /// @param webhookUrl The URL that will receive webhook notifications
+  /// @param username Optional username for the Lightning Address
+  /// @return A properly formatted and signed registration request
+  /// @throws Exception if message signing fails
   Future<RegisterLnurlPayRequest> buildRegisterRequest({
     required String webhookUrl,
     String? username,
   }) async {
-    _logger.info('Building register request with username: $username');
-    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final String usernameComponent = username?.isNotEmpty == true ? '-$username' : '';
-    final String message = '$time-$webhookUrl$usernameComponent';
-    final String signature = await messageSigner.signMessage(message);
+    try {
+      _logger.info('Building registration request for webhook: $webhookUrl');
 
-    return RegisterLnurlPayRequest(
-      time: time,
-      webhookUrl: webhookUrl,
-      signature: signature,
-      username: username,
-    );
+      // Format the username component if provided
+      final String usernameComponent = _formatUsernameComponent(username);
+
+      // Build the signed request
+      final SignedRequestData requestData = await _buildSignedRequestData(
+        webhookUrl: webhookUrl,
+        additionalData: usernameComponent,
+      );
+
+      // Create and return the final request object
+      final RegisterLnurlPayRequest request = RegisterLnurlPayRequest(
+        time: requestData.timestamp,
+        webhookUrl: webhookUrl,
+        signature: requestData.signature,
+        username: username,
+      );
+
+      _logger.info('Successfully built registration request with timestamp: ${requestData.timestamp}');
+      return request;
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to build registration request', e, stackTrace);
+      rethrow;
+    }
   }
 
-  Future<UnregisterRecoverLnurlPayRequest> buildRecoverRequest({
+  /// Builds a request to unregister or recover a webhook URL.
+  ///
+  /// Creates a signed request that can be sent to an LNURL-pay service
+  /// to unregister or recover a Lightning Address or payment handler.
+  ///
+  /// @param webhookUrl The URL to unregister or recover
+  /// @return A properly formatted and signed unregister/recover request
+  /// @throws Exception if message signing fails
+  Future<UnregisterRecoverLnurlPayRequest> buildUnregisterRecoverRequest({
     required String webhookUrl,
   }) async {
-    _logger.info('Building recover/unregister request');
-    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final String message = '$time-$webhookUrl';
+    try {
+      _logger.info('Building unregister/recover request for webhook: $webhookUrl');
+
+      // Build the signed request data
+      final SignedRequestData requestData = await _buildSignedRequestData(
+        webhookUrl: webhookUrl,
+      );
+
+      // Create and return the final request object
+      final UnregisterRecoverLnurlPayRequest request = UnregisterRecoverLnurlPayRequest(
+        time: requestData.timestamp,
+        webhookUrl: webhookUrl,
+        signature: requestData.signature,
+      );
+
+      _logger.info('Successfully built unregister/recover request with timestamp: ${requestData.timestamp}');
+      return request;
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to build unregister/recover request', e, stackTrace);
+      rethrow;
+    }
+  }
+
+  /// Formats the username component for inclusion in the signed message.
+  ///
+  /// @param username The optional username to format
+  /// @return A formatted string with a leading hyphen if username exists, empty string otherwise
+  String _formatUsernameComponent(String? username) {
+    if (username == null || username.isEmpty) {
+      return '';
+    }
+    return '-$username';
+  }
+
+  /// Builds the common signed request data used by all request types.
+  ///
+  /// @param webhookUrl The webhook URL to include in the signed message
+  /// @param additionalData Optional additional data to append to the message
+  /// @return A data object containing the timestamp and signature
+  /// @throws Exception if message signing fails
+  Future<SignedRequestData> _buildSignedRequestData({
+    required String webhookUrl,
+    String additionalData = '',
+  }) async {
+    // Create a Unix timestamp (seconds since epoch)
+    final int timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    // Build the message to sign
+    final String message = '$timestamp-$webhookUrl$additionalData';
+    _logger.fine('Signing message: $message');
+
+    // Sign the message
     final String signature = await messageSigner.signMessage(message);
 
-    return UnregisterRecoverLnurlPayRequest(
-      time: time,
-      webhookUrl: webhookUrl,
+    return SignedRequestData(
+      timestamp: timestamp,
       signature: signature,
     );
   }

--- a/lib/cubit/ln_address/services/webhook_request_builder.dart
+++ b/lib/cubit/ln_address/services/webhook_request_builder.dart
@@ -1,0 +1,43 @@
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('WebhookRequestBuilder');
+
+class WebhookRequestBuilder {
+  final MessageSigner messageSigner;
+
+  WebhookRequestBuilder(this.messageSigner);
+
+  Future<RegisterLnurlPayRequest> buildRegisterRequest({
+    required String webhookUrl,
+    String? username,
+  }) async {
+    _logger.info('Building register request with username: $username');
+    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final String usernameComponent = username?.isNotEmpty == true ? '-$username' : '';
+    final String message = '$time-$webhookUrl$usernameComponent';
+    final String signature = await messageSigner.signMessage(message);
+
+    return RegisterLnurlPayRequest(
+      time: time,
+      webhookUrl: webhookUrl,
+      signature: signature,
+      username: username,
+    );
+  }
+
+  Future<UnregisterRecoverLnurlPayRequest> buildRecoverRequest({
+    required String webhookUrl,
+  }) async {
+    _logger.info('Building recover/unregister request');
+    final int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final String message = '$time-$webhookUrl';
+    final String signature = await messageSigner.signMessage(message);
+
+    return UnregisterRecoverLnurlPayRequest(
+      time: time,
+      webhookUrl: webhookUrl,
+      signature: signature,
+    );
+  }
+}

--- a/lib/cubit/ln_address/services/webhook_service.dart
+++ b/lib/cubit/ln_address/services/webhook_service.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:breez_liquid/breez_liquid.dart';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:firebase_notifications_client/firebase_notifications_client.dart';
 import 'package:flutter/foundation.dart';
@@ -6,56 +9,231 @@ import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('WebhookService');
 
+/// Service responsible for managing webhooks for Lightning Network payments.
+///
+/// Handles webhook registration with the Breez SDK and generation of
+/// webhook URLs for receiving payment notifications.
 class WebhookService {
+  /// Maximum number of retry attempts for operations.
+  static const int _maxRetries = 3;
+
+  /// Default timeout for SDK operations.
+  static const Duration _defaultTimeout = Duration(seconds: 20);
+
+  /// Default cache duration for notification tokens.
+  static const Duration _tokenCacheDuration = Duration(hours: 1);
+
+  /// Base URL for the notification service.
   static const String _notifierServiceURL = 'https://notifier.breez.technology';
 
   final BreezSDKLiquid _breezSdkLiquid;
   final NotificationsClient _notificationsClient;
 
+  /// Cached notification token to avoid repeated requests.
+  String? _cachedToken;
+
+  /// When the token was last cached.
+  DateTime? _tokenCacheTime;
+
+  /// Platform string (ios, android) for webhook URL generation.
+  String? _platformString;
+
+  /// Creates a new [WebhookService] instance.
+  ///
+  /// Requires [BreezSDKLiquid] for webhook registration and
+  /// [NotificationsClient] for notification token management.
   WebhookService(this._breezSdkLiquid, this._notificationsClient);
 
-  Future<void> register(String webhookUrl) async {
+  /// Registers a webhook with the Breez SDK.
+  ///
+  /// The [webhookUrl] is the URL that will receive payment notifications.
+  /// Throws [RegisterWebhookException] if registration fails.
+  Future<void> register(String webhookUrl, {Duration timeout = _defaultTimeout}) async {
+    _logger.info('Registering webhook: $webhookUrl');
+
+    await _executeWithRetry<void>(
+      () => _registerWebhook(webhookUrl, timeout),
+      operationName: 'register webhook',
+    );
+
+    _logger.info('Successfully registered webhook');
+  }
+
+  /// Generates a webhook URL for receiving payment notifications.
+  ///
+  /// The URL includes the device platform and notification token.
+  /// Throws [GenerateWebhookUrlException] if URL generation fails.
+  Future<String> generateWebhookUrl() async {
+    _logger.info('Generating webhook URL');
+
     try {
-      _logger.info('Registering webhook: $webhookUrl');
-      await _breezSdkLiquid.instance?.registerWebhook(webhookUrl: webhookUrl);
-      _logger.info('Successfully registered webhook');
+      final List<String> components = await Future.wait(<Future<String>>[
+        _getPlatform(),
+        _getToken(),
+      ]);
+
+      final String platform = components[0];
+      final String token = components[1];
+
+      final String webhookUrl = '$_notifierServiceURL/api/v1/notify?platform=$platform&token=$token';
+      _logger.info('Generated webhook URL: $webhookUrl');
+
+      return webhookUrl;
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to generate webhook URL', e, stackTrace);
+      throw GenerateWebhookUrlException(e.toString());
+    }
+  }
+
+  /// Registers a webhook with timeout handling.
+  Future<void> _registerWebhook(String webhookUrl, Duration timeout) async {
+    try {
+      final BindingLiquidSdk? sdk = _breezSdkLiquid.instance;
+      if (sdk == null) {
+        throw RegisterWebhookException('Breez SDK not initialized');
+      }
+
+      await sdk.registerWebhook(webhookUrl: webhookUrl).timeout(
+        timeout,
+        onTimeout: () {
+          throw TimeoutException('Webhook registration timed out after ${timeout.inSeconds} seconds');
+        },
+      );
     } catch (e, stackTrace) {
       _logger.severe('Failed to register webhook', e, stackTrace);
       throw RegisterWebhookException('Failed to register webhook: $e');
     }
   }
 
-  Future<String> generateWebhookUrl() async {
-    try {
-      _logger.info('Generating webhook URL');
-      final String platform = _getPlatform();
-      final String token = await _getToken();
-      final String webhookUrl = '$_notifierServiceURL/api/v1/notify?platform=$platform&token=$token';
-      _logger.info('Generated webhook URL: $webhookUrl');
-      return webhookUrl;
-    } catch (e) {
-      _logger.severe('Failed to generate webhook URL', e);
-      throw GenerateWebhookUrlException(e.toString());
+  /// Gets the platform identifier string (ios, android).
+  ///
+  /// Caches the result to avoid unnecessary platform checks.
+  Future<String> _getPlatform() async {
+    // Return cached platform string if available
+    if (_platformString != null) {
+      return _platformString!;
     }
-  }
 
-  String _getPlatform() {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      return 'ios';
+      _platformString = 'ios';
+      return _platformString!;
     }
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return 'android';
+      _platformString = 'android';
+      return _platformString!;
     }
+
     _logger.severe('Unsupported platform: $defaultTargetPlatform');
     throw GenerateWebhookUrlException('Platform not supported');
   }
 
+  /// Gets the notification token from the notification client.
+  ///
+  /// Caches the token to avoid repeated requests and manages token
+  /// refresh when the cache expires.
   Future<String> _getToken() async {
-    final String? token = await _notificationsClient.getToken();
+    // Return cached token if still valid
+    if (_cachedToken != null && _tokenCacheTime != null) {
+      final DateTime now = DateTime.now();
+      if (now.difference(_tokenCacheTime!) < _tokenCacheDuration) {
+        _logger.fine('Using cached notification token');
+        return _cachedToken!;
+      }
+      _logger.fine('Cached token expired, refreshing');
+    }
+
+    final String? token = await _executeWithRetry<String?>(
+      () => _notificationsClient.getToken(),
+      operationName: 'get notification token',
+    );
+
     if (token != null) {
+      // Update cache
+      _cachedToken = token;
+      _tokenCacheTime = DateTime.now();
       return token;
     }
-    _logger.severe('Failed to get notification token');
+
+    _logger.severe('Failed to get notification token after multiple attempts');
     throw GenerateWebhookUrlException('Failed to get notification token');
+  }
+
+  /// Executes an operation with retry logic for transient errors.
+  ///
+  /// [operation] is the async operation to execute.
+  /// [maxRetries] is the maximum number of retry attempts.
+  /// [operationName] is used for logging.
+  Future<T> _executeWithRetry<T>(
+    Future<T> Function() operation, {
+    required String operationName,
+    int maxRetries = _maxRetries,
+  }) async {
+    int attempts = 0;
+    Exception? lastException;
+
+    while (attempts <= maxRetries) {
+      try {
+        return await operation();
+      } on TimeoutException catch (e, stackTrace) {
+        attempts++;
+        lastException = e;
+
+        if (attempts <= maxRetries) {
+          final Duration backoff = Duration(milliseconds: 500 * (1 << attempts));
+          _logger.warning(
+            'Timeout occurred while trying to $operationName. '
+            'Retrying in ${backoff.inMilliseconds}ms (attempt $attempts/$maxRetries)',
+            e,
+            stackTrace,
+          );
+          await Future<void>.delayed(backoff);
+        } else {
+          _logger.severe('Max retries exceeded for $operationName', e, stackTrace);
+          rethrow;
+        }
+      } catch (e, stackTrace) {
+        // Only retry specific errors that are likely transient
+        if (_isTransientError(e)) {
+          attempts++;
+          lastException = e is Exception ? e : Exception(e.toString());
+
+          if (attempts <= maxRetries) {
+            final Duration backoff = Duration(milliseconds: 500 * (1 << attempts));
+            _logger.warning(
+              'Transient error occurred while trying to $operationName. '
+              'Retrying in ${backoff.inMilliseconds}ms (attempt $attempts/$maxRetries)',
+              e,
+              stackTrace,
+            );
+            await Future<void>.delayed(backoff);
+          } else {
+            _logger.severe('Max retries exceeded for $operationName', e, stackTrace);
+            throw lastException;
+          }
+        } else {
+          // Non-transient errors should not be retried
+          _logger.severe('Non-transient error occurred during $operationName', e, stackTrace);
+          rethrow;
+        }
+      }
+    }
+
+    // This should never be reached unless something went wrong
+    throw lastException ?? Exception('Failed to $operationName after multiple attempts');
+  }
+
+  /// Determines if an error is transient and can be retried.
+  bool _isTransientError(dynamic error) {
+    // Customize this logic based on specific error types in your application
+    return error is TimeoutException ||
+        error.toString().contains('network') ||
+        error.toString().contains('connection') ||
+        error.toString().contains('timeout');
+  }
+
+  /// Clears any cached tokens to force a refresh on next operation.
+  void clearCache() {
+    _cachedToken = null;
+    _tokenCacheTime = null;
   }
 }

--- a/lib/cubit/ln_address/utils/username_formatter.dart
+++ b/lib/cubit/ln_address/utils/username_formatter.dart
@@ -1,48 +1,147 @@
+import 'dart:collection';
+
 import 'package:flutter/services.dart';
 
+/// A formatter for validating and formatting usernames in text input fields.
+///
+/// This formatter ensures that usernames only contain valid characters
+/// and follow specific formatting rules (no consecutive dots, etc.).
 class UsernameInputFormatter extends TextInputFormatter {
-  static final RegExp _usernameRegExp = RegExp(
-    r'^[a-zA-Z0-9._%+-]+$',
-  );
+  /// Regular expression for valid username characters: letters, numbers, and certain symbols
+  static final RegExp _validCharRegExp = RegExp(r'^[a-zA-Z0-9._%+-]+$');
 
-  static final RegExp _noConsecutiveDotsRegExp = RegExp(
-    r'\.\.',
-  );
+  /// Regular expression to detect consecutive dots
+  static final RegExp _consecutiveDotsRegExp = RegExp(r'\.\.');
 
   @override
   TextEditingValue formatEditUpdate(
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
-    // Check if the username matches the valid characters and does not contain consecutive dots
-    if (_usernameRegExp.hasMatch(newValue.text) && !_noConsecutiveDotsRegExp.hasMatch(newValue.text)) {
+    // Fix for backspace bug: Always allow deletion operations
+    if (newValue.text.length < oldValue.text.length) {
       return newValue;
     }
-    return oldValue; // Revert to old value if invalid
+
+    // Validate the input for allowed characters and formatting rules
+    if (_isValidUsername(newValue.text)) {
+      return newValue;
+    } else {
+      return oldValue;
+    }
+  }
+
+  /// Validates if the given string follows username formatting rules.
+  ///
+  /// Returns true if the username contains only valid characters
+  /// and does not contain consecutive dots.
+  bool _isValidUsername(String username) {
+    return _validCharRegExp.hasMatch(username) && !_consecutiveDotsRegExp.hasMatch(username);
   }
 }
 
+/// Utility class for sanitizing and formatting usernames.
+///
+/// Provides methods to clean and format raw username strings for storage
+/// and display, following consistent username rules.
 class UsernameFormatter {
-  // Example: ".  Satoshi Nakamoto." -> "satoshinakamoto"
+  /// Cache size for sanitized usernames
+  static const int _maxCacheSize = 100;
+
+  /// LRU cache for sanitized usernames
+  static final LinkedHashMap<String, String> _sanitizeCache = LinkedHashMap<String, String>();
+
+  /// Sanitizes a raw username by removing invalid characters and formatting.
+  ///
+  /// Performs the following operations:
+  /// - Trims leading and trailing whitespace
+  /// - Removes leading and trailing dots
+  /// - Converts to lowercase
+  /// - Removes all spaces
+  ///
+  /// Example: ".  Satoshi Nakamoto." -> "satoshinakamoto"
+  ///
+  /// Returns an empty string if the input is empty.
   static String sanitize(String rawUsername) {
     if (rawUsername.isEmpty) {
       return '';
     }
 
-    // Ensure no leading or trailing dots
-    String sanitized = rawUsername.trim();
-    if (sanitized.startsWith('.')) {
-      sanitized = sanitized.substring(1);
-    }
-    if (sanitized.endsWith('.')) {
-      sanitized = sanitized.substring(0, sanitized.length - 1);
+    // Check cache first
+    if (_sanitizeCache.containsKey(rawUsername)) {
+      // Move this entry to the end (most recently used)
+      final String value = _sanitizeCache.remove(rawUsername)!;
+      _sanitizeCache[rawUsername] = value;
+      return value;
     }
 
-    return sanitized.toLowerCase().replaceAll(' ', '');
+    try {
+      // Create a sanitized version following username rules
+      String sanitized = rawUsername.trim();
+
+      // Remove leading and trailing dots
+      sanitized = _removeLeadingTrailingDots(sanitized);
+
+      // Convert to lowercase and remove spaces
+      sanitized = sanitized.toLowerCase().replaceAll(' ', '');
+
+      // Cache the result
+      _addToCache(rawUsername, sanitized);
+
+      return sanitized;
+    } catch (e) {
+      return '';
+    }
   }
 
-  // Example: "Tomato Elephant" -> "tomatoelephant"
+  /// Adds a key-value pair to the cache, managing its size.
+  ///
+  /// If the cache is at capacity, removes the least recently used entry.
+  static void _addToCache(String key, String value) {
+    if (_sanitizeCache.length >= _maxCacheSize) {
+      // Remove least recently used (first key)
+      _sanitizeCache.remove(_sanitizeCache.keys.first);
+    }
+    _sanitizeCache[key] = value;
+  }
+
+  /// Efficiently removes leading and trailing dots from a string.
+  static String _removeLeadingTrailingDots(String input) {
+    if (input.isEmpty) {
+      return input;
+    }
+
+    String result = input;
+    // Remove leading dots
+    while (result.isNotEmpty && result.startsWith('.')) {
+      result = result.substring(1);
+    }
+
+    // Remove trailing dots
+    while (result.isNotEmpty && result.endsWith('.')) {
+      result = result.substring(0, result.length - 1);
+    }
+
+    return result;
+  }
+
+  /// Formats a default profile name according to username rules.
+  ///
+  /// Takes a potential null input and sanitizes it for use as a username.
+  ///
+  /// Example: "Tomato Elephant" -> "tomatoelephant"
+  ///
+  /// Returns an empty string if input is null or empty.
   static String formatDefaultProfileName(String? defaultProfileName) {
-    return sanitize(defaultProfileName ?? '');
+    final String nameToFormat = defaultProfileName ?? '';
+
+    return sanitize(nameToFormat);
+  }
+
+  /// Clears the username sanitization cache.
+  ///
+  /// Can be called to free memory when the cache is no longer needed.
+  static void clearCache() {
+    _sanitizeCache.clear();
   }
 }

--- a/lib/cubit/ln_address/utils/username_generator.dart
+++ b/lib/cubit/ln_address/utils/username_generator.dart
@@ -1,16 +1,83 @@
 import 'dart:math';
 
+import 'package:logging/logging.dart';
+
+Logger _logger = Logger('UsernameGenerator');
+
+/// A utility class for generating usernames with optional random discriminators.
+///
+/// Used when creating a new wallet to generate default profile usernames.
+/// Example flow: "Red Panda" => "redpanda" -> "redpanda0231" -> "redpanda7439"
 class UsernameGenerator {
+  /// The length of the random discriminator to append to usernames
   static const int _discriminatorLength = 4;
+
+  /// Maximum possible discriminator value (10^_discriminatorLength - 1)
+  static const int _maxDiscriminatorValue = 10000;
+
+  /// Secure random number generator for discriminator values
   static final Random _secureRandom = Random.secure();
 
+  /// Generates a username, optionally with a random discriminator.
+  ///
+  /// Takes a base username and an attempt counter to handle name collisions.
+  /// - If attempt is 0, returns the base username as-is.
+  /// - If attempt > 0, appends a random 4-digit discriminator.
+  ///
+  /// @param baseUsername The core username to use
+  /// @param attempt The current generation attempt (0 = no discriminator)
+  /// @return A username string, with discriminator if attempt > 0
   static String generateUsername(String baseUsername, int attempt) {
+    _validateInputParameters(baseUsername, attempt);
+
+    // Return base username on first attempt
     if (attempt == 0) {
+      _logger.info('First attempt. Using base username: $baseUsername');
       return baseUsername;
     }
 
-    final int discriminator = _secureRandom.nextInt(10000);
-    final String formattedDiscriminator = discriminator.toString().padLeft(_discriminatorLength, '0');
-    return '$baseUsername$formattedDiscriminator';
+    // Generate a unique discriminator and format the username
+    try {
+      return _generateUsernameWithDiscriminator(baseUsername);
+    } catch (e) {
+      _logger.severe('Error generating username. Attempting to re-generate username.', e);
+      return _generateUsernameWithDiscriminator(baseUsername);
+    }
+  }
+
+  /// Validates input parameters for username generation.
+  ///
+  /// @throws ArgumentError if validation fails
+  static void _validateInputParameters(String baseUsername, int attempt) {
+    if (baseUsername.isEmpty) {
+      const String message = 'Base username cannot be empty';
+      _logger.warning(message);
+      throw ArgumentError(message);
+    }
+
+    if (attempt < 0) {
+      final String message = 'Attempt number cannot be negative: $attempt';
+      _logger.warning(message);
+      throw ArgumentError(message);
+    }
+  }
+
+  /// Generates a unique discriminator not previously used for this base username.
+  ///
+  /// Implements collision avoidance by tracking previously used values.
+  /// @param baseUsername The username to generate a discriminator for
+  /// @return A unique integer discriminator
+  static int _generateUniqueDiscriminator() => _secureRandom.nextInt(_maxDiscriminatorValue);
+
+  /// Generates a username with its discriminator.
+  ///
+  /// @param baseUsername The core username
+  /// @return Formatted username with padded discriminator
+  static String _generateUsernameWithDiscriminator(String baseUsername) {
+    final String discriminatorStr = _generateUniqueDiscriminator().toString();
+    final String formattedDiscriminator = discriminatorStr.padLeft(_discriminatorLength, '0');
+    final String generatedUsername = '$baseUsername$formattedDiscriminator';
+    _logger.info('Generated username: $generatedUsername');
+    return generatedUsername;
   }
 }

--- a/lib/cubit/ln_address/utils/username_resolver.dart
+++ b/lib/cubit/ln_address/utils/username_resolver.dart
@@ -1,0 +1,43 @@
+import 'package:breez_preferences/breez_preferences.dart';
+import 'package:l_breez/cubit/cubit.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('UsernameResolver');
+
+class UsernameResolver {
+  final BreezPreferences breezPreferences;
+
+  UsernameResolver(this.breezPreferences);
+
+  Future<String?> resolveUsername({
+    required bool isNewRegistration,
+    String? recoveredLightningAddress,
+    String? baseUsername,
+  }) async {
+    // Priority 1: Recovered lightning address username
+    if (recoveredLightningAddress != null && recoveredLightningAddress.isNotEmpty) {
+      final String username = recoveredLightningAddress.split('@').first;
+      _logger.info('Using username from recovered Lightning Address: $username');
+      return username;
+    }
+
+    // Priority 2: Explicitly provided username (for updates)
+    if (baseUsername != null && baseUsername.isNotEmpty) {
+      _logger.info('Using provided baseUsername: $baseUsername');
+      return baseUsername;
+    }
+
+    // Priority 3: For new registrations, use profile name
+    if (isNewRegistration) {
+      final String? defaultProfileName = await breezPreferences.defaultProfileName;
+      final String formattedUsername = UsernameFormatter.formatDefaultProfileName(defaultProfileName);
+      _logger.info('Using formatted profile name: $formattedUsername');
+      return formattedUsername;
+    }
+
+    // Priority 4: For existing registrations, use stored username
+    final String? storedUsername = await breezPreferences.lnAddressUsername;
+    _logger.info('Using stored username: $storedUsername');
+    return storedUsername;
+  }
+}

--- a/lib/cubit/ln_address/utils/username_resolver.dart
+++ b/lib/cubit/ln_address/utils/username_resolver.dart
@@ -4,40 +4,152 @@ import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('UsernameResolver');
 
+/// Resolution strategies in order of precedence
+enum UsernameResolutionStrategy { recoveredAddress, providedUsername, profileName, storedUsername }
+
+/// Responsible for resolving usernames from various sources according to priority rules.
+///
+/// This class implements a consistent strategy for determining which username to use
+/// based on the available sources and the context (new registration vs. existing user).
 class UsernameResolver {
+  /// Preferences store used to retrieve and store username information
   final BreezPreferences breezPreferences;
 
+  /// Creates a new UsernameResolver with the given preferences store
+  ///
+  /// @param breezPreferences The preferences store to use for username retrieval/storage
   UsernameResolver(this.breezPreferences);
 
+  /// Resolves the appropriate username based on priority rules.
+  ///
+  /// Resolution priority:
+  /// 1. Recovered lightning address username (if available)
+  /// 2. Explicitly provided username (if available)
+  /// 3. Formatted profile name (for new registrations)
+  /// 4. Stored username (for existing users)
+  ///
+  /// @param isNewRegistration Whether this is a new user registration
+  /// @param recoveredLightningAddress Optional recovered lightning address
+  /// @param baseUsername Optional explicitly provided username
+  /// @return The resolved username or null if no username could be determined
   Future<String?> resolveUsername({
     required bool isNewRegistration,
     String? recoveredLightningAddress,
     String? baseUsername,
   }) async {
-    // Priority 1: Recovered lightning address username
-    if (recoveredLightningAddress != null && recoveredLightningAddress.isNotEmpty) {
-      final String username = recoveredLightningAddress.split('@').first;
-      _logger.info('Using username from recovered Lightning Address: $username');
+    try {
+      _logger.info('Resolving username (isNewRegistration: $isNewRegistration)');
+
+      // Try each resolution strategy in order of precedence
+      final String? username = await _tryResolveFromRecoveredAddress(recoveredLightningAddress) ??
+          _tryResolveFromProvidedUsername(baseUsername) ??
+          (isNewRegistration ? await _tryResolveFromProfileName() : await _tryResolveFromStoredUsername());
+
+      if (username == null || username.isEmpty) {
+        _logger.warning('Failed to resolve username using any strategy');
+      } else {
+        _logger.info(
+          'Successfully resolved username using strategy: ${_determineUsedStrategy(isNewRegistration: isNewRegistration, hasRecoveredAddress: recoveredLightningAddress != null && recoveredLightningAddress.isNotEmpty, hasProvidedUsername: baseUsername != null && baseUsername.isNotEmpty)}',
+        );
+      }
+
       return username;
+    } catch (e, stackTrace) {
+      _logger.severe('Error resolving username', e, stackTrace);
+      // Return null on error - caller must handle this case
+      return null;
+    }
+  }
+
+  /// Determines which resolution strategy was used for logging purposes
+  ///
+  /// @return The strategy that was successfully used
+  UsernameResolutionStrategy _determineUsedStrategy({
+    required bool isNewRegistration,
+    required bool hasRecoveredAddress,
+    required bool hasProvidedUsername,
+  }) {
+    if (hasRecoveredAddress) {
+      return UsernameResolutionStrategy.recoveredAddress;
+    } else if (hasProvidedUsername) {
+      return UsernameResolutionStrategy.providedUsername;
+    } else if (isNewRegistration) {
+      return UsernameResolutionStrategy.profileName;
+    } else {
+      return UsernameResolutionStrategy.storedUsername;
+    }
+  }
+
+  /// Priority 1: Extract username from recovered lightning address
+  ///
+  /// @param recoveredLightningAddress The recovered lightning address, if any
+  /// @return The extracted username or null if not available
+  Future<String?> _tryResolveFromRecoveredAddress(String? recoveredLightningAddress) async {
+    if (recoveredLightningAddress == null || recoveredLightningAddress.isEmpty) {
+      return null;
     }
 
-    // Priority 2: Explicitly provided username (for updates)
-    if (baseUsername != null && baseUsername.isNotEmpty) {
-      _logger.info('Using provided baseUsername: $baseUsername');
-      return baseUsername;
+    try {
+      final String username = recoveredLightningAddress.split('@').first;
+      _logger.info('Extracted username from recovered Lightning Address: $username');
+      return username;
+    } catch (e) {
+      _logger.warning('Failed to extract username from Lightning Address: $recoveredLightningAddress', e);
+      return null;
+    }
+  }
+
+  /// Priority 2: Use explicitly provided username
+  ///
+  /// @param baseUsername The explicitly provided username, if any
+  /// @return The provided username or null if not available
+  String? _tryResolveFromProvidedUsername(String? baseUsername) {
+    if (baseUsername == null || baseUsername.isEmpty) {
+      return null;
     }
 
-    // Priority 3: For new registrations, use profile name
-    if (isNewRegistration) {
+    _logger.info('Using explicitly provided username: $baseUsername');
+    return baseUsername;
+  }
+
+  /// Priority 3: Format and use the user's profile name
+  ///
+  /// @return The formatted profile name or null if not available
+  Future<String?> _tryResolveFromProfileName() async {
+    try {
       final String? defaultProfileName = await breezPreferences.defaultProfileName;
-      final String formattedUsername = UsernameFormatter.formatDefaultProfileName(defaultProfileName);
-      _logger.info('Using formatted profile name: $formattedUsername');
-      return formattedUsername;
-    }
 
-    // Priority 4: For existing registrations, use stored username
-    final String? storedUsername = await breezPreferences.lnAddressUsername;
-    _logger.info('Using stored username: $storedUsername');
-    return storedUsername;
+      if (defaultProfileName == null || defaultProfileName.isEmpty) {
+        _logger.info('No default profile name available');
+        return null;
+      }
+
+      final String formattedUsername = UsernameFormatter.formatDefaultProfileName(defaultProfileName);
+      _logger.info('Formatted profile name to username: $formattedUsername');
+      return formattedUsername;
+    } catch (e) {
+      _logger.warning('Error retrieving or formatting profile name', e);
+      return null;
+    }
+  }
+
+  /// Priority 4: Retrieve previously stored username
+  ///
+  /// @return The stored username or null if not available
+  Future<String?> _tryResolveFromStoredUsername() async {
+    try {
+      final String? storedUsername = await breezPreferences.lnAddressUsername;
+
+      if (storedUsername == null || storedUsername.isEmpty) {
+        _logger.info('No previously stored username found');
+      } else {
+        _logger.info('Retrieved previously stored username: $storedUsername');
+      }
+
+      return storedUsername;
+    } catch (e) {
+      _logger.warning('Error retrieving stored username', e);
+      return null;
+    }
   }
 }

--- a/lib/cubit/ln_address/utils/utils.dart
+++ b/lib/cubit/ln_address/utils/utils.dart
@@ -1,2 +1,3 @@
 export 'username_formatter.dart';
 export 'username_generator.dart';
+export 'username_resolver.dart';

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -7,8 +7,12 @@ import 'package:l_breez/routes/receive_payment/widgets/widgets.dart';
 import 'package:l_breez/utils/utils.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
+/// Page that displays the user's Lightning Address for receiving payments.
 class ReceiveLightningAddressPage extends StatefulWidget {
+  /// Route name for navigation
   static const String routeName = '/lightning_address';
+
+  /// Index in tab navigation
   static const int pageIndex = 1;
 
   const ReceiveLightningAddressPage({super.key});
@@ -21,58 +25,21 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
-    final ThemeData themeData = Theme.of(context);
 
     return BlocBuilder<LnAddressCubit, LnAddressState>(
       builder: (BuildContext context, LnAddressState lnAddressState) {
         return Scaffold(
-          body: lnAddressState.status == LnAddressStatus.loading
-              ? Center(
-                  child: Loader(
-                    color: themeData.primaryColor.withValues(alpha: .5),
-                  ),
-                )
-              : lnAddressState.status == LnAddressStatus.error
-                  ? ScrollableErrorMessageWidget(
-                      showIcon: true,
-                      title: texts.lightning_address_service_error_title,
-                      message: ExceptionHandler.extractMessage(lnAddressState.error!, texts),
-                    )
-                  : lnAddressState.status == LnAddressStatus.success && lnAddressState.lnurl != null
-                      ? Padding(
-                          padding: const EdgeInsets.only(top: 32.0, bottom: 40.0),
-                          child: SingleChildScrollView(
-                            child: Container(
-                              decoration: const ShapeDecoration(
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.all(
-                                    Radius.circular(12),
-                                  ),
-                                ),
-                                color: Color.fromRGBO(10, 20, 40, 1),
-                              ),
-                              padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
-                              child: SingleChildScrollView(
-                                child: DestinationWidget(
-                                  destination: lnAddressState.lnurl,
-                                  lnAddress: lnAddressState.lnAddress,
-                                  paymentMethod: texts.receive_payment_method_lightning_address,
-                                  infoWidget: const PaymentLimitsMessageBox(),
-                                ),
-                              ),
-                            ),
-                          ),
-                        )
-                      : const SizedBox.shrink(),
+          body: _getLnAddressContent(lnAddressState, texts),
           bottomNavigationBar: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
             builder: (BuildContext context, PaymentLimitsState limitsState) {
-              final bool hasError = lnAddressState.status == LnAddressStatus.error || limitsState.hasError;
+              final bool hasError = lnAddressState.hasError || limitsState.hasError;
 
               return SingleButtonBottomBar(
                 stickToBottom: true,
                 text: hasError ? texts.invoice_ln_address_action_retry : texts.qr_code_dialog_action_close,
-                onPressed:
-                    hasError ? _handleRetry(lnAddressState, limitsState) : () => Navigator.of(context).pop(),
+                onPressed: hasError
+                    ? () => _onRetryPressed(lnAddressState, limitsState)
+                    : () => Navigator.of(context).pop(),
               );
             },
           ),
@@ -81,15 +48,109 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
     );
   }
 
-  VoidCallback _handleRetry(LnAddressState state, PaymentLimitsState limitsState) {
-    return () {
-      if (state.status == LnAddressStatus.error) {
-        final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
-        lnAddressCubit.setupLightningAddress(isRecover: true);
-      } else if (limitsState.hasError) {
-        final PaymentLimitsCubit paymentLimitsCubit = context.read<PaymentLimitsCubit>();
-        paymentLimitsCubit.fetchLightningLimits();
-      }
-    };
+  Widget _getLnAddressContent(LnAddressState lnAddressState, BreezTranslations texts) {
+    if (lnAddressState.isLoading) {
+      return const LnAddressLoadingView();
+    }
+
+    if (lnAddressState.hasError) {
+      return LnAddressErrorView(
+        title: texts.lightning_address_service_error_title,
+        error: lnAddressState.error!,
+      );
+    }
+
+    if (lnAddressState.isSuccess && lnAddressState.hasValidLnUrl) {
+      return LnAddressSuccessView(lnAddressState: lnAddressState);
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  void _onRetryPressed(LnAddressState lnAddressState, PaymentLimitsState limitsState) {
+    if (lnAddressState.hasError) {
+      final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
+      lnAddressCubit.setupLightningAddress(isRecover: true);
+    } else if (limitsState.hasError) {
+      final PaymentLimitsCubit paymentLimitsCubit = context.read<PaymentLimitsCubit>();
+      paymentLimitsCubit.fetchLightningLimits();
+    }
+  }
+}
+
+/// Widget to display loading indicator for Lightning Address
+class LnAddressLoadingView extends StatelessWidget {
+  const LnAddressLoadingView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    return Center(
+      child: Loader(
+        color: themeData.primaryColor.withValues(alpha: .5),
+      ),
+    );
+  }
+}
+
+/// Widget to display error state for Lightning Address
+class LnAddressErrorView extends StatelessWidget {
+  final String title;
+  final Object error;
+
+  const LnAddressErrorView({
+    required this.title,
+    required this.error,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+    return ScrollableErrorMessageWidget(
+      showIcon: true,
+      title: title,
+      message: ExceptionHandler.extractMessage(error, texts),
+    );
+  }
+}
+
+/// Widget to display successful Lightning Address state
+class LnAddressSuccessView extends StatelessWidget {
+  final LnAddressState lnAddressState;
+
+  const LnAddressSuccessView({
+    required this.lnAddressState,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 32.0, bottom: 40.0),
+      child: SingleChildScrollView(
+        child: Container(
+          decoration: const ShapeDecoration(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(
+                Radius.circular(12),
+              ),
+            ),
+            color: Color.fromRGBO(40, 59, 74, 0.5),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
+          child: SingleChildScrollView(
+            child: DestinationWidget(
+              destination: lnAddressState.lnurl,
+              lnAddress: lnAddressState.lnAddress,
+              paymentMethod: texts.receive_payment_method_lightning_address,
+              infoWidget: const PaymentLimitsMessageBox(),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -195,7 +195,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
     return EmailValidator.validate(email) ? null : 'Invalid username.';
   }
 
-  void _handleSubmit() {
+  void _handleSubmit() async {
     if (_usernameController.text.isEmpty) {
       Navigator.pop(context);
       return;
@@ -205,8 +205,28 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
     lnAddressCubit.clearUpdateStatus();
 
     if (_formKey.currentState?.validate() ?? false) {
-      final String username = UsernameFormatter.sanitize(_usernameController.text);
-      lnAddressCubit.setupLightningAddress(baseUsername: username);
+      final String newUsername = UsernameFormatter.sanitize(_usernameController.text);
+      final String currentUsername = widget.lnAddress.split('@').first;
+
+      // Only show confirmation if username is actually changing
+      if (currentUsername != newUsername) {
+        final bool? confirmed = await promptAreYouSure(
+          context,
+          'Confirm Username Change',
+          Text(
+            "Changing your Lightning Address username will permanently release '$currentUsername@breez.fun'"
+            ', making it available for other users.\n\n'
+            'Do you want to proceed?',
+            style: const TextStyle(color: Colors.white),
+          ),
+        );
+
+        if (confirmed != true) {
+          return;
+        }
+        lnAddressCubit.setupLightningAddress(baseUsername: newUsername);
+      }
+      return;
     }
   }
 }

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -7,7 +7,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
+/// Bottom sheet to update a Lightning Address username.
 class UpdateLnAddressUsernameBottomSheet extends StatefulWidget {
+  /// The current Lightning Address
   final String lnAddress;
 
   const UpdateLnAddressUsernameBottomSheet({
@@ -24,11 +26,22 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
   final TextEditingController _usernameController = TextEditingController();
   final FocusNode _usernameFocusNode = FocusNode();
   late final KeyboardDoneAction _doneAction;
+  late final String _domain;
 
   @override
   void initState() {
     super.initState();
-    _usernameController.text = widget.lnAddress.split('@').first;
+    final LnAddressState lnAddressState = context.read<LnAddressCubit>().state;
+
+    // First try to get username from state, fall back to username from widget.lnAddress
+    final String username =
+        lnAddressState.username ?? (widget.lnAddress.contains('@') ? widget.lnAddress.split('@').first : '');
+
+    // First try to get domain from state, fall back to domain from widget.lnAddress & lastly hardcoded value
+    _domain = lnAddressState.domain ??
+        (widget.lnAddress.contains('@') ? widget.lnAddress.split('@').last : 'breez.fun');
+
+    _usernameController.text = username;
     _usernameController.addListener(() => setState(() {}));
     _doneAction = KeyboardDoneAction(focusNodes: <FocusNode>[_usernameFocusNode]);
 
@@ -47,28 +60,11 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
-    final ThemeData themeData = Theme.of(context);
 
     return BlocListener<LnAddressCubit, LnAddressState>(
       listenWhen: (LnAddressState previous, LnAddressState current) =>
           current.updateStatus.status != previous.updateStatus.status,
-      listener: (BuildContext context, LnAddressState state) {
-        if (state.updateStatus.status == UpdateStatus.success) {
-          Navigator.pop(context);
-          showFlushbar(
-            context,
-            message: 'Successfully updated Lightning Address username.',
-          );
-        } else if (state.updateStatus.status == UpdateStatus.error) {
-          if (state.updateStatus.error is! UsernameConflictException) {
-            showFlushbar(
-              context,
-              message: 'Failed to update Lightning Address username.',
-            );
-          }
-          _formKey.currentState?.validate();
-        }
-      },
+      listener: _onUpdateStatusChanged,
       child: Padding(
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
@@ -78,96 +74,19 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Align(
-                child: Container(
-                  margin: const EdgeInsets.only(top: 8.0),
-                  width: 40.0,
-                  height: 6.5,
-                  decoration: BoxDecoration(
-                    color: Colors.white12,
-                    borderRadius: BorderRadius.circular(50),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Text(
-                  'Customize Address:',
-                  style: themeData.primaryTextTheme.headlineMedium!.copyWith(
-                    fontSize: 18.0,
-                    color: Colors.white,
-                  ),
-                  textAlign: TextAlign.left,
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Form(
-                  key: _formKey,
-                  child: BlocBuilder<LnAddressCubit, LnAddressState>(
-                    buildWhen: (LnAddressState previous, LnAddressState current) =>
-                        current.updateStatus != previous.updateStatus,
-                    builder: (BuildContext context, LnAddressState state) {
-                      final bool isConflict = state.updateStatus.error is UsernameConflictException;
-                      return TextFormField(
-                        controller: _usernameController,
-                        focusNode: _usernameFocusNode,
-                        decoration: InputDecoration(
-                          labelText: 'Username',
-                          errorBorder: OutlineInputBorder(
-                            borderSide: BorderSide(color: themeData.colorScheme.error),
-                          ),
-                          focusedErrorBorder: OutlineInputBorder(
-                            borderSide: BorderSide(color: themeData.colorScheme.error),
-                          ),
-                          errorMaxLines: 2,
-                          errorStyle: themeData.primaryTextTheme.bodySmall!.copyWith(
-                            color: themeData.colorScheme.error,
-                            height: 1.0,
-                          ),
-                          suffix: const Padding(
-                            padding: EdgeInsets.only(right: 8.0),
-                            child: Text('@breez.fun'),
-                          ),
-                          border: const OutlineInputBorder(),
-                          errorText: isConflict ? 'Username is already taken' : null,
-                        ),
-                        keyboardType: TextInputType.emailAddress,
-                        autofocus: true,
-                        validator: _validateUsername,
-                        inputFormatters: <TextInputFormatter>[
-                          UsernameInputFormatter(),
-                          // 64 is the maximum allowed length for a username
-                          // but a %12.5 margin of error is added for good measure,
-                          // which is likely to get sanitized by the UsernameFormatter
-                          LengthLimitingTextInputFormatter(72),
-                        ],
-                        onEditingComplete: () => _usernameFocusNode.unfocus(),
-                      );
-                    },
-                  ),
-                ),
+              const BottomSheetHandle(),
+              const BottomSheetTitle(title: 'Customize Address:'),
+              UsernameFormField(
+                formKey: _formKey,
+                controller: _usernameController,
+                focusNode: _usernameFocusNode,
+                domain: _domain,
+                validator: _validateUsername,
               ),
               const SizedBox(height: 8.0),
-              Align(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 16.0,
-                  ),
-                  child: BlocBuilder<LnAddressCubit, LnAddressState>(
-                    buildWhen: (LnAddressState previous, LnAddressState current) =>
-                        current.updateStatus.status != previous.updateStatus.status,
-                    builder: (BuildContext context, LnAddressState state) {
-                      return SingleButtonBottomBar(
-                        text: texts.currency_converter_dialog_action_done,
-                        loading: state.updateStatus.status == UpdateStatus.loading,
-                        expand: true,
-                        onPressed: _handleSubmit,
-                      );
-                    },
-                  ),
-                ),
+              SubmitButtonSection(
+                doneText: texts.currency_converter_dialog_action_done,
+                onPressed: _handleSubmit,
               ),
             ],
           ),
@@ -176,6 +95,26 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
     );
   }
 
+  /// Handle changes to the update status from the LnAddressCubit.
+  void _onUpdateStatusChanged(BuildContext context, LnAddressState state) {
+    if (state.updateStatus.status == UpdateStatus.success) {
+      Navigator.pop(context);
+      showFlushbar(
+        context,
+        message: 'Successfully updated Lightning Address username.',
+      );
+    } else if (state.updateStatus.status == UpdateStatus.error) {
+      if (state.updateStatus.error is! UsernameConflictException) {
+        showFlushbar(
+          context,
+          message: 'Failed to update Lightning Address username.',
+        );
+      }
+      _formKey.currentState?.validate();
+    }
+  }
+
+  /// Validates the username input.
   String? _validateUsername(String? value) {
     final String sanitized = UsernameFormatter.sanitize(value ?? '');
     if (sanitized.isEmpty) {
@@ -191,10 +130,11 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
       return 'Username is already taken';
     }
 
-    final String email = '$sanitized@${widget.lnAddress.split('@').last}';
+    final String email = '$sanitized@$_domain';
     return EmailValidator.validate(email) ? null : 'Invalid username.';
   }
 
+  /// Handles the form submission.
   void _handleSubmit() async {
     if (_usernameController.text.isEmpty) {
       Navigator.pop(context);
@@ -206,7 +146,10 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
 
     if (_formKey.currentState?.validate() ?? false) {
       final String newUsername = UsernameFormatter.sanitize(_usernameController.text);
-      final String currentUsername = widget.lnAddress.split('@').first;
+      final LnAddressState state = lnAddressCubit.state;
+
+      final String currentUsername =
+          state.username ?? (widget.lnAddress.contains('@') ? widget.lnAddress.split('@').first : '');
 
       // Only show confirmation if username is actually changing
       if (currentUsername != newUsername) {
@@ -214,7 +157,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
           context,
           'Confirm Username Change',
           Text(
-            "Changing your Lightning Address username will permanently release '$currentUsername@breez.fun'"
+            "Changing your Lightning Address username will permanently release '$currentUsername@$_domain'"
             ', making it available for other users.\n\n'
             'Do you want to proceed?',
             style: const TextStyle(color: Colors.white),
@@ -225,8 +168,164 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
           return;
         }
         lnAddressCubit.setupLightningAddress(baseUsername: newUsername);
+      } else {
+        Navigator.pop(context);
+        return;
       }
-      return;
     }
+  }
+}
+
+/// Handle at the top of the bottom sheet
+class BottomSheetHandle extends StatelessWidget {
+  const BottomSheetHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      child: Container(
+        margin: const EdgeInsets.only(top: 8.0),
+        width: 40.0,
+        height: 6.5,
+        decoration: BoxDecoration(
+          color: Colors.white24,
+          borderRadius: BorderRadius.circular(50),
+        ),
+      ),
+    );
+  }
+}
+
+/// Title display for the bottom sheet
+class BottomSheetTitle extends StatelessWidget {
+  final String title;
+
+  const BottomSheetTitle({
+    required this.title,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Text(
+        title,
+        style: themeData.primaryTextTheme.headlineMedium!.copyWith(
+          fontSize: 18.0,
+          color: Colors.white,
+        ),
+        textAlign: TextAlign.left,
+      ),
+    );
+  }
+}
+
+/// Username input form field
+class UsernameFormField extends StatelessWidget {
+  final GlobalKey<FormState> formKey;
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final String domain;
+  final FormFieldValidator<String> validator;
+
+  const UsernameFormField({
+    required this.formKey,
+    required this.controller,
+    required this.focusNode,
+    required this.domain,
+    required this.validator,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Form(
+        key: formKey,
+        child: BlocBuilder<LnAddressCubit, LnAddressState>(
+          buildWhen: (LnAddressState previous, LnAddressState current) =>
+              current.updateStatus != previous.updateStatus,
+          builder: (BuildContext context, LnAddressState state) {
+            final bool isConflict = state.updateStatus.error is UsernameConflictException;
+            return TextFormField(
+              controller: controller,
+              focusNode: focusNode,
+              decoration: InputDecoration(
+                labelText: 'Username',
+                errorBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: themeData.colorScheme.error),
+                ),
+                focusedErrorBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: themeData.colorScheme.error),
+                ),
+                errorMaxLines: 2,
+                errorStyle: themeData.primaryTextTheme.bodySmall!.copyWith(
+                  color: themeData.colorScheme.error,
+                  height: 1.0,
+                ),
+                suffix: Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: Text('@$domain'),
+                ),
+                border: const OutlineInputBorder(),
+                errorText: isConflict ? 'Username is already taken' : null,
+              ),
+              keyboardType: TextInputType.emailAddress,
+              autofocus: true,
+              validator: validator,
+              inputFormatters: <TextInputFormatter>[
+                UsernameInputFormatter(),
+                // 64 is the maximum allowed length for a username
+                // but a %12.5 margin of error is added for good measure,
+                // which is likely to get sanitized by the UsernameFormatter
+                LengthLimitingTextInputFormatter(72),
+              ],
+              onEditingComplete: () => focusNode.unfocus(),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Submit button section
+class SubmitButtonSection extends StatelessWidget {
+  final String doneText;
+  final VoidCallback onPressed;
+
+  const SubmitButtonSection({
+    required this.doneText,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+          vertical: 16.0,
+        ),
+        child: BlocBuilder<LnAddressCubit, LnAddressState>(
+          buildWhen: (LnAddressState previous, LnAddressState current) =>
+              current.updateStatus.status != previous.updateStatus.status,
+          builder: (BuildContext context, LnAddressState state) {
+            return SingleButtonBottomBar(
+              text: doneText,
+              loading: state.updateStatus.status == UpdateStatus.loading,
+              expand: true,
+              onPressed: onPressed,
+            );
+          },
+        ),
+      ),
+    );
   }
 }

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -280,10 +280,7 @@ class UsernameFormField extends StatelessWidget {
               validator: validator,
               inputFormatters: <TextInputFormatter>[
                 UsernameInputFormatter(),
-                // 64 is the maximum allowed length for a username
-                // but a %12.5 margin of error is added for good measure,
-                // which is likely to get sanitized by the UsernameFormatter
-                LengthLimitingTextInputFormatter(72),
+                LengthLimitingTextInputFormatter(64),
               ],
               onEditingComplete: () => focusNode.unfocus(),
             );


### PR DESCRIPTION
Fixes #400
Fixes #397
Fixes #396

This PR restructures LnAddressCubit for improved maintainability, fixes input formatter bugs & adds an "Are you sure?" prompt to the user when they are updating their LN Address username.


#### Changelist:
- Extracted components from LnAddressCubit to clarify responsibilities: (#400)
  - MessageSigner: Handles cryptographic message signing
  - WebhookRequestBuilder: Creates structured API requests
  - UsernameResolver: Centralizes username selection with priority rules
  - RegistrationManager: Orchestrates registration workflows
  - Registration types: Clear identifiers for different scenarios
  - Simplified control flow with explicit registration types
- Fix bug where first character was kept when deleting with backspace (#396)
- Add confirmation dialog for username change (#397)

> When users change their Lightning address username, their previous address
> becomes available for others to register. This commit adds a confirmation
> dialog that:
> 
> - Explains the consequences of changing usernames
> - Shows the specific address being released
> - Only appears when the username is actually changing
> 
> This helps prevent accidental username changes and improves security by
> ensuring users understand the implications of their actions.

- Add comprehensive documentation
- Implement caching, & improve error handling