### PR TITLE
theme: move card color to custom them data as `surfaceBgColor`

### DIFF
--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -252,7 +252,7 @@ class _DevelopersViewState extends State<DevelopersView> {
       (AccountCubit cubit) => cubit.state.walletInfo,
     );
     return Card(
-      color: themeData.customData.navigationDrawerBgColor,
+      color: themeData.customData.surfaceBgColor,
       margin: const EdgeInsets.all(16),
       child: Padding(
         padding: const EdgeInsets.all(16),

--- a/lib/routes/enter_payment_info/enter_payment_info_page.dart
+++ b/lib/routes/enter_payment_info/enter_payment_info_page.dart
@@ -78,13 +78,13 @@ class _EnterPaymentInfoPageState extends State<EnterPaymentInfoPage> {
   /// Builds the main content container with form and action buttons.
   Widget _buildContentContainer(BreezTranslations texts, ThemeData themeData) {
     return Container(
-      decoration: const ShapeDecoration(
-        shape: RoundedRectangleBorder(
+      decoration: ShapeDecoration(
+        shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(
             Radius.circular(12),
           ),
         ),
-        color: Color.fromRGBO(10, 20, 40, 1),
+        color: themeData.customData.surfaceBgColor,
       ),
       padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
       child: Column(

--- a/lib/routes/home/widgets/home_drawer/widgets/breez_navigation_drawer.dart
+++ b/lib/routes/home/widgets/home_drawer/widgets/breez_navigation_drawer.dart
@@ -87,11 +87,11 @@ class BreezNavigationDrawer extends StatelessWidget {
 
         return AnnotatedRegion<SystemUiOverlayStyle>(
           value: Theme.of(context).appBarTheme.systemOverlayStyle!.copyWith(
-                systemNavigationBarColor: themeData.customData.navigationDrawerBgColor,
+                systemNavigationBarColor: themeData.customData.surfaceBgColor,
               ),
           child: Theme(
             data: themeData.copyWith(
-              canvasColor: themeData.customData.navigationDrawerBgColor,
+              canvasColor: themeData.customData.surfaceBgColor,
             ),
             child: Drawer(
               child: Column(

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -7,6 +7,7 @@ import 'package:l_breez/models/payment_details_extension.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_bip_353_address.dart';
 import 'package:l_breez/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart';
 import 'package:l_breez/routes/home/widgets/widgets.dart';
+import 'package:l_breez/theme/theme.dart';
 import 'package:logging/logging.dart';
 
 export 'widgets/widgets.dart';
@@ -147,13 +148,13 @@ class PaymentDetailsSheet extends StatelessWidget {
                   child: PaymentDetailsSheetHeader(paymentData: paymentData),
                 ),
                 Container(
-                  decoration: const ShapeDecoration(
-                    shape: RoundedRectangleBorder(
+                  decoration: ShapeDecoration(
+                    shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.all(
                         Radius.circular(12),
                       ),
                     ),
-                    color: Color.fromRGBO(10, 20, 40, 1),
+                    color: themeData.customData.surfaceBgColor,
                   ),
                   padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 24),
                   child: Column(

--- a/lib/routes/receive_payment/lightning/receive_lightning_page.dart
+++ b/lib/routes/receive_payment/lightning/receive_lightning_page.dart
@@ -155,13 +155,13 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
     return BlocBuilder<CurrencyCubit, CurrencyState>(
       builder: (BuildContext context, CurrencyState currencyState) {
         return Container(
-          decoration: const ShapeDecoration(
-            shape: RoundedRectangleBorder(
+          decoration: ShapeDecoration(
+            shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(
                 Radius.circular(12),
               ),
             ),
-            color: Color.fromRGBO(10, 20, 40, 1),
+            color: themeData.customData.surfaceBgColor,
           ),
           padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
           child: Form(
@@ -269,13 +269,13 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
 
               if (receiveSnapshot.hasData) {
                 return Container(
-                  decoration: const ShapeDecoration(
-                    shape: RoundedRectangleBorder(
+                  decoration: ShapeDecoration(
+                    shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.all(
                         Radius.circular(12),
                       ),
                     ),
-                    color: Color.fromRGBO(10, 20, 40, 1),
+                    color: themeData.customData.surfaceBgColor,
                   ),
                   padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
                   child: SingleChildScrollView(

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/receive_payment/widgets/widgets.dart';
+import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/utils.dart';
 import 'package:l_breez/widgets/widgets.dart';
 
@@ -127,18 +128,19 @@ class LnAddressSuccessView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
 
     return Padding(
       padding: const EdgeInsets.only(top: 32.0, bottom: 40.0),
       child: SingleChildScrollView(
         child: Container(
-          decoration: const ShapeDecoration(
-            shape: RoundedRectangleBorder(
+          decoration: ShapeDecoration(
+            shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(
                 Radius.circular(12),
               ),
             ),
-            color: Color.fromRGBO(40, 59, 74, 0.5),
+            color: themeData.customData.surfaceBgColor,
           ),
           padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
           child: SingleChildScrollView(

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -205,13 +205,13 @@ class LnUrlWithdrawPageState extends State<LnUrlWithdrawPage> {
                           ),
                         ],
                         Container(
-                          decoration: const ShapeDecoration(
-                            shape: RoundedRectangleBorder(
+                          decoration: ShapeDecoration(
+                            shape: const RoundedRectangleBorder(
                               borderRadius: BorderRadius.all(
                                 Radius.circular(12),
                               ),
                             ),
-                            color: Color.fromRGBO(10, 20, 40, 1),
+                            color: themeData.customData.surfaceBgColor,
                           ),
                           padding: const EdgeInsets.symmetric(
                             vertical: 32,

--- a/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
+++ b/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
@@ -180,13 +180,13 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
 
               if (receiveSnapshot.hasData) {
                 return Container(
-                  decoration: const ShapeDecoration(
-                    shape: RoundedRectangleBorder(
+                  decoration: ShapeDecoration(
+                    shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.all(
                         Radius.circular(12),
                       ),
                     ),
-                    color: Color.fromRGBO(10, 20, 40, 1),
+                    color: themeData.customData.surfaceBgColor,
                   ),
                   padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
                   child: SingleChildScrollView(
@@ -228,13 +228,13 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
     return BlocBuilder<CurrencyCubit, CurrencyState>(
       builder: (BuildContext context, CurrencyState currencyState) {
         return Container(
-          decoration: const ShapeDecoration(
-            shape: RoundedRectangleBorder(
+          decoration: ShapeDecoration(
+            shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(
                 Radius.circular(12),
               ),
             ),
-            color: Color.fromRGBO(10, 20, 40, 1),
+            color: themeData.customData.surfaceBgColor,
           ),
           padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
           child: Form(

--- a/lib/routes/refund/pages/get_refund/widgets/refund_item_card/refund_item_card.dart
+++ b/lib/routes/refund/pages/get_refund/widgets/refund_item_card/refund_item_card.dart
@@ -22,7 +22,7 @@ class RefundItemCard extends StatelessWidget {
     final String lastRefundTxId = refundableSwap.lastRefundTxId ?? '';
 
     return Card(
-      color: themeData.customData.paymentListBgColorLight,
+      color: themeData.customData.surfaceBgColor,
       margin: const EdgeInsets.all(16),
       child: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/routes/refund/pages/refund/refund_page.dart
+++ b/lib/routes/refund/pages/refund/refund_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/models/sdk_formatted_string_extensions.dart';
 import 'package:l_breez/routes/routes.dart';
+import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/utils.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
 import 'package:l_breez/widgets/widgets.dart';
@@ -39,6 +40,7 @@ class RefundPageState extends State<RefundPage> {
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
 
     return Scaffold(
       key: _scaffoldKey,
@@ -52,13 +54,13 @@ class RefundPageState extends State<RefundPage> {
           child: Column(
             children: <Widget>[
               Container(
-                decoration: const ShapeDecoration(
-                  shape: RoundedRectangleBorder(
+                decoration: ShapeDecoration(
+                  shape: const RoundedRectangleBorder(
                     borderRadius: BorderRadius.all(
                       Radius.circular(12),
                     ),
                   ),
-                  color: Color.fromRGBO(10, 20, 40, 1),
+                  color: themeData.customData.surfaceBgColor,
                 ),
                 padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
                 child: RefundForm(

--- a/lib/routes/send_payment/chainswap/send_chainswap_form_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_form_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/models/currency.dart';
 import 'package:l_breez/routes/routes.dart';
+import 'package:l_breez/theme/theme.dart';
 
 class SendChainSwapFormPage extends StatefulWidget {
   final GlobalKey<FormState> formKey;
@@ -32,19 +33,21 @@ class SendChainSwapFormPage extends StatefulWidget {
 class _SendChainSwapFormPageState extends State<SendChainSwapFormPage> {
   @override
   Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 32),
         child: Column(
           children: <Widget>[
             Container(
-              decoration: const ShapeDecoration(
-                shape: RoundedRectangleBorder(
+              decoration: ShapeDecoration(
+                shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.all(
                     Radius.circular(12),
                   ),
                 ),
-                color: Color.fromRGBO(10, 20, 40, 1),
+                color: themeData.customData.surfaceBgColor,
               ),
               padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
               child: SendChainSwapForm(

--- a/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:l_breez/cubit/cubit.dart';
 import 'package:l_breez/routes/routes.dart';
+import 'package:l_breez/theme/theme.dart';
 import 'package:l_breez/utils/exceptions/exception_handler.dart';
 import 'package:l_breez/utils/payments/payment_validator.dart';
 import 'package:l_breez/widgets/back_button.dart' as back_button;
@@ -154,13 +155,13 @@ class LnPaymentPageState extends State<LnPaymentPage> {
                     ),
                   ),
                   Container(
-                    decoration: const ShapeDecoration(
-                      shape: RoundedRectangleBorder(
+                    decoration: ShapeDecoration(
+                      shape: const RoundedRectangleBorder(
                         borderRadius: BorderRadius.all(
                           Radius.circular(12),
                         ),
                       ),
-                      color: Color.fromRGBO(10, 20, 40, 1),
+                      color: themeData.customData.surfaceBgColor,
                     ),
                     padding: const EdgeInsets.symmetric(
                       vertical: 16,

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -219,13 +219,13 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                       ),
                     ],
                     Container(
-                      decoration: const ShapeDecoration(
-                        shape: RoundedRectangleBorder(
+                      decoration: ShapeDecoration(
+                        shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(
                             Radius.circular(12),
                           ),
                         ),
-                        color: Color.fromRGBO(10, 20, 40, 1),
+                        color: themeData.customData.surfaceBgColor,
                       ),
                       padding: const EdgeInsets.symmetric(
                         vertical: 16,

--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -299,13 +299,13 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                       ),
                     ],
                     Container(
-                      decoration: const ShapeDecoration(
-                        shape: RoundedRectangleBorder(
+                      decoration: ShapeDecoration(
+                        shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(
                             Radius.circular(12),
                           ),
                         ),
-                        color: Color.fromRGBO(10, 20, 40, 1),
+                        color: themeData.customData.surfaceBgColor,
                       ),
                       padding: const EdgeInsets.symmetric(
                         vertical: 32,

--- a/lib/theme/src/custom_theme_data.dart
+++ b/lib/theme/src/custom_theme_data.dart
@@ -8,7 +8,7 @@ class CustomData {
   Color paymentListBgColor;
   Color paymentListBgColorLight;
   Color navigationDrawerHeaderBgColor;
-  Color navigationDrawerBgColor;
+  Color surfaceBgColor;
 
   CustomData({
     required this.loaderAssetPath,
@@ -17,7 +17,7 @@ class CustomData {
     required this.paymentListBgColor,
     required this.paymentListBgColorLight,
     required this.navigationDrawerHeaderBgColor,
-    required this.navigationDrawerBgColor,
+    required this.surfaceBgColor,
   });
 }
 
@@ -27,7 +27,7 @@ final CustomData blueThemeCustomData = CustomData(
   pendingTextColor: const Color(0xff4D88EC),
   paymentListBgColor: const Color(0xFFf9f9f9),
   paymentListBgColorLight: Colors.white,
-  navigationDrawerBgColor: BreezColors.blue[500]!,
+  surfaceBgColor: BreezColors.blue[500]!,
   navigationDrawerHeaderBgColor: const Color.fromRGBO(0, 103, 255, 1),
 );
 
@@ -37,6 +37,6 @@ final CustomData darkThemeCustomData = CustomData(
   dashboardBgColor: const Color(0xFF00091c),
   paymentListBgColor: const Color.fromRGBO(10, 20, 40, 1),
   paymentListBgColorLight: const Color.fromRGBO(10, 20, 40, 1.33),
-  navigationDrawerBgColor: const Color.fromRGBO(10, 20, 40, 1),
+  surfaceBgColor: const Color.fromRGBO(10, 20, 40, 1),
   navigationDrawerHeaderBgColor: const Color(0xFF00091c),
 );


### PR DESCRIPTION
Extracted from `pending-refund-ui` changes to make review process easier.


- Moved card color to custom them data as `surfaceBgColor`, replaces `navigationDrawerBgColor`
- Fixes card background color Receive Lightning Address page