### PR TITLE
Show invoice page by default when app doesn't have notification permissions

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -66,6 +66,9 @@ class App extends StatelessWidget {
         BlocProvider<ChainSwapCubit>(
           create: (BuildContext context) => ChainSwapCubit(injector.breezSdkLiquid),
         ),
+        BlocProvider<PermissionsCubit>(
+          create: (BuildContext context) => PermissionsCubit(),
+        ),
       ],
       child: const AppView(),
     );

--- a/lib/cubit/cubit.dart
+++ b/lib/cubit/cubit.dart
@@ -13,6 +13,7 @@ export 'lnurl/lnurl_cubit.dart';
 export 'model/models.dart';
 export 'payment_limits/payment_limits_cubit.dart';
 export 'payments/payments_cubit.dart';
+export 'permissions/permissions_cubit.dart';
 export 'refund/refund_cubit.dart';
 export 'security/security_cubit.dart';
 export 'user_profile/user_profile_cubit.dart';

--- a/lib/cubit/permissions/permissions_cubit.dart
+++ b/lib/cubit/permissions/permissions_cubit.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_fgbg/flutter_fgbg.dart';
+import 'package:logging/logging.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+import 'package:permission_handler/permission_handler.dart' as ph;
+
+export 'permissions_state.dart';
+
+/// Logger for PermissionsCubit
+final Logger _logger = Logger('PermissionsCubit');
+
+/// Cubit that manages permission states and listens for app lifecycle changes
+class PermissionsCubit extends Cubit<PermissionsState> {
+  /// Stream subscription for foreground/background events
+  StreamSubscription<FGBGType>? fgBgEventsStreamSubscription;
+
+  PermissionsCubit() : super(PermissionsState.initial()) {
+    _initializePermissions();
+  }
+
+  /// Initialize permissions and set up event listeners
+  Future<void> _initializePermissions() async {
+    _logger.info('Initializing permissions');
+    await checkNotificationPermission();
+    _setupForegroundBackgroundListener();
+  }
+
+  /// Set up listener for foreground/background events
+  void _setupForegroundBackgroundListener() {
+    _logger.fine('Setting up foreground/background event listener');
+    fgBgEventsStreamSubscription = FGBGEvents.instance.stream.listen(_handleForegroundBackgroundEvent);
+  }
+
+  /// Handle foreground/background events
+  void _handleForegroundBackgroundEvent(FGBGType event) {
+    if (event == FGBGType.foreground) {
+      _logger.info('App came to foreground, checking permissions');
+      checkNotificationPermission();
+    }
+  }
+
+  /// Check notification permission
+  Future<void> checkNotificationPermission() async {
+    try {
+      final ph.PermissionStatus status = await ph.Permission.notification.status;
+      _logger.info('Raw notification permission status: ${status.name}');
+
+      final PermissionStatus mappedStatus = _mapPermissionStatus(status);
+
+      emit(
+        state.copyWith(
+          notificationStatus: mappedStatus,
+        ),
+      );
+      _logger.info('Mapped notification permission status: $mappedStatus');
+    } catch (error) {
+      _logger.severe('Error checking notification permission', error);
+    }
+  }
+
+  /// Request notification permission
+  Future<void> requestNotificationPermission() async {
+    try {
+      final ph.PermissionStatus status = await ph.Permission.notification.request();
+      _logger.info('Raw notification permission request result: ${status.name}');
+
+      final PermissionStatus mappedStatus = _mapPermissionStatus(status);
+
+      emit(
+        state.copyWith(
+          notificationStatus: mappedStatus,
+        ),
+      );
+      _logger.info('Mapped notification permission request result: $mappedStatus');
+    } catch (error) {
+      _logger.severe('Error requesting notification permission', error);
+    }
+  }
+
+  /// Opens app settings to enable permissions
+  Future<bool> openAppSettings() async {
+    try {
+      final bool result = await ph.openAppSettings();
+      _logger.info('Opened app settings. Result: $result');
+      return result;
+    } catch (error) {
+      _logger.severe('Error opening app settings', error);
+      return false;
+    }
+  }
+
+  /// Map permission_handler status to our enum
+  PermissionStatus _mapPermissionStatus(ph.PermissionStatus status) {
+    switch (status) {
+      case ph.PermissionStatus.granted:
+        return PermissionStatus.granted;
+      case ph.PermissionStatus.denied:
+        return PermissionStatus.denied;
+      case ph.PermissionStatus.permanentlyDenied:
+      case ph.PermissionStatus.restricted:
+      case ph.PermissionStatus.limited:
+        return PermissionStatus.permanentlyDenied;
+      default:
+        return PermissionStatus.unknown;
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    _logger.info('Closing PermissionsCubit');
+    await fgBgEventsStreamSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/cubit/permissions/permissions_state.dart
+++ b/lib/cubit/permissions/permissions_state.dart
@@ -1,0 +1,41 @@
+/// Enum representing permission status states
+enum PermissionStatus {
+  /// Permission is granted
+  granted,
+
+  /// Permission is denied
+  denied,
+
+  /// Permission is permanently denied and can only be granted from app settings
+  permanentlyDenied,
+
+  /// Permission status is unknown (initial state)
+  unknown,
+}
+
+/// Class that represents the state of the permissions
+class PermissionsState {
+  /// Notification permission status
+  final PermissionStatus notificationStatus;
+
+  const PermissionsState({required this.notificationStatus});
+
+  /// Default state constructor
+  factory PermissionsState.initial() => const PermissionsState(notificationStatus: PermissionStatus.unknown);
+
+  /// Creates a copy of this state with the given values
+  PermissionsState copyWith({
+    PermissionStatus? notificationStatus,
+  }) {
+    return PermissionsState(
+      notificationStatus: notificationStatus ?? this.notificationStatus,
+    );
+  }
+
+  /// Whether notification permissions are granted
+  bool get hasNotificationPermission => notificationStatus == PermissionStatus.granted;
+
+  /// Whether notification permissions are permanently denied
+  bool get hasNotificationPermissionPermanentlyDenied =>
+      notificationStatus == PermissionStatus.permanentlyDenied;
+}

--- a/lib/routes/receive_payment/lightning/receive_lightning_page.dart
+++ b/lib/routes/receive_payment/lightning/receive_lightning_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/theme/src/theme.dart';
@@ -12,7 +13,6 @@ import 'package:misty_breez/theme/src/theme_extensions.dart';
 import 'package:misty_breez/theme/theme.dart';
 import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/widgets.dart';
-import 'package:logging/logging.dart';
 
 final Logger _logger = Logger('ReceiveLightningPaymentPage');
 
@@ -84,7 +84,12 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
               ? Padding(
                   padding: const EdgeInsets.only(top: 32, bottom: 40.0),
                   child: SingleChildScrollView(
-                    child: _buildForm(lightningPaymentLimits),
+                    child: Column(
+                      children: <Widget>[
+                        _buildForm(lightningPaymentLimits),
+                        _buildNotificationWarningBox(),
+                      ],
+                    ),
                   ),
                 )
               : _buildQRCode();
@@ -363,5 +368,16 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
       lightningPaymentLimits,
       balance,
     );
+  }
+
+  Widget _buildNotificationWarningBox() {
+    final int? initialPageIndex = ModalRoute.of(context)?.settings.arguments as int?;
+
+    // Only show this on the invoice page if we wanted to navigate to LN Address
+    // and don't have permissions
+    if (initialPageIndex == ReceiveLightningAddressPage.pageIndex) {
+      return const NotificationPermissionWarningBox();
+    }
+    return const SizedBox.shrink();
   }
 }

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -30,12 +30,21 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
     final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
