### PR TITLE
Show invoice page by default when LnAddressState has errors

### DIFF
--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/theme/theme.dart';
-import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/widgets.dart';
 
 /// Page that displays the user's Lightning Address for receiving payments.
@@ -30,19 +29,17 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
     return BlocBuilder<LnAddressCubit, LnAddressState>(
       builder: (BuildContext context, LnAddressState lnAddressState) {
         return Scaffold(
-          body: _getLnAddressContent(lnAddressState, texts),
+          body: _getLnAddressContent(lnAddressState),
           bottomNavigationBar: BlocBuilder<PaymentLimitsCubit, PaymentLimitsState>(
             builder: (BuildContext context, PaymentLimitsState limitsState) {
-              final bool hasError = lnAddressState.hasError || limitsState.hasError;
+              final bool hasError = limitsState.hasError;
 
               return Padding(
                 padding: const EdgeInsets.only(top: 16.0),
                 child: SingleButtonBottomBar(
                   stickToBottom: true,
                   text: hasError ? texts.invoice_ln_address_action_retry : texts.qr_code_dialog_action_close,
-                  onPressed: hasError
-                      ? () => _onRetryPressed(lnAddressState, limitsState)
-                      : () => Navigator.of(context).pop(),
+                  onPressed: hasError ? () => _fetchLightningLimits() : () => Navigator.of(context).pop(),
                 ),
               );
             },
@@ -52,16 +49,9 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
     );
   }
 
-  Widget _getLnAddressContent(LnAddressState lnAddressState, BreezTranslations texts) {
+  Widget _getLnAddressContent(LnAddressState lnAddressState) {
     if (lnAddressState.isLoading) {
       return const CenteredLoader();
-    }
-
-    if (lnAddressState.hasError) {
-      return LnAddressErrorView(
-        title: texts.lightning_address_service_error_title,
-        error: lnAddressState.error!,
-      );
     }
 
     if (lnAddressState.isSuccess && lnAddressState.hasValidLnUrl) {
@@ -71,58 +61,9 @@ class ReceiveLightningAddressPageState extends State<ReceiveLightningAddressPage
     return const SizedBox.shrink();
   }
 
-  void _onRetryPressed(LnAddressState lnAddressState, PaymentLimitsState limitsState) {
-    if (lnAddressState.hasError) {
-      final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
-      lnAddressCubit.setupLightningAddress(isRecover: true);
-    } else if (limitsState.hasError) {
-      final PaymentLimitsCubit paymentLimitsCubit = context.read<PaymentLimitsCubit>();
-      paymentLimitsCubit.fetchLightningLimits();
-    }
-  }
-}
-
-/// Widget to display loading indicator for Lightning Address
-class LnAddressLoadingView extends StatelessWidget {
-  const LnAddressLoadingView({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
-    return Center(
-      child: Loader(
-        color: themeData.primaryColor.withValues(alpha: .5),
-      ),
-    );
-  }
-}
-
-/// Widget to display error state for Lightning Address
-class LnAddressErrorView extends StatelessWidget {
-  final String title;
-  final Object error;
-
-  const LnAddressErrorView({
-    required this.title,
-    required this.error,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final BreezTranslations texts = context.texts();
-
-    return Column(
-      children: <Widget>[
-        Expanded(
-          child: ScrollableErrorMessageWidget(
-            showIcon: true,
-            title: title,
-            message: ExceptionHandler.extractMessage(error, texts),
-          ),
-        ),
-      ],
-    );
+  void _fetchLightningLimits() {
+    final PaymentLimitsCubit paymentLimitsCubit = context.read<PaymentLimitsCubit>();
+    paymentLimitsCubit.fetchLightningLimits();
   }
 }
 

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -92,6 +92,14 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       return ReceiveLightningPaymentPage.pageIndex;
     }
 
+    final bool hasLnAddressStateError = context.select<LnAddressCubit, bool>(
+      (LnAddressCubit cubit) => cubit.state.hasError,
+    );
+
+    if (!hasLnAddressStateError) {
+      return ReceiveLightningPaymentPage.pageIndex;
+    }
+
     return widget.initialPageIndex;
   }
 }

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -93,7 +93,8 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       case ReceiveBitcoinAddressPaymentPage.pageIndex:
         return texts.invoice_btc_address_title;
       default:
-        return texts.invoice_lightning_title;
+        // TODO(erdemyerebasmaz): Add message to Breez-Translations
+        return 'Receive with Lightning';
     }
   }
 

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -39,13 +39,16 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       hasLnAddressStateError: hasLnAddressStateError,
     );
 
