### PR TITLE
fix: prioritize stored username over profile name in registration flows

### DIFF
--- a/lib/cubit/ln_address/services/registration_manager.dart
+++ b/lib/cubit/ln_address/services/registration_manager.dart
@@ -204,7 +204,6 @@ class LnUrlRegistrationManager {
     }
 
     final String? username = await usernameResolver.resolveUsername(
-      isNewRegistration: false, // Ownership transfer preserves existing username
       recoveredLightningAddress: recoveredLightningAddress,
       baseUsername: baseUsername,
     );
@@ -243,7 +242,6 @@ class LnUrlRegistrationManager {
     }
 
     final String? username = await usernameResolver.resolveUsername(
-      isNewRegistration: false,
       recoveredLightningAddress: recoveredLightningAddress,
       baseUsername: effectiveBaseUsername,
     );
@@ -263,7 +261,6 @@ class LnUrlRegistrationManager {
     String? recoveredLightningAddress,
   }) async {
     final String? username = await usernameResolver.resolveUsername(
-      isNewRegistration: true,
       recoveredLightningAddress: recoveredLightningAddress,
       baseUsername: baseUsername,
     );


### PR DESCRIPTION
Fixes #450

This PR addresses the case where recovery failure would fallback to registration without using stored username first.

This change ensures stored LN address username is always prioritized over profile name in all registration flows. Profile name is only used as a fallback when a stored username doesn't exist.

#### Other changelist:
- Removed `isNewRegistration` parameter as it's no longer needed with the new resolution priority order.
- Removed `UsernameResolutionStrategy` for simplicity