### PR TITLE
fix: Address Mnemonic Verification Status Bugs

### DIFF
--- a/lib/routes/home/widgets/home_app_bar/widgets/account_required_actions.dart
+++ b/lib/routes/home/widgets/home_app_bar/widgets/account_required_actions.dart
@@ -30,8 +30,10 @@ class _AccountRequiredActionsIndicatorState extends State<AccountRequiredActions
           warnings.add(const RefundablesWarningAction());
         }
 
-        final SecurityState securityState = context.read<SecurityCubit>().state;
-        if (securityState.verificationStatus != VerificationStatus.verified) {
+        final VerificationStatus verificationStatus = context.select<SecurityCubit, VerificationStatus>(
+          (SecurityCubit cubit) => cubit.state.verificationStatus,
+        );
+        if (verificationStatus != VerificationStatus.verified) {
           _logger.info('Adding mnemonic verification warning.');
           warnings.add(const VerifyMnemonicWarningAction());
         }

--- a/lib/routes/initial_walkthrough/initial_walkthrough_page.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough_page.dart
@@ -176,6 +176,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
   void connect({String? mnemonic}) async {
     final SdkConnectivityCubit connectionService = context.read<SdkConnectivityCubit>();
     final AccountCubit accountCubit = context.read<AccountCubit>();
+    final SecurityCubit securityCubit = context.read<SecurityCubit>();
 
     final bool isRestore = mnemonic != null;
     _logger.info("${isRestore ? "Restore" : "Starting new"} wallet");
@@ -188,7 +189,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
     try {
       if (isRestore) {
         await connectionService.restore(mnemonic: mnemonic);
-        await MnemonicVerificationStatusPreferences.setVerificationComplete(true);
+        await securityCubit.verifyMnemonic();
         accountCubit.setIsRestoring(true);
       } else {
         await connectionService.register();


### PR DESCRIPTION
This PR handles parts overlooked on #378.
- Updates `SecurityState` after setting mnemonics verification status to verified on restore.
- `AccountRequiredActions` watches changes on `SecurityState` instead of reading once & relying on external state updates.