### PR TITLE
fix: Update paste icon on Pay with Lightning page

### DIFF
--- a/lib/routes/enter_payment_info/enter_payment_info_page.dart
+++ b/lib/routes/enter_payment_info/enter_payment_info_page.dart
@@ -356,7 +356,7 @@ class PaymentInfoPasteButton extends StatelessWidget {
             ),
           ),
           icon: const Icon(
-            IconData(0xe90b, fontFamily: 'icomoon'),
+            Icons.paste,
             size: 20.0,
           ),
           label: AutoSizeText(


### PR DESCRIPTION
Fixes #455