+    final PermissionStatus notificationStatus = context.select<PermissionsCubit, PermissionStatus>(
+      (PermissionsCubit cubit) => cubit.state.notificationStatus,
+    );
+    final int currentPageIndex = _getEffectivePageIndex(notificationStatus);
+
+    final bool isLightningPage = <int>[
+      ReceiveLightningPaymentPage.pageIndex,
+      ReceiveLightningAddressPage.pageIndex,
+    ].contains(currentPageIndex);
+
     return Scaffold(
       appBar: AppBar(
         leading: const back_button.BackButton(),
-        title: Text(_getTitle()),
-        actions: widget.initialPageIndex == ReceiveLightningPaymentPage.pageIndex ||
-                widget.initialPageIndex == ReceiveLightningAddressPage.pageIndex
+        title: Text(_getTitle(currentPageIndex)),
+        actions: isLightningPage
             ? <Widget>[
                 IconButton(
                   alignment: Alignment.center,
@@ -54,14 +63,14 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0),
-        child: pages.elementAt(widget.initialPageIndex),
+        child: pages.elementAt(currentPageIndex),
       ),
     );
   }
 
-  String _getTitle() {
+  String _getTitle(int pageIndex) {
     final BreezTranslations texts = context.texts();
-    switch (widget.initialPageIndex) {
+    switch (pageIndex) {
       case ReceiveLightningPaymentPage.pageIndex:
       case ReceiveLightningAddressPage.pageIndex:
         // TODO(erdemyerebasmaz): Add message to Breez-Translations
@@ -71,6 +80,16 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       default:
         return texts.invoice_lightning_title;
     }
+  }
+
+  int _getEffectivePageIndex(PermissionStatus notificationStatus) {
+    // Redirect to Invoice page if LN Address page is opened without notification permissions
+    if (widget.initialPageIndex == ReceiveLightningAddressPage.pageIndex &&
+        notificationStatus != PermissionStatus.granted) {
+      return ReceiveLightningPaymentPage.pageIndex;
+    }
+
+    return widget.initialPageIndex;
   }
 
   void _scanBarcode() {

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -42,7 +42,17 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
 
     return Scaffold(
       appBar: AppBar(
-        leading: const back_button.BackButton(),
+        leading: back_button.BackButton(
+          onPressed: () {
+            if (currentPageIndex == ReceiveLightningPaymentPage.pageIndex &&
+                notificationStatus != PermissionStatus.granted) {
+              // Pop to Home page, bypassing LN Address page if notification permissions are disabled
+              Navigator.of(context).pushReplacementNamed(Home.routeName);
+              return;
+            }
+            Navigator.of(context).pop();
+          },
+        ),
         title: Text(_getTitle(currentPageIndex)),
         actions: isLightningPage
             ? <Widget>[

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/notification_permission_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/notification_permission_warning_box.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+final Logger _logger = Logger('NotificationPermissionWarningBox');
+
+/// Warning box for notification permission status
+class NotificationPermissionWarningBox extends StatelessWidget {
+  const NotificationPermissionWarningBox({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final PermissionsCubit permissionsCubit = context.read<PermissionsCubit>();
+
+    return BlocBuilder<PermissionsCubit, PermissionsState>(
+      builder: (BuildContext context, PermissionsState state) {
+        // Skip loading this widget until we've actually checked permissions
+        if (state.notificationStatus == PermissionStatus.unknown) {
+          _logger.info('Permission status is unknown, triggering check');
+          // Trigger permission check and avoid showing anything until we have a result
+          Future<void>.microtask(() => permissionsCubit.checkNotificationPermission());
+          return const SizedBox.shrink();
+        }
+
+        if (state.hasNotificationPermission) {
+          return const SizedBox.shrink();
+        }
+
+        _logger.info('No notification permission, showing warning box');
+        // TODO(erdemyerebasmaz): Add message to Breez-Translations
+        final String warningMessage = 'Your Lightning Address is disabled because '
+            "Misty Breez doesn't have notification permissions.";
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 32.0),
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => _requestPermission(context),
+            child: WarningBox(
+              boxPadding: EdgeInsets.zero,
+              backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
+              contentPadding: const EdgeInsets.all(16.0),
+              child: RichText(
+                text: TextSpan(
+                  text: warningMessage,
+                  style: themeData.textTheme.titleLarge?.copyWith(
+                    color: themeData.colorScheme.error,
+                  ),
+                  children: <InlineSpan>[
+                    TextSpan(
+                      // TODO(erdemyerebasmaz): Add message to Breez-Translations
+                      text: '\n\nTap here',
+                      style: themeData.textTheme.titleLarge?.copyWith(
+                        color: themeData.colorScheme.error.withValues(alpha: .7),
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                    TextSpan(
+                      text:
+                          ' to enable them${state.hasNotificationPermissionPermanentlyDenied ? ' in settings.' : '.'}',
+                    ),
+                  ],
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _requestPermission(BuildContext context) {
+    final PermissionsCubit permissionsCubit = context.read<PermissionsCubit>();
+    if (permissionsCubit.state.hasNotificationPermissionPermanentlyDenied) {
+      permissionsCubit.openAppSettings();
+    } else {
+      permissionsCubit.requestNotificationPermission();
+    }
+  }
+}

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
@@ -1,3 +1,4 @@
+export 'notification_permission_warning_box.dart';
 export 'payment_fees_message_box.dart';
 export 'payment_info_message_box.dart';
 export 'payment_limits_message_box.dart';


### PR DESCRIPTION
Fixes #465 

This PR
- introduces a new `PermissionsCubit` to manage permission states with app lifecycle listener. 
- improves "Receive with Lightning" workflow based on notification permission status:
  - Invoice page is shown by default when app doesn't have notification permissions (instead of Lightning Address)
  - Shows a warning explaining why notifications are required for Lightning Address feature
    - Users can tap the **Tap here** hyperlink on warning to enable notification permissions
      - _Edit:_ Changed this so users can tap anywhere on the warning box to enable notification permissions. Attaching gesture recognizer to the `TextSpan` was causing clicks to be missed due to small tap area.
    - This warning is:
      - Only shown when redirected from LN Address page due to missing permissions
      - Hidden when Invoice page is accessed directly via the **Specify Amount** button    
  - Improves Back button to bypass Lightning Address page if notifications are disabled after Invoice page is opened via Specify Amount

#### Misc. Change:
- Extracted Lightning page check into a readable boolean variable using a list-based approach