### PR TITLE
fix: prevent lock screen from getting stuck after PIN deactivation

### DIFF
--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -159,12 +159,7 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   @override
   SecurityState? fromJson(Map<String, dynamic> json) {
     final SecurityState state = SecurityState.fromJson(json);
-    // Only lock if PIN is enabled and not already in another lock state
-    if (state.pinStatus == PinStatus.enabled && state.lockState != LockState.unlocked) {
-      _setLockState(LockState.locked);
-    } else {
-      _setLockState(LockState.unlocked);
-    }
+    _setLockState(state.pinStatus == PinStatus.enabled ? LockState.locked : LockState.unlocked);
     return state;
   }
 

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -49,13 +49,6 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   }
 
   Future<bool> testPin(String pin) async {
-    // Allow access if PIN is disabled
-    if (state.pinStatus != PinStatus.enabled) {
-      _setLockState(LockState.unlocked);
-      _logger.info('PIN check bypassed: PIN is disabled');
-      return true;
-    }
-
     final String? storedPin = await keyChain.read(pinCodeKey);
     if (storedPin == null) {
       _logger.warning('PIN not found in storage but state indicates enabled');

--- a/lib/routes/security/lock_screen.dart
+++ b/lib/routes/security/lock_screen.dart
@@ -22,6 +22,12 @@ class LockScreen extends StatelessWidget {
       child: Scaffold(
         body: BlocBuilder<SecurityCubit, SecurityState>(
           builder: (BuildContext context, SecurityState state) {
+            // If PIN is disabled, immediately authorize
+            if (state.pinStatus != PinStatus.enabled) {
+              // Future.microtask is used to ensure navigation happens after build completes
+              Future<void>.microtask(() => _authorized(navigator));
+            }
+
             return PinCodeWidget(
               label: texts.lock_screen_enter_pin,
               localAuthenticationOption: state.localAuthenticationOption,

--- a/lib/routes/security/secured_page.dart
+++ b/lib/routes/security/secured_page.dart
@@ -36,6 +36,12 @@ class _SecuredPageState<T> extends State<SecuredPage<T>> {
               key: ValueKey<int>(DateTime.now().millisecondsSinceEpoch),
               builder: (BuildContext context, SecurityState state) {
                 _logger.info('Building with: $state');
+                // If PIN is disabled, skip PIN check
+                if (state.pinStatus != PinStatus.enabled || _allowed) {
+                  _allowed = true;
+                  return widget.securedWidget;
+                }
+
                 if (state.pinStatus == PinStatus.enabled && !_allowed) {
                   final BreezTranslations texts = context.texts();
                   return Scaffold(


### PR DESCRIPTION
Fixes #436

This PR resolves an issue where the app would become stuck on the lock screen after deactivating the PIN, with no way to unlock or exit. The problem was caused by a race condition in state management between PIN status and lock state.

#### Changes:
- Bypass PIN verification on `LockScreen` & `SecuredPage` is PIN is disabled
- Improve error handling in `testPin()` to properly recover from missing PIN data
- Update `clearPin()` to ensure consistent state transitions when disabling PIN

These changes ensure that if the PIN is disabled or missing from storage, the app will properly unlock itself instead of requiring verification of a non-existent PIN.

#### Testing Notes:
- Enable & Deactivate PIN on a previous device until app gets stuck.
- Update to following builds:
  - **Android:** Under artifacts on [Build Android](https://github.com/breez/misty-breez/actions/runs/13899789666)
  - **iOS:** v6350.1 on TestFlight.
- Confirm the app properly unlocks itself
- Attempt several times to get the app stuck again by enabling & deactivating PIN.