### PR TITLE
Hide refundables warning once all refundables have been broadcasted

### DIFF
--- a/lib/cubit/refund/refund_state.dart
+++ b/lib/cubit/refund/refund_state.dart
@@ -30,6 +30,10 @@ class RefundState {
   }
 
   bool get hasRefundables => refundables?.isNotEmpty ?? false;
+
+  /// Returns true if there are any refundable swaps that haven't been refunded yet
+  bool get hasNonRefunded =>
+      hasRefundables && refundables!.any((RefundableSwap swap) => swap.lastRefundTxId == null);
 }
 
 /// Extension on [SdkEvent] to determine if the event is refund-related.

--- a/lib/routes/home/widgets/home_app_bar/widgets/account_required_actions.dart
+++ b/lib/routes/home/widgets/home_app_bar/widgets/account_required_actions.dart
@@ -22,12 +22,12 @@ class _AccountRequiredActionsIndicatorState extends State<AccountRequiredActions
       builder: (BuildContext context) {
         final List<Widget> warnings = <Widget>[];
 
-        final bool hasRefundables = context.select<RefundCubit, bool>(
-          (RefundCubit cubit) => cubit.state.hasRefundables,
+        final bool hasNonRefunded = context.select<RefundCubit, bool>(
+          (RefundCubit cubit) => cubit.state.hasNonRefunded,
         );
-        if (hasRefundables) {
-          _logger.info('Adding refundables warning.');
-          warnings.add(const RefundablesWarningAction());
+        if (hasNonRefunded) {
+          _logger.info('Adding non-refunded refundables warning.');
+          warnings.add(const NonRefundedRefundablesWarningAction());
         }
 
         final VerificationStatus verificationStatus = context.select<SecurityCubit, VerificationStatus>(
@@ -65,10 +65,10 @@ class _AccountRequiredActionsIndicatorState extends State<AccountRequiredActions
   }
 }
 
-class RefundablesWarningAction extends StatelessWidget {
-  static final Logger _logger = Logger('RefundablesWarningAction');
+class NonRefundedRefundablesWarningAction extends StatelessWidget {
+  static final Logger _logger = Logger('NonRefundedRefundablesWarningAction');
 
-  const RefundablesWarningAction({super.key});
+  const NonRefundedRefundablesWarningAction({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Fixes #391

### Changelist:
- Show home page warning only when unrefunded swaps exist
  - Added `hasNonRefunded` getter to check for unrefunded swaps
  