+    final bool isLNPaymentPage = currentPageIndex == ReceiveLightningPaymentPage.pageIndex;
+
     return Scaffold(
       appBar: AppBar(
         leading: back_button.BackButton(
           onPressed: () {
-            if (currentPageIndex == ReceiveLightningPaymentPage.pageIndex &&
-                notificationStatus != PermissionStatus.granted) {
-              // Pop to Home page, bypassing LN Address page if notification permissions are disabled
+            if (isLNPaymentPage && (!hasNotificationPermission || hasLnAddressStateError)) {
+              // Pop to Home page, bypassing LN Address page if
+              // - notification permissions are disabled
+              // - LnAddressState has errors
               Navigator.of(context).pushReplacementNamed(Home.routeName);
               return;
             }

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/ln_address_error_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/ln_address_error_warning_box.dart
@@ -1,0 +1,82 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/utils/utils.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+/// Warning box for LnAddressState errors
+class LnAddressErrorWarningBox extends StatelessWidget {
+  const LnAddressErrorWarningBox({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final BreezTranslations texts = context.texts();
+
+    return BlocBuilder<LnAddressCubit, LnAddressState>(
+      builder: (BuildContext context, LnAddressState state) {
+        if (state.isLoading) {
+          return const CenteredLoader();
+        }
+
+        if (!state.hasError) {
+          // Redirect to Lightning Address Page after LnAddressState error is resolved
+          Future<void>.microtask(() {
+            if (context.mounted) {
+              Navigator.of(context).pushReplacementNamed(
+                ReceivePaymentPage.routeName,
+                arguments: ReceiveLightningAddressPage.pageIndex,
+              );
+            }
+          });
+          return const SizedBox.shrink();
+        }
+
+        final String errorMessage = ExceptionHandler.extractMessage(state.error!, texts);
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 32.0),
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () {
+              final LnAddressCubit lnAddressCubit = context.read<LnAddressCubit>();
+              lnAddressCubit.setupLightningAddress(isRecover: true);
+            },
+            child: WarningBox(
+              boxPadding: EdgeInsets.zero,
+              backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
+              contentPadding: const EdgeInsets.all(16.0),
+              child: RichText(
+                text: TextSpan(
+                  text: texts.lightning_address_service_error_title,
+                  style: themeData.textTheme.titleLarge?.copyWith(
+                    color: themeData.colorScheme.error,
+                  ),
+                  children: <InlineSpan>[
+                    TextSpan(
+                      text: '\n\n$errorMessage',
+                      style: themeData.textTheme.bodyLarge?.copyWith(
+                        color: themeData.colorScheme.error.withValues(alpha: .8),
+                      ),
+                    ),
+                    TextSpan(
+                      text: '\n\nTap here to retry',
+                      style: themeData.textTheme.titleLarge?.copyWith(
+                        color: themeData.colorScheme.error.withValues(alpha: .7),
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ],
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
@@ -1,3 +1,4 @@
+export 'ln_address_error_warning_box.dart';
 export 'notification_permission_warning_box.dart';
 export 'payment_fees_message_box.dart';
 export 'payment_info_message_box.dart';


### PR DESCRIPTION
Fixes #466 

This PR improves "Receive with Lightning" workflow based on `LnAddressState` errors:
- Invoice page is shown by default when `LnAddressState` has errors (instead of Lightning Address)
- Shows a warning explaining `LnAddressState` error in details
  - Users can tap on warning to attempt recovering their webhook
  - Only shown when redirected from LN Address page due to `LnAddressState` errors
  - Hidden when Invoice page is accessed directly via the Specify Amount button
- Improves Back button to bypass Lightning Address page if `LnAddressState` had errors after Invoice page is opened via Specify Amount

#### Misc. Change:
- Fixed default title of `ReceivePaymentPage`
- Removed the `LnAddressErrorView` & `LnAddressLoadingView` widgets