### PR TITLE
Bump minSdkVersion to 33 to match Uniffi 0.28

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,7 +64,7 @@ android {
         applicationId = "com.breez.liquid.l_breez"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 24 // Android 7.0
+        minSdkVersion 33
         targetSdk = flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName


### PR DESCRIPTION
Bumps minSdkVersion to the same as the SDK minSdk / Uniffi 0.28 required version

Related PR: https://github.com/breez/breez-sdk-liquid/pull/766