### PR TITLE
Use new translations

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		12FD9DC1B3DABF9F02F5A8DA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE35AC2B60493087E40CA64E /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		22246727F178B1E17E673139 /* BreezSDKLiquidConnector.swift in Resources */ = {isa = PBXBuildFile; fileRef = 64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
@@ -28,12 +27,12 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A09F2C75439FD441CCB45C4B /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		A5B7FE775C5DE85F5BA030AA /* SwapUpdated.swift in Resources */ = {isa = PBXBuildFile; fileRef = 6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		B4993FBA6A49F61E1D8A3E3F /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29A152FB675C3E6D9AB583FD /* Pods_NotificationService.framework */; };
+		B42BB15EAA84909A290DF54B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E992E9B8F606FC7CB746104 /* Pods_Runner.framework */; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
 		BEFD2B173AD9A8F75F4C4E70 /* Constants.swift in Resources */ = {isa = PBXBuildFile; fileRef = B5E5724CB2BA100C10032AF2 /* Constants.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		C20CE275E425F859C7E6DE4C /* String+SHA256.swift in Resources */ = {isa = PBXBuildFile; fileRef = A9EEF592AC15F5122FE4839C /* String+SHA256.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		C3850D9DB1F37D4536E0023E /* ServiceLogger.swift in Resources */ = {isa = PBXBuildFile; fileRef = 1A928177C42305FC6DA768BE /* ServiceLogger.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		DB4A20891B80EDA31F012738 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F29CD093F16CD1D663E21F18 /* Pods_RunnerTests.framework */; };
+		CACB2AA18C9FB4203B96BC89 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2C4F0D03952554D3BCEFF67 /* Pods_NotificationService.framework */; };
 		E2882E44B007EB2A2A3DA08E /* LnurlPay.swift in Resources */ = {isa = PBXBuildFile; fileRef = B820DCA0F1919C03D6BA3896 /* LnurlPay.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		E81E0B282CA33D3400B1C606 /* BreezSDKLiquid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */; };
 		E81E0B292CA33D3400B1C606 /* BreezSDKLiquidConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */; };
@@ -48,6 +47,7 @@
 		E81E0B322CA33D3400B1C606 /* LnurlPayInvoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */; };
 		E81E0B332CA33D3400B1C606 /* SwapUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */; };
 		F5AB6D9DA4E6C7BB8D096EC1 /* SDKNotificationService.swift in Resources */ = {isa = PBXBuildFile; fileRef = B05FDB7E07CF3107D1D2C0CB /* SDKNotificationService.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		FE35AFB8930900962A9794F7 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4A4A086561ACD4309D348D /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,23 +92,23 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04D05EBD496A769FC858F143 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		19179868DD263E85044A991E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		1A928177C42305FC6DA768BE /* ServiceLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceLogger.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ServiceLogger.swift; sourceTree = "<group>"; };
-		29A152FB675C3E6D9AB583FD /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		313B151F780B099ED955709D /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		1E992E9B8F606FC7CB746104 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3089B69E90F52E836C7619C1 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquid.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquid.swift; sourceTree = "<group>"; };
-		467398982955A1C5684C6AD0 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
-		57ACD6FED91EDBE890FEBBF2 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
-		5CD9E84BF7DD48924EFBD0ED /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		3FCEC0564139C7C40790D881 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
+		4A4A4A086561ACD4309D348D /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquidConnector.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquidConnector.swift; sourceTree = "<group>"; };
 		68C3549E54F158E6F1BF215E /* ResourceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResourceHelper.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ResourceHelper.swift; sourceTree = "<group>"; };
 		6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwapUpdated.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/SwapUpdated.swift; sourceTree = "<group>"; };
+		72596900787D17EF20B5CE09 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		732A3D252C6CCF13007563A8 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		732A3D272C6CCF13007563A8 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		732A3D292C6CCF13007563A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -129,18 +129,18 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		984572C5607273863FF30B52 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		A1AB3191AA09DA2E90A128D6 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
+		A2C4F0D03952554D3BCEFF67 /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9EEF592AC15F5122FE4839C /* String+SHA256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SHA256.swift"; path = "../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/String+SHA256.swift"; sourceTree = "<group>"; };
 		B05FDB7E07CF3107D1D2C0CB /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/SDKNotificationService.swift; sourceTree = "<group>"; };
 		B5E5724CB2BA100C10032AF2 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Constants.swift; sourceTree = "<group>"; };
 		B820DCA0F1919C03D6BA3896 /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPay.swift; sourceTree = "<group>"; };
-		C8B2D326E419DC766F1BCE04 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		DA3BBE4ED93DFCC37C29FC58 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
+		E48F8CCEEE38EFCE616228EF /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		EE35AC2B60493087E40CA64E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F29CD093F16CD1D663E21F18 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FCE327A1A8B9423F4017B6A2 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
+		EE118ED6F54B92E27958CC09 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F53C6A2F68B159B681EDC490 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		FBA112BCDA5C6CD92B01F3FC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,7 +148,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB4A20891B80EDA31F012738 /* Pods_RunnerTests.framework in Frameworks */,
+				FE35AFB8930900962A9794F7 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,7 +157,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				733E91342CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework in Frameworks */,
-				B4993FBA6A49F61E1D8A3E3F /* Pods_NotificationService.framework in Frameworks */,
+				CACB2AA18C9FB4203B96BC89 /* Pods_NotificationService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,7 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				12FD9DC1B3DABF9F02F5A8DA /* Pods_Runner.framework in Frameworks */,
+				B42BB15EAA84909A290DF54B /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,9 +216,9 @@
 			isa = PBXGroup;
 			children = (
 				733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */,
-				29A152FB675C3E6D9AB583FD /* Pods_NotificationService.framework */,
-				EE35AC2B60493087E40CA64E /* Pods_Runner.framework */,
-				F29CD093F16CD1D663E21F18 /* Pods_RunnerTests.framework */,
+				A2C4F0D03952554D3BCEFF67 /* Pods_NotificationService.framework */,
+				1E992E9B8F606FC7CB746104 /* Pods_Runner.framework */,
+				4A4A4A086561ACD4309D348D /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -286,15 +286,15 @@
 			isa = PBXGroup;
 			children = (
 				859CF8DB9DF068928BF5B359 /* flutter_breez_liquid-OnDemandResources */,
-				FCE327A1A8B9423F4017B6A2 /* Pods-NotificationService.debug.xcconfig */,
-				DA3BBE4ED93DFCC37C29FC58 /* Pods-NotificationService.release.xcconfig */,
-				57ACD6FED91EDBE890FEBBF2 /* Pods-NotificationService.profile.xcconfig */,
-				19179868DD263E85044A991E /* Pods-Runner.debug.xcconfig */,
-				984572C5607273863FF30B52 /* Pods-Runner.release.xcconfig */,
-				5CD9E84BF7DD48924EFBD0ED /* Pods-Runner.profile.xcconfig */,
-				313B151F780B099ED955709D /* Pods-RunnerTests.debug.xcconfig */,
-				467398982955A1C5684C6AD0 /* Pods-RunnerTests.release.xcconfig */,
-				C8B2D326E419DC766F1BCE04 /* Pods-RunnerTests.profile.xcconfig */,
+				04D05EBD496A769FC858F143 /* Pods-NotificationService.debug.xcconfig */,
+				3FCEC0564139C7C40790D881 /* Pods-NotificationService.release.xcconfig */,
+				A1AB3191AA09DA2E90A128D6 /* Pods-NotificationService.profile.xcconfig */,
+				EE118ED6F54B92E27958CC09 /* Pods-Runner.debug.xcconfig */,
+				FBA112BCDA5C6CD92B01F3FC /* Pods-Runner.release.xcconfig */,
+				F53C6A2F68B159B681EDC490 /* Pods-Runner.profile.xcconfig */,
+				E48F8CCEEE38EFCE616228EF /* Pods-RunnerTests.debug.xcconfig */,
+				72596900787D17EF20B5CE09 /* Pods-RunnerTests.release.xcconfig */,
+				3089B69E90F52E836C7619C1 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -306,7 +306,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				788CBBED2D1CFEED5F009175 /* [CP] Check Pods Manifest.lock */,
+				B76C40DFB2C0A98B48CF2799 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -325,7 +325,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732A3D312C6CCF13007563A8 /* Build configuration list for PBXNativeTarget "NotificationService" */;
 			buildPhases = (
-				D6E4A6BE7A4CC44D3093114D /* [CP] Check Pods Manifest.lock */,
+				8B782EDA69B695B531A03A9F /* [CP] Check Pods Manifest.lock */,
 				732A3D212C6CCF13007563A8 /* Sources */,
 				732A3D222C6CCF13007563A8 /* Frameworks */,
 				732A3D232C6CCF13007563A8 /* Resources */,
@@ -343,7 +343,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				ABE235D569CD87997D61C037 /* [CP] Check Pods Manifest.lock */,
+				F5969849EB92540AD550CCED /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				732A3D2D2C6CCF13007563A8 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
@@ -351,8 +351,8 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				4CA7312AB38A403FD43D7DA9 /* [CP] Embed Pods Frameworks */,
-				4CE79CB1A36C26A90F4EA98E /* [CP] Copy Pods Resources */,
+				111AAF73A8D518F3649EFFE3 /* [CP] Embed Pods Frameworks */,
+				1CA674DDB86C869CD8E73FF8 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -454,23 +454,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
-		};
-		4CA7312AB38A403FD43D7DA9 /* [CP] Embed Pods Frameworks */ = {
+		111AAF73A8D518F3649EFFE3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -487,7 +471,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4CE79CB1A36C26A90F4EA98E /* [CP] Copy Pods Resources */ = {
+		1CA674DDB86C869CD8E73FF8 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -504,7 +488,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		788CBBED2D1CFEED5F009175 /* [CP] Check Pods Manifest.lock */ = {
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
+		};
+		8B782EDA69B695B531A03A9F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -519,7 +519,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -541,7 +541,29 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		ABE235D569CD87997D61C037 /* [CP] Check Pods Manifest.lock */ = {
+		B76C40DFB2C0A98B48CF2799 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F5969849EB92540AD550CCED /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -557,28 +579,6 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D6E4A6BE7A4CC44D3093114D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -719,7 +719,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5CD9E84BF7DD48924EFBD0ED /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = F53C6A2F68B159B681EDC490 /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -749,7 +749,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 313B151F780B099ED955709D /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = E48F8CCEEE38EFCE616228EF /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -767,7 +767,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 467398982955A1C5684C6AD0 /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 72596900787D17EF20B5CE09 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -783,7 +783,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C8B2D326E419DC766F1BCE04 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 3089B69E90F52E836C7619C1 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -799,7 +799,7 @@
 		};
 		732A3D2E2C6CCF13007563A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FCE327A1A8B9423F4017B6A2 /* Pods-NotificationService.debug.xcconfig */;
+			baseConfigurationReference = 04D05EBD496A769FC858F143 /* Pods-NotificationService.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -841,7 +841,7 @@
 		};
 		732A3D2F2C6CCF13007563A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DA3BBE4ED93DFCC37C29FC58 /* Pods-NotificationService.release.xcconfig */;
+			baseConfigurationReference = 3FCEC0564139C7C40790D881 /* Pods-NotificationService.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -884,7 +884,7 @@
 		};
 		732A3D302C6CCF13007563A8 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57ACD6FED91EDBE890FEBBF2 /* Pods-NotificationService.profile.xcconfig */;
+			baseConfigurationReference = A1AB3191AA09DA2E90A128D6 /* Pods-NotificationService.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1038,7 +1038,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 19179868DD263E85044A991E /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = EE118ED6F54B92E27958CC09 /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1069,7 +1069,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 984572C5607273863FF30B52 /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = FBA112BCDA5C6CD92B01F3FC /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/lib/cubit/refund/refund_cubit.dart
+++ b/lib/cubit/refund/refund_cubit.dart
@@ -221,7 +221,7 @@ class RefundCubit extends Cubit<RefundState> {
       );
 
       final PrepareRefundResponse response = await _breezSdkLiquid.instance!.prepareRefund(req: req);
-      _logger.info('Prepared refund response: $response');
+      _logger.info('Prepared refund response: ${response.toFormattedString()}');
       return response;
     } catch (e) {
       _logger.severe('Failed to prepare refund', e);

--- a/lib/models/sdk_formatted_string_extensions.dart
+++ b/lib/models/sdk_formatted_string_extensions.dart
@@ -22,10 +22,16 @@ extension RecommendedFeesFormatter on RecommendedFees {
 }
 
 extension PaymentEventFormatter on PaymentEvent {
-  String toFormattedString() => 'PaymentEvent('
-      'sdkEvent: ${sdkEvent.toFormattedString()}, '
-      'payment: ${payment.toFormattedString()}'
-      ')';
+  String toFormattedString() {
+    final String sdkEventStr = sdkEvent.toFormattedString();
+    final String paymentStr = payment.toFormattedString();
+
+    if (sdkEventStr.contains(paymentStr)) {
+      return 'PaymentEvent(sdkEvent: $sdkEventStr)';
+    }
+
+    return 'PaymentEvent(sdkEvent: $sdkEventStr, payment: $paymentStr)';
+  }
 }
 
 extension SdkEventFormatter on SdkEvent {

--- a/lib/models/sdk_formatted_string_extensions.dart
+++ b/lib/models/sdk_formatted_string_extensions.dart
@@ -68,7 +68,7 @@ extension PaymentFormatter on Payment {
       'feesSat: $feesSat, '
       'swapperFeesSat: ${swapperFeesSat ?? "N/A"}, '
       'paymentType: $paymentType, '
-      'status: $status'
+      'status: $status, '
       'details: ${details.toFormattedString()}'
       ')';
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_amount.dart
@@ -27,7 +27,7 @@ class PaymentDetailsSheetAmount extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
-            texts.ln_payment_amount_label,
+            texts.payment_details_sheet_amount_label,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
               color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetBip353Address extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_share_lightning_address}:',
+      title: texts.payment_details_sheet_ln_address_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_date.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_date.dart
@@ -25,7 +25,7 @@ class PaymentDetailsSheetDate extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
-            '${texts.payment_details_dialog_date_and_time}:',
+            texts.payment_details_sheet_date_time_label,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
               color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_destination_pubkey.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_destination_pubkey.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetDestinationPubkey extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_single_info_node_id}:',
+      title: texts.payment_details_sheet_destination_pubkey_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_expiry.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_expiry.dart
@@ -24,7 +24,7 @@ class PaymentDetailsSheetExpiry extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
-            '${texts.payment_details_dialog_expiration}:',
+            texts.payment_details_sheet_expiration_label,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
               color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_fee.dart
@@ -26,7 +26,7 @@ class PaymentDetailsSheetFee extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
-            texts.ln_payment_fee_label,
+            texts.payment_details_sheet_fee_label,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
               color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_invoice.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_invoice.dart
@@ -1,3 +1,5 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -8,12 +10,13 @@ class PaymentDetailsSheetInvoice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: 'Invoice:',
+      title: texts.payment_details_sheet_invoice_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_ln_address.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_ln_address.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetLnUrlLnAddress extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_share_lightning_address}:',
+      title: texts.payment_details_sheet_ln_address_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_comment.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_comment.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetLnUrlPayComment extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_share_comment}:',
+      title: texts.payment_details_sheet_comment_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_domain.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_domain.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetLnUrlPayDomain extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_share_lnurl_pay_domain}:',
+      title: texts.payment_details_sheet_lnurlpay_success_domain_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_description.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_description.dart
@@ -1,5 +1,5 @@
-//import 'package:breez_translations/breez_translations_locales.dart';
-//import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -10,14 +10,13 @@ class PaymentDetailsSheetLnUrlPaySuccessDescription extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //final BreezTranslations texts = context.texts();
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      // TODO(danielgranhao): translate.
-      title: 'LNURL Pay Success Description:',
+      title: texts.payment_details_sheet_lnurlpay_success_description_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_message.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_message.dart
@@ -1,5 +1,5 @@
-//import 'package:breez_translations/breez_translations_locales.dart';
-//import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -10,14 +10,13 @@ class PaymentDetailsSheetLnUrlPaySuccessMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //final BreezTranslations texts = context.texts();
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      // TODO(danielgranhao): translate.
-      title: 'LNURL Pay Success Message:',
+      title: texts.payment_details_sheet_lnurlpay_success_message_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_url.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_lnurl_pay_success_url.dart
@@ -1,5 +1,5 @@
-//import 'package:breez_translations/breez_translations_locales.dart';
-//import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -10,14 +10,13 @@ class PaymentDetailsSheetLnUrlPaySuccessUrl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //final BreezTranslations texts = context.texts();
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      // TODO(danielgranhao): translate.
-      title: 'LNURL Pay Success URL:',
+      title: texts.payment_details_sheet_lnurlpay_success_url_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_preimage.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_preimage.dart
@@ -22,7 +22,7 @@ class PaymentDetailsSheetPreimage extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_single_info_pre_image}:',
+      title: texts.payment_details_sheet_preimage_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_refund_tx_fee_amount.dart
@@ -26,8 +26,7 @@ class PaymentDetailsSheetRefundTxAmount extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(right: 8.0),
           child: AutoSizeText(
-            // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
-            'Refund Tx ${texts.ln_payment_amount_label}',
+            texts.payment_details_sheet_refund_tx_amount_label,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
               color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_swap_id.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_swap_id.dart
@@ -16,7 +16,7 @@ class PaymentDetailsSheetSwapId extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_single_info_swap_id}:',
+      title: texts.payment_details_sheet_swap_id_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_tx_id.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_tx_id.dart
@@ -18,7 +18,7 @@ class PaymentDetailsSheetTxId extends StatelessWidget {
     return ShareablePaymentRow(
       tilePadding: EdgeInsets.zero,
       dividerColor: Colors.transparent,
-      title: '${texts.payment_details_dialog_single_info_tx_id}:',
+      title: texts.payment_details_sheet_tx_id_label,
       titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
         fontSize: 18.0,
         color: Colors.white,

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -432,13 +432,11 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
       final String networkLimit = '(${currencyState.bitcoinCurrency.format(
         effectiveMaxSat,
       )})';
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? texts.valid_payment_error_exceeds_the_limit(networkLimit)
           : '${texts.lnurl_withdraw_dialog_error_amount_exceeds(effectiveMaxSat)} ${currencyState.bitcoinCurrency.displayName}';
     } else if (amountSat < effectiveMinSat) {
       final String effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? '${texts.invoice_payment_validator_error_payment_below_invoice_limit(effMinSendableFormatted)}.'
           : '${texts.lnurl_withdraw_dialog_error_amount_below(effectiveMinSat)} ${currencyState.bitcoinCurrency.displayName}';

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_actions.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_actions.dart
@@ -93,9 +93,8 @@ class _CopyButton extends StatelessWidget {
             IconData(0xe90b, fontFamily: 'icomoon'),
             size: 20.0,
           ),
-          // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
           label: AutoSizeText(
-            'COPY',
+            texts.destination_action_copy_label,
             style: balanceFiatConversionTextStyle,
             maxLines: 1,
             group: textGroup,
@@ -134,6 +133,7 @@ class _ShareButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final MinFontSize minFont = MinFontSize(context);
 
     return ConstrainedBox(
@@ -142,10 +142,9 @@ class _ShareButton extends StatelessWidget {
         minWidth: 138.0,
       ),
       child: Tooltip(
-        // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
         message: (paymentMethod != null && paymentMethod!.isNotEmpty)
-            ? 'Share $paymentMethod'
-            : 'Share deposit address',
+            ? texts.destination_action_share_payment_method_tooltip(paymentMethod!)
+            : texts.destination_action_share_default_tooltip,
         child: OutlinedButton.icon(
           style: OutlinedButton.styleFrom(
             side: const BorderSide(color: Colors.white),
@@ -157,9 +156,8 @@ class _ShareButton extends StatelessWidget {
             IconData(0xe917, fontFamily: 'icomoon'),
             size: 20.0,
           ),
-          // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
           label: AutoSizeText(
-            'SHARE',
+            texts.destination_action_share_label,
             style: balanceFiatConversionTextStyle,
             maxLines: 1,
             group: textGroup,

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_information.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/destination_information.dart
@@ -1,3 +1,5 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/routes/receive_payment/widgets/widgets.dart';
 import 'package:l_breez/theme/theme.dart';
@@ -18,6 +20,7 @@ class DestinationInformation extends StatefulWidget {
 class DestinationInformationState extends State<DestinationInformation> {
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return GestureDetector(
@@ -37,17 +40,16 @@ class DestinationInformationState extends State<DestinationInformation> {
             borderRadius: BorderRadius.circular(4.0),
           ),
           items: <PopupMenuItem<String>>[
-            const PopupMenuItem<String>(
+            PopupMenuItem<String>(
               // TODO(erdemyerebasmaz): Replace with const var
               value: 'customize',
               child: Row(
                 children: <Widget>[
-                  Icon(Icons.edit),
-                  SizedBox(
+                  const Icon(Icons.edit),
+                  const SizedBox(
                     width: 8.0,
                   ),
-                  // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
-                  Text('Customize Address'),
+                  Text(texts.update_ln_address_username_title),
                 ],
               ),
             ),

--- a/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
+++ b/lib/routes/receive_payment/widgets/destination_widget/widgets/update_ln_address_username_bottom_sheet.dart
@@ -75,7 +75,7 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               const BottomSheetHandle(),
-              const BottomSheetTitle(title: 'Customize Address:'),
+              BottomSheetTitle(title: '${texts.update_ln_address_username_title}:'),
               UsernameFormField(
                 formKey: _formKey,
                 controller: _usernameController,
@@ -97,18 +97,13 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
 
   /// Handle changes to the update status from the LnAddressCubit.
   void _onUpdateStatusChanged(BuildContext context, LnAddressState state) {
+    final BreezTranslations texts = context.texts();
     if (state.updateStatus.status == UpdateStatus.success) {
       Navigator.pop(context);
-      showFlushbar(
-        context,
-        message: 'Successfully updated Lightning Address username.',
-      );
+      showFlushbar(context, message: texts.update_ln_address_username_success);
     } else if (state.updateStatus.status == UpdateStatus.error) {
       if (state.updateStatus.error is! UsernameConflictException) {
-        showFlushbar(
-          context,
-          message: 'Failed to update Lightning Address username.',
-        );
+        showFlushbar(context, message: texts.update_ln_address_username_failed);
       }
       _formKey.currentState?.validate();
     }
@@ -116,22 +111,23 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
 
   /// Validates the username input.
   String? _validateUsername(String? value) {
+    final BreezTranslations texts = context.texts();
     final String sanitized = UsernameFormatter.sanitize(value ?? '');
     if (sanitized.isEmpty) {
-      return 'Please enter a username';
+      return texts.validator_ln_address_username_empty;
     }
 
     if (sanitized.length > 64) {
-      return 'Username cannot exceed 64 characters.';
+      return texts.validator_ln_address_username_exceed_length;
     }
 
     final LnAddressState state = context.read<LnAddressCubit>().state;
     if (state.updateStatus.error is UsernameConflictException) {
-      return 'Username is already taken';
+      return texts.validator_ln_address_username_taken;
     }
 
     final String email = '$sanitized@$_domain';
-    return EmailValidator.validate(email) ? null : 'Invalid username.';
+    return EmailValidator.validate(email) ? null : texts.validator_ln_address_username_invalid;
   }
 
   /// Handles the form submission.
@@ -153,13 +149,12 @@ class _UpdateLnAddressUsernameBottomSheetState extends State<UpdateLnAddressUser
 
       // Only show confirmation if username is actually changing
       if (currentUsername != newUsername) {
+        final BreezTranslations texts = context.texts();
         final bool? confirmed = await promptAreYouSure(
           context,
-          title: 'Confirm Username Change',
+          title: texts.update_ln_address_username_confirmation_title,
           body: Text(
-            "Changing your Lightning Address username will permanently release '$currentUsername@$_domain'"
-            ', making it available for other users.\n\n'
-            'Do you want to proceed?',
+            texts.update_ln_address_username_confirmation_message(currentUsername, _domain),
             style: const TextStyle(color: Colors.white),
           ),
         );
@@ -241,6 +236,7 @@ class UsernameFormField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return Padding(
@@ -256,7 +252,7 @@ class UsernameFormField extends StatelessWidget {
               controller: controller,
               focusNode: focusNode,
               decoration: InputDecoration(
-                labelText: 'Username',
+                labelText: texts.update_ln_address_username_label,
                 errorBorder: OutlineInputBorder(
                   borderSide: BorderSide(color: themeData.colorScheme.error),
                 ),
@@ -273,7 +269,7 @@ class UsernameFormField extends StatelessWidget {
                   child: Text('@$domain'),
                 ),
                 border: const OutlineInputBorder(),
-                errorText: isConflict ? 'Username is already taken' : null,
+                errorText: isConflict ? texts.validator_ln_address_username_taken : null,
               ),
               keyboardType: TextInputType.emailAddress,
               autofocus: true,

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/payment_limits_message_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/payment_limits_message_box.dart
@@ -47,22 +47,22 @@ class PaymentLimitsMessageBox extends StatelessWidget {
   }
 
   String _formatLimitsMessage(BuildContext context, Limits limits) {
+    final BreezTranslations texts = context.texts();
     final CurrencyState currencyState = context.read<CurrencyCubit>().state;
 
     // Get the minimum sendable amount (in sats), can not be less than 1 or more than maxSendable
     final int minSendableSat = limits.minSat.toInt();
     final bool minSendableAboveMin = minSendableSat >= 1;
     if (!minSendableAboveMin) {
-      return "Minimum sendable amount can't be less than ${currencyState.bitcoinCurrency.format(1)}.";
+      return texts.payment_limits_message_min_below_limit(currencyState.bitcoinCurrency.format(1));
     }
 
     final int maxSendableSat = limits.maxSat.toInt();
     if (minSendableSat > maxSendableSat) {
-      return "Minimum sendable amount can't be greater than maximum sendable amount.";
+      return texts.payment_limits_message_min_greater_limit;
     }
     final String minSendableFormatted = currencyState.bitcoinCurrency.format(minSendableSat);
     final String maxSendableFormatted = currencyState.bitcoinCurrency.format(maxSendableSat);
-    // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
-    return 'Send at least $minSendableFormatted and at most $maxSendableFormatted to this address.';
+    return texts.payment_limits_message(minSendableFormatted, maxSendableFormatted);
   }
 }

--- a/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
@@ -241,13 +241,11 @@ class LnPaymentPageState extends State<LnPaymentPage> {
       final String networkLimit = '(${currencyState.bitcoinCurrency.format(
         effectiveMaxSat,
       )})';
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? texts.valid_payment_error_exceeds_the_limit(networkLimit)
           : '${texts.lnurl_payment_page_error_exceeds_limit(effectiveMaxSat)} ${currencyState.bitcoinCurrency.displayName}';
     } else if (amountSat < effectiveMinSat) {
       final String effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? '${texts.invoice_payment_validator_error_payment_below_invoice_limit(effMinSendableFormatted)}.'
           : '${texts.lnurl_payment_page_error_below_limit(effectiveMinSat)} ${currencyState.bitcoinCurrency.displayName}';

--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -596,13 +596,11 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       final String networkLimit = '(${currencyState.bitcoinCurrency.format(
         effectiveMaxSat,
       )})';
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? texts.valid_payment_error_exceeds_the_limit(networkLimit)
           : '${texts.lnurl_payment_page_error_exceeds_limit(effectiveMaxSat)} ${currencyState.bitcoinCurrency.displayName}';
     } else if (amountSat < effectiveMinSat) {
       final String effMinSendableFormatted = currencyState.bitcoinCurrency.format(effectiveMinSat);
-      // TODO(erdemyerebasmaz): Add necessary messages to Breez-Translations that uses formatted string for amount
       message = throwError
           ? '${texts.invoice_payment_validator_error_payment_below_invoice_limit(effMinSendableFormatted)}.'
           : '${texts.lnurl_payment_page_error_below_limit(effectiveMinSat)} ${currencyState.bitcoinCurrency.displayName}';

--- a/lib/routes/send_payment/lnurl/widgets/lnurl_payment_comment.dart
+++ b/lib/routes/send_payment/lnurl/widgets/lnurl_payment_comment.dart
@@ -38,7 +38,7 @@ class LnUrlPaymentComment extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             AutoSizeText(
-              // TODO(erdemyerebasmaz): Add message to Breez-Translation instead of reusing another value
+              // TODO(erdemyerebasmaz): Add message to Breez-Translations instead of reusing another value
               texts.payment_details_dialog_share_comment,
               style: themeData.primaryTextTheme.headlineMedium?.copyWith(
                 fontSize: 18.0,

--- a/lib/widgets/amount_form_field/currency_converter_bottom_sheet.dart
+++ b/lib/widgets/amount_form_field/currency_converter_bottom_sheet.dart
@@ -149,8 +149,7 @@ class _CurrencyConverterBottomSheetState extends State<CurrencyConverterBottomSh
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: Text(
-                    // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
-                    'Select Fiat Currency:',
+                    texts.currency_converter_sheet_label,
                     style: themeData.primaryTextTheme.headlineMedium!.copyWith(
                       fontSize: 18.0,
                       color: Colors.white,

--- a/lib/widgets/payment_status_sheets/widgets/payment_received/payment_received_content.dart
+++ b/lib/widgets/payment_status_sheets/widgets/payment_received/payment_received_content.dart
@@ -1,3 +1,5 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:l_breez/theme/src/theme.dart';
 import 'package:lottie/lottie.dart';
@@ -7,6 +9,7 @@ class PaymentReceivedContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
     return Column(
@@ -15,8 +18,7 @@ class PaymentReceivedContent extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Text(
-            // TODO(erdemyerebasmaz): Add these messages to Breez-Translations
-            'Payment Received',
+            texts.payment_received_content_title,
             style: themeData.dialogTheme.titleTextStyle!.copyWith(
               fontSize: 24.0,
               color: themeData.isLightTheme ? null : Colors.white,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,8 +170,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "7399eabc4194d71741718ef933bceed5d5bc2129"
-      resolved-ref: "7399eabc4194d71741718ef933bceed5d5bc2129"
+      ref: a116bd9fa41695f8d0ba22347df679144fd1c5dc
+      resolved-ref: a116bd9fa41695f8d0ba22347df679144fd1c5dc
       url: "https://github.com/breez/Breez-Translations"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations
-      ref: 7399eabc4194d71741718ef933bceed5d5bc2129
+      ref: a116bd9fa41695f8d0ba22347df679144fd1c5dc
   csv: ^6.0.0
   connectivity_plus: ^6.1.3
   device_info_plus: ^11.3.2


### PR DESCRIPTION
Fixes #303
Fixes #315

This PR updates the `Breez-Translations` to the latest version, refactors `PaymentEvent` to reduce redundancy by not printing payments matching the event details. 
It also fixes the log formatting for `PrepareRefundResponse` by adding a missing comma in `PaymentFormatter` and ensures safe removal of overlays on dispose in `KeyboardDoneAction`.