### PR TITLE
ui(FeeChooser): update UI for consistent styling

### DIFF
--- a/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_confirmation_page.dart
@@ -3,10 +3,10 @@ import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/widgets/widgets.dart';
-import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('SendChainSwapConfirmationPage');
 

--- a/lib/routes/send_payment/chainswap/send_chainswap_page.dart
+++ b/lib/routes/send_payment/chainswap/send_chainswap_page.dart
@@ -3,12 +3,12 @@ import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/back_button.dart' as back_button;
 import 'package:misty_breez/widgets/widgets.dart';
-import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('SendChainSwapPage');
 

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/fee_breakdown.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/fee_breakdown.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/theme/theme.dart';
 
 class FeeBreakdown extends StatelessWidget {
   final FeeOption feeOption;
@@ -24,11 +25,13 @@ class FeeBreakdown extends StatelessWidget {
     }
 
     return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
       decoration: BoxDecoration(
         borderRadius: const BorderRadius.all(Radius.circular(5.0)),
         border: Border.all(
           color: themeData.colorScheme.onSurface.withValues(alpha: .4),
         ),
+        color: themeData.customData.surfaceBgColor,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -43,7 +46,16 @@ class FeeBreakdown extends StatelessWidget {
             TransactionFee(txFeeSat: feeDetails.txFeeSat.toInt()),
             RecipientAmount(amountSat: refundAmountSat! - (feeDetails.txFeeSat).toInt()),
           ],
-        ],
+        ].expand((Widget widget) sync* {
+          yield widget;
+          yield const Divider(
+            height: 8.0,
+            color: Color.fromRGBO(40, 59, 74, 0.5),
+            indent: 16.0,
+            endIndent: 16.0,
+          );
+        }).toList()
+          ..removeLast(),
       ),
     );
   }

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/boltz_service_fee.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/boltz_service_fee.dart
@@ -19,7 +19,10 @@ class BoltzServiceFee extends StatelessWidget {
     return ListTile(
       title: AutoSizeText(
         texts.reverse_swap_confirmation_boltz_fee,
-        style: TextStyle(color: Colors.white.withValues(alpha: .4)),
+        style: themeData.primaryTextTheme.headlineMedium?.copyWith(
+          fontSize: 18.0,
+          color: Colors.white.withValues(alpha: .4),
+        ),
         maxLines: 1,
         minFontSize: minFontSize.minFontSize,
         stepGranularity: 0.1,
@@ -28,7 +31,10 @@ class BoltzServiceFee extends StatelessWidget {
         texts.reverse_swap_confirmation_boltz_fee_value(
           BitcoinCurrency.sat.format(boltzServiceFee),
         ),
-        style: TextStyle(color: themeData.colorScheme.error.withValues(alpha: .4)),
+        style: themeData.primaryTextTheme.displaySmall!.copyWith(
+          fontSize: 18.0,
+          color: themeData.colorScheme.error.withValues(alpha: .4),
+        ),
         maxLines: 1,
         minFontSize: minFontSize.minFontSize,
         stepGranularity: 0.1,

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/recipient_amount.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/recipient_amount.dart
@@ -20,8 +20,12 @@ class RecipientAmount extends StatelessWidget {
 
     return ListTile(
       title: AutoSizeText(
-        texts.sweep_all_coins_label_receive,
-        style: const TextStyle(color: Colors.white),
+        // TODO(erdemyerebasmaz): Add message to Breez-Translations
+        'To receive:',
+        style: themeData.primaryTextTheme.headlineMedium?.copyWith(
+          fontSize: 18.0,
+          color: Colors.white,
+        ),
         maxLines: 1,
         minFontSize: minFont.minFontSize,
         stepGranularity: 0.1,
@@ -39,7 +43,10 @@ class RecipientAmount extends StatelessWidget {
                     BitcoinCurrency.sat.format(amountSat),
                     fiatConversion.format(amountSat),
                   ),
-            style: TextStyle(color: themeData.colorScheme.error),
+            style: themeData.primaryTextTheme.displaySmall!.copyWith(
+              fontSize: 18.0,
+              color: themeData.colorScheme.error,
+            ),
             maxLines: 1,
             minFontSize: minFont.minFontSize,
             stepGranularity: 0.1,

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/sender_amount.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/sender_amount.dart
@@ -20,7 +20,12 @@ class SenderAmount extends StatelessWidget {
 
     return ListTile(
       title: AutoSizeText(
-        texts.sweep_all_coins_label_send,
+        // TODO(erdemyerebasmaz): Add message to Breez-Translations
+        'To send:',
+        style: themeData.primaryTextTheme.headlineMedium?.copyWith(
+          fontSize: 18.0,
+          color: Colors.white,
+        ),
         maxLines: 1,
         minFontSize: minFont.minFontSize,
         stepGranularity: 0.1,
@@ -38,7 +43,10 @@ class SenderAmount extends StatelessWidget {
                     BitcoinCurrency.sat.format(amountSat),
                     fiatConversion.format(amountSat),
                   ),
-            style: TextStyle(color: themeData.colorScheme.error),
+            style: themeData.primaryTextTheme.displaySmall!.copyWith(
+              fontSize: 18.0,
+              color: themeData.colorScheme.error,
+            ),
             maxLines: 1,
             minFontSize: minFont.minFontSize,
             stepGranularity: 0.1,

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/transaction_fee.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/transaction_fee.dart
@@ -19,7 +19,10 @@ class TransactionFee extends StatelessWidget {
     return ListTile(
       title: AutoSizeText(
         texts.sweep_all_coins_label_transaction_fee,
-        style: TextStyle(color: Colors.white.withValues(alpha: .4)),
+        style: themeData.primaryTextTheme.headlineMedium?.copyWith(
+          fontSize: 18.0,
+          color: Colors.white.withValues(alpha: .4),
+        ),
         maxLines: 1,
         minFontSize: minFont.minFontSize,
         stepGranularity: 0.1,
@@ -28,7 +31,10 @@ class TransactionFee extends StatelessWidget {
         texts.sweep_all_coins_fee(
           BitcoinCurrency.sat.format(txFeeSat),
         ),
-        style: TextStyle(color: themeData.colorScheme.error.withValues(alpha: .4)),
+        style: themeData.primaryTextTheme.displaySmall!.copyWith(
+          fontSize: 18.0,
+          color: themeData.colorScheme.error.withValues(alpha: .4),
+        ),
         maxLines: 1,
         minFontSize: minFont.minFontSize,
         stepGranularity: 0.1,

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/fee_chooser.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/fee_chooser.dart
@@ -26,7 +26,7 @@ class _FeeChooserState extends State<FeeChooser> {
     final FeeOption selectedFeeOption = widget.feeOptions.elementAt(widget.selectedFeeIndex);
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 40.0),
+      padding: const EdgeInsets.fromLTRB(16.0, 32.0, 16.0, 40.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -36,12 +36,15 @@ class _FeeChooserState extends State<FeeChooser> {
             selectedFeeIndex: widget.selectedFeeIndex,
             onSelect: (int index) => widget.onSelect(index),
           ),
-          const SizedBox(height: 12.0),
+          const SizedBox(height: 8.0),
           ProcessingSpeedWaitTime(
             selectedFeeOption.processingSpeed.waitingTime,
           ),
-          const SizedBox(height: 36.0),
-          FeeBreakdown(feeOption: selectedFeeOption, refundAmountSat: widget.amountSat),
+          const SizedBox(height: 8.0 + 16.0),
+          FeeBreakdown(
+            feeOption: selectedFeeOption,
+            refundAmountSat: widget.amountSat,
+          ),
         ],
       ),
     );

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/widgets/fee_option_button.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/widgets/fee_option_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:misty_breez/theme/theme.dart';
 
 class FeeOptionButton extends StatelessWidget {
   final int index;
@@ -32,7 +33,11 @@ class FeeOptionButton extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           borderRadius: borderRadius,
-          color: isSelected ? themeData.colorScheme.onSurface : themeData.canvasColor,
+          color: !isAffordable
+              ? themeData.disabledColor
+              : isSelected
+                  ? themeData.primaryColor
+                  : themeData.customData.surfaceBgColor,
           border: border,
         ),
         child: TextButton(
@@ -40,11 +45,12 @@ class FeeOptionButton extends StatelessWidget {
           child: Text(
             text.toUpperCase(),
             style: themeData.textTheme.labelLarge!.copyWith(
+              fontSize: 16.0,
               color: !isAffordable
-                  ? themeData.primaryColor.withValues(alpha: .4)
+                  ? Colors.white.withValues(alpha: .4)
                   : isSelected
-                      ? themeData.canvasColor
-                      : themeData.colorScheme.onSurface,
+                      ? Colors.white
+                      : Colors.white,
             ),
           ),
         ),

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/widgets/processing_speed_wait_time.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_chooser/widgets/processing_speed_wait_time.dart
@@ -1,6 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
+import 'package:misty_breez/theme/theme.dart';
 
 class ProcessingSpeedWaitTime extends StatelessWidget {
   final Duration waitingTime;
@@ -13,7 +14,6 @@ class ProcessingSpeedWaitTime extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final BreezTranslations texts = context.texts();
-    final ThemeData themeData = Theme.of(context);
 
     final int hours = waitingTime.inHours;
 
@@ -36,9 +36,7 @@ class ProcessingSpeedWaitTime extends StatelessWidget {
 
     return Text(
       message,
-      style: themeData.textTheme.labelLarge!.copyWith(
-        color: themeData.colorScheme.onSurface.withValues(alpha: .4),
-      ),
+      style: FieldTextStyle.labelStyle.copyWith(fontSize: 13.0),
     );
   }
 }


### PR DESCRIPTION
Fixes #449

This PR aligns design language of `FeeChoser` with the rest of our app.

### Changelist:
- Updated background color of `FeeChooserHeader` & `FeeBreakdown` so they are consistent with the wrapping cards we’ve added on Send & Receive pages.
- Updated text styles for readability & consistency
- `FeeBreakdown` texts are updated to use `To` instead of `You` 
- added divider between `FeeBreakdown` items
- added vertical padding to `FeeBreakdown`
- reduced padding between `FeeChooserHeader`, `ProcessingSpeedWaitTime` & `FeeBreakdown`

### Screenshot:
![image](https://github.com/user-attachments/assets/95bebc83-8625-4d4d-8c74-2ab40558c8d0)
