### PR TITLE
fix: Resolve HydratedBloc persistence issues in obfuscated release builds

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,14 +9,12 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		22246727F178B1E17E673139 /* BreezSDKLiquidConnector.swift in Resources */ = {isa = PBXBuildFile; fileRef = 64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		2D159DA5D4F2CB59F0F13F39 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDB17678D8D92742DF3DC275 /* Pods_NotificationService.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		442AE910DC3589D0BD9C3F38 /* BreezSDKLiquid.swift in Resources */ = {isa = PBXBuildFile; fileRef = 3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		5A1B8E788210285CFD84BDA9 /* TaskProtocol.swift in Resources */ = {isa = PBXBuildFile; fileRef = 94B64D07DB5A75CA4E5809DF /* TaskProtocol.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		619399E2500DF1F47AC77393 /* LnurlPayInfo.swift in Resources */ = {isa = PBXBuildFile; fileRef = 8BD8A8F87E52CF59156EC5B7 /* LnurlPayInfo.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
-		65FDDF6C9F437CF59B581E6B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5225DDF8A268ACAC3C32B7C2 /* Pods_RunnerTests.framework */; };
-		69599EA70560EA10B0359ACD /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 261DFAC6A22B94742BC07077 /* Pods_Runner.framework */; };
+		61A41F424FBE6F3F2AD38863 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18DEACABA25EF9956FDD319C /* Pods_Runner.framework */; };
 		71047A5D4902C8ED77D1A08E /* ResourceHelper.swift in Resources */ = {isa = PBXBuildFile; fileRef = 68C3549E54F158E6F1BF215E /* ResourceHelper.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		732A3D282C6CCF13007563A8 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D272C6CCF13007563A8 /* NotificationService.swift */; };
 		732A3D2C2C6CCF13007563A8 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 732A3D252C6CCF13007563A8 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -30,6 +28,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A09F2C75439FD441CCB45C4B /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		A5B7FE775C5DE85F5BA030AA /* SwapUpdated.swift in Resources */ = {isa = PBXBuildFile; fileRef = 6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		A648D1F22C17FF1D02B60DE1 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61BCFFB85AF1890464645132 /* Pods_NotificationService.framework */; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
 		BEFD2B173AD9A8F75F4C4E70 /* Constants.swift in Resources */ = {isa = PBXBuildFile; fileRef = B5E5724CB2BA100C10032AF2 /* Constants.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		C20CE275E425F859C7E6DE4C /* String+SHA256.swift in Resources */ = {isa = PBXBuildFile; fileRef = A9EEF592AC15F5122FE4839C /* String+SHA256.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
@@ -48,6 +47,7 @@
 		E81E0B322CA33D3400B1C606 /* LnurlPayInvoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */; };
 		E81E0B332CA33D3400B1C606 /* SwapUpdated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */; };
 		F5AB6D9DA4E6C7BB8D096EC1 /* SDKNotificationService.swift in Resources */ = {isa = PBXBuildFile; fileRef = B05FDB7E07CF3107D1D2C0CB /* SDKNotificationService.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		FFF83886A8D3C5BB895C6868 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44201FD49CD2A589BE5F5FF7 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,15 +95,18 @@
 		12304F0B1670756F9611DCE1 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPayInvoice.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		18DEACABA25EF9956FDD319C /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A928177C42305FC6DA768BE /* ServiceLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceLogger.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ServiceLogger.swift; sourceTree = "<group>"; };
-		260EC93890632D017C1B53E7 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		261DFAC6A22B94742BC07077 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D7EAFAFD1FC4F6D8AB32A1A /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3D7DB8C77688ADE62DB8512C /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		3DB7CA710C358B76F5CDB67F /* BreezSDKLiquid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquid.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquid.swift; sourceTree = "<group>"; };
-		5225DDF8A268ACAC3C32B7C2 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6019AD54A8622D4794ABBC0B /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		44201FD49CD2A589BE5F5FF7 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		444C08A9400482A370C6B20A /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		4726A28FAFE3B9B1ECA5DB0E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		61BCFFB85AF1890464645132 /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		64CD9507572573C8A93078E8 /* BreezSDKLiquidConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDKLiquidConnector.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/BreezSDKLiquidConnector.swift; sourceTree = "<group>"; };
 		68C3549E54F158E6F1BF215E /* ResourceHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResourceHelper.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/ResourceHelper.swift; sourceTree = "<group>"; };
 		6D92E330AE9E0FFA4F342038 /* SwapUpdated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwapUpdated.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/SwapUpdated.swift; sourceTree = "<group>"; };
@@ -115,14 +118,12 @@
 		732A3D342C6CD974007563A8 /* KeychainHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		732A3D352C6CD974007563A8 /* KeyChainAccessGroupHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyChainAccessGroupHelper.swift; sourceTree = "<group>"; };
 		733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = breez_sdk_liquidFFI.xcframework; path = .symlinks/plugins/flutter_breez_liquid/ios/Frameworks/breez_sdk_liquidFFI.xcframework; sourceTree = "<group>"; };
+		73DEEA83F5EEE93916FE3BC9 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		74D7F12BF5F9E7BD730EF421 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		7F77F6E1B027D1A45EBC6757 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
-		8AC475DE49780B21AAF4C6E0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		809D6C083AFB6A07ED84AE25 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		8BD8A8F87E52CF59156EC5B7 /* LnurlPayInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInfo.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPayInfo.swift; sourceTree = "<group>"; };
-		92C1B6A7940CFBBF34773937 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		94B64D07DB5A75CA4E5809DF /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/TaskProtocol.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -131,16 +132,15 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A0A2F0032DA8813F93B5746 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		A9EEF592AC15F5122FE4839C /* String+SHA256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+SHA256.swift"; path = "../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/String+SHA256.swift"; sourceTree = "<group>"; };
 		B05FDB7E07CF3107D1D2C0CB /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/SDKNotificationService.swift; sourceTree = "<group>"; };
 		B5E5724CB2BA100C10032AF2 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Constants.swift; sourceTree = "<group>"; };
 		B820DCA0F1919C03D6BA3896 /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = ../.symlinks/plugins/flutter_breez_liquid/ios/Sources/BreezSDKLiquid/Task/LnurlPay.swift; sourceTree = "<group>"; };
-		B8C3137CC8BE53353D6C0E81 /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		E692739327A99C86F34030D8 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
+		E06A9649F51F7469FB233E38 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		EDB17678D8D92742DF3DC275 /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F868129C5F3A303A435C7EB8 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
+		F3915D8AE5E9ED6D9406902F /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,7 +148,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65FDDF6C9F437CF59B581E6B /* Pods_RunnerTests.framework in Frameworks */,
+				FFF83886A8D3C5BB895C6868 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,7 +157,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				733E91342CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework in Frameworks */,
-				2D159DA5D4F2CB59F0F13F39 /* Pods_NotificationService.framework in Frameworks */,
+				A648D1F22C17FF1D02B60DE1 /* Pods_NotificationService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,7 +165,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				69599EA70560EA10B0359ACD /* Pods_Runner.framework in Frameworks */,
+				61A41F424FBE6F3F2AD38863 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -216,9 +216,9 @@
 			isa = PBXGroup;
 			children = (
 				733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */,
-				EDB17678D8D92742DF3DC275 /* Pods_NotificationService.framework */,
-				261DFAC6A22B94742BC07077 /* Pods_Runner.framework */,
-				5225DDF8A268ACAC3C32B7C2 /* Pods_RunnerTests.framework */,
+				61BCFFB85AF1890464645132 /* Pods_NotificationService.framework */,
+				18DEACABA25EF9956FDD319C /* Pods_Runner.framework */,
+				44201FD49CD2A589BE5F5FF7 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -286,15 +286,15 @@
 			isa = PBXGroup;
 			children = (
 				859CF8DB9DF068928BF5B359 /* flutter_breez_liquid-OnDemandResources */,
-				F868129C5F3A303A435C7EB8 /* Pods-NotificationService.debug.xcconfig */,
-				B8C3137CC8BE53353D6C0E81 /* Pods-NotificationService.release.xcconfig */,
-				E692739327A99C86F34030D8 /* Pods-NotificationService.profile.xcconfig */,
-				260EC93890632D017C1B53E7 /* Pods-Runner.debug.xcconfig */,
-				8AC475DE49780B21AAF4C6E0 /* Pods-Runner.release.xcconfig */,
-				6019AD54A8622D4794ABBC0B /* Pods-Runner.profile.xcconfig */,
-				74D7F12BF5F9E7BD730EF421 /* Pods-RunnerTests.debug.xcconfig */,
-				92C1B6A7940CFBBF34773937 /* Pods-RunnerTests.release.xcconfig */,
-				7F77F6E1B027D1A45EBC6757 /* Pods-RunnerTests.profile.xcconfig */,
+				3D7DB8C77688ADE62DB8512C /* Pods-NotificationService.debug.xcconfig */,
+				73DEEA83F5EEE93916FE3BC9 /* Pods-NotificationService.release.xcconfig */,
+				F3915D8AE5E9ED6D9406902F /* Pods-NotificationService.profile.xcconfig */,
+				9A0A2F0032DA8813F93B5746 /* Pods-Runner.debug.xcconfig */,
+				4726A28FAFE3B9B1ECA5DB0E /* Pods-Runner.release.xcconfig */,
+				444C08A9400482A370C6B20A /* Pods-Runner.profile.xcconfig */,
+				E06A9649F51F7469FB233E38 /* Pods-RunnerTests.debug.xcconfig */,
+				2D7EAFAFD1FC4F6D8AB32A1A /* Pods-RunnerTests.release.xcconfig */,
+				809D6C083AFB6A07ED84AE25 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -306,7 +306,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				3A2CDCDEE8E989A639675640 /* [CP] Check Pods Manifest.lock */,
+				60FEED7353DC10AA2499806D /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -325,7 +325,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732A3D312C6CCF13007563A8 /* Build configuration list for PBXNativeTarget "NotificationService" */;
 			buildPhases = (
-				18A1BBC5D6740A4B39D0CC48 /* [CP] Check Pods Manifest.lock */,
+				7F40DCB5BE94F6F2A036CAE5 /* [CP] Check Pods Manifest.lock */,
 				732A3D212C6CCF13007563A8 /* Sources */,
 				732A3D222C6CCF13007563A8 /* Frameworks */,
 				732A3D232C6CCF13007563A8 /* Resources */,
@@ -343,7 +343,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				2C50C04F42319BDDF4CAE529 /* [CP] Check Pods Manifest.lock */,
+				7F605715B883CCF96B1C3056 /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				732A3D2D2C6CCF13007563A8 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
@@ -351,8 +351,8 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				7582CACA966BFEC3A9ED31BE /* [CP] Embed Pods Frameworks */,
-				248BA1E33654EBAC04313829 /* [CP] Copy Pods Resources */,
+				FEC4874BFC660051728FE717 /* [CP] Embed Pods Frameworks */,
+				0AEC7FDBED47B98D31052A19 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -454,29 +454,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		18A1BBC5D6740A4B39D0CC48 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		248BA1E33654EBAC04313829 /* [CP] Copy Pods Resources */ = {
+		0AEC7FDBED47B98D31052A19 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -493,29 +471,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2C50C04F42319BDDF4CAE529 /* [CP] Check Pods Manifest.lock */ = {
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "Thin Binary";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		3A2CDCDEE8E989A639675640 /* [CP] Check Pods Manifest.lock */ = {
+		60FEED7353DC10AA2499806D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -537,37 +509,48 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
-		};
-		7582CACA966BFEC3A9ED31BE /* [CP] Embed Pods Frameworks */ = {
+		7F40DCB5BE94F6F2A036CAE5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NotificationService-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7F605715B883CCF96B1C3056 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
@@ -584,6 +567,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		FEC4874BFC660051728FE717 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -719,7 +719,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6019AD54A8622D4794ABBC0B /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = 444C08A9400482A370C6B20A /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -749,7 +749,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 74D7F12BF5F9E7BD730EF421 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = E06A9649F51F7469FB233E38 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -767,7 +767,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 92C1B6A7940CFBBF34773937 /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 2D7EAFAFD1FC4F6D8AB32A1A /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -783,7 +783,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F77F6E1B027D1A45EBC6757 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 809D6C083AFB6A07ED84AE25 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -799,7 +799,7 @@
 		};
 		732A3D2E2C6CCF13007563A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F868129C5F3A303A435C7EB8 /* Pods-NotificationService.debug.xcconfig */;
+			baseConfigurationReference = 3D7DB8C77688ADE62DB8512C /* Pods-NotificationService.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -841,7 +841,7 @@
 		};
 		732A3D2F2C6CCF13007563A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8C3137CC8BE53353D6C0E81 /* Pods-NotificationService.release.xcconfig */;
+			baseConfigurationReference = 73DEEA83F5EEE93916FE3BC9 /* Pods-NotificationService.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -884,7 +884,7 @@
 		};
 		732A3D302C6CCF13007563A8 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E692739327A99C86F34030D8 /* Pods-NotificationService.profile.xcconfig */;
+			baseConfigurationReference = F3915D8AE5E9ED6D9406902F /* Pods-NotificationService.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1038,7 +1038,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 260EC93890632D017C1B53E7 /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = 9A0A2F0032DA8813F93B5746 /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1069,7 +1069,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8AC475DE49780B21AAF4C6E0 /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = 4726A28FAFE3B9B1ECA5DB0E /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
@@ -74,7 +75,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
   }
 
   @override
-  String get storagePrefix => 'lVa';
+  String get storagePrefix => defaultTargetPlatform == TargetPlatform.iOS ? 'lVa' : 'AccountCubit';
 
   void setIsRestoring(bool isRestoring) {
     emit(state.copyWith(isRestoring: isRestoring));

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -74,7 +74,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
   }
 
   @override
-  String get storagePrefix => 'account_cubit';
+  String get storagePrefix => 'lVa';
 
   void setIsRestoring(bool isRestoring) {
     emit(state.copyWith(isRestoring: isRestoring));

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -16,6 +16,7 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
     this.breezSdkLiquid,
   ) : super(AccountState.initial()) {
     hydrate();
+
     _listenAccountChanges();
     _listenInitialSyncEvent();
   }
@@ -43,13 +44,33 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
   }
 
   @override
-  AccountState? fromJson(Map<String, dynamic> json) {
-    return AccountState.fromJson(json);
+  AccountState? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _logger.severe('No stored data found.');
+      return null;
+    }
+
+    try {
+      final AccountState result = AccountState.fromJson(json);
+      _logger.fine('Successfully hydrated with $result');
+      return result;
+    } catch (e, stackTrace) {
+      _logger.severe('Error hydrating: $e');
+      _logger.fine('Stack trace: $stackTrace');
+      return AccountState.initial();
+    }
   }
 
   @override
   Map<String, dynamic>? toJson(AccountState state) {
-    return state.toJson();
+    try {
+      final Map<String, dynamic> result = state.toJson();
+      _logger.fine('Serialized: $result');
+      return result;
+    } catch (e) {
+      _logger.severe('Error serializing: $e');
+      return null;
+    }
   }
 
   @override

--- a/lib/cubit/account/account_cubit.dart
+++ b/lib/cubit/account/account_cubit.dart
@@ -52,6 +52,9 @@ class AccountCubit extends Cubit<AccountState> with HydratedMixin<AccountState> 
     return state.toJson();
   }
 
+  @override
+  String get storagePrefix => 'account_cubit';
+
   void setIsRestoring(bool isRestoring) {
     emit(state.copyWith(isRestoring: isRestoring));
   }

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/models/models.dart';
+import 'package:misty_breez/utils/utils.dart';
 
 final Logger _logger = Logger('AccountState');
 
@@ -85,27 +86,11 @@ extension WalletInfoFromJson on WalletInfo {
     }
 
     try {
-      final dynamic balanceSatValue = json['balanceSat'];
-      final dynamic pendingSendSatValue = json['pendingSendSat'];
-      final dynamic pendingReceiveSatValue = json['pendingReceiveSat'];
-
-      // Handle both integer and string formats
-      final BigInt balanceSat = balanceSatValue is String
-          ? BigInt.parse(balanceSatValue)
-          : BigInt.from(balanceSatValue as int? ?? 0);
-
-      final BigInt pendingSendSat = pendingSendSatValue is String
-          ? BigInt.parse(pendingSendSatValue)
-          : BigInt.from(pendingSendSatValue as int? ?? 0);
-
-      final BigInt pendingReceiveSat = pendingReceiveSatValue is String
-          ? BigInt.parse(pendingReceiveSatValue)
-          : BigInt.from(pendingReceiveSatValue as int? ?? 0);
-
       return WalletInfo(
-        balanceSat: balanceSat,
-        pendingSendSat: pendingSendSat,
-        pendingReceiveSat: pendingReceiveSat,
+        balanceSat: JsonParsingUtils.parseToBigInt(json['balanceSat'], fieldName: 'balanceSat'),
+        pendingSendSat: JsonParsingUtils.parseToBigInt(json['pendingSendSat'], fieldName: 'pendingSendSat'),
+        pendingReceiveSat:
+            JsonParsingUtils.parseToBigInt(json['pendingReceiveSat'], fieldName: 'pendingReceiveSat'),
         fingerprint: json['fingerprint'] as String? ?? '',
         pubkey: json['pubkey'] as String? ?? '',
         assetBalances: json['assetBalances'] != null
@@ -138,19 +123,9 @@ extension BlockchainInfoFromJson on BlockchainInfo {
     }
 
     try {
-      final dynamic liquidTipValue = json['liquidTip'];
-      final dynamic bitcoinTipValue = json['bitcoinTip'];
-
-      // Handle both integer and string formats
-      final int liquidTip =
-          liquidTipValue is String ? int.parse(liquidTipValue) : (liquidTipValue as int? ?? 0);
-
-      final int bitcoinTip =
-          bitcoinTipValue is String ? int.parse(bitcoinTipValue) : (bitcoinTipValue as int? ?? 0);
-
       return BlockchainInfo(
-        liquidTip: liquidTip,
-        bitcoinTip: bitcoinTip,
+        liquidTip: JsonParsingUtils.parseToInt(json['liquidTip'], fieldName: 'liquidTip'),
+        bitcoinTip: JsonParsingUtils.parseToInt(json['bitcoinTip'], fieldName: 'bitcoinTip'),
       );
     } catch (e, stack) {
       _logger.severe('Error parsing BlockchainInfo from JSON: $e\n$stack');

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -53,10 +53,10 @@ class AccountState {
 
   factory AccountState.fromJson(Map<String, dynamic> json) {
     return AccountState(
-      isRestoring: json['isRestoring'] ?? false,
+      isRestoring: json['isRestoring'] as bool? ?? false,
       didCompleteInitialSync: false,
-      walletInfo: WalletInfoFromJson.fromJson(json['walletInfo']),
-      blockchainInfo: BlockchainInfoFromJson.fromJson(json['blockchainInfo']),
+      walletInfo: WalletInfoFromJson.fromJson(json['walletInfo'] as Map<String, dynamic>?),
+      blockchainInfo: BlockchainInfoFromJson.fromJson(json['blockchainInfo'] as Map<String, dynamic>?),
     );
   }
 

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -84,27 +84,40 @@ extension WalletInfoFromJson on WalletInfo {
       return null;
     }
 
-    if (json['balanceSat'] == null ||
-        json['pendingSendSat'] == null ||
-        json['pendingReceiveSat'] == null ||
-        json['fingerprint'] == null ||
-        json['pubkey'] == null) {
-      _logger.warning('WalletInfo has missing fields on AccountState JSON.');
+    try {
+      final dynamic balanceSatValue = json['balanceSat'];
+      final dynamic pendingSendSatValue = json['pendingSendSat'];
+      final dynamic pendingReceiveSatValue = json['pendingReceiveSat'];
+
+      // Handle both integer and string formats
+      final BigInt balanceSat = balanceSatValue is String
+          ? BigInt.parse(balanceSatValue)
+          : BigInt.from(balanceSatValue as int? ?? 0);
+
+      final BigInt pendingSendSat = pendingSendSatValue is String
+          ? BigInt.parse(pendingSendSatValue)
+          : BigInt.from(pendingSendSatValue as int? ?? 0);
+
+      final BigInt pendingReceiveSat = pendingReceiveSatValue is String
+          ? BigInt.parse(pendingReceiveSatValue)
+          : BigInt.from(pendingReceiveSatValue as int? ?? 0);
+
+      return WalletInfo(
+        balanceSat: balanceSat,
+        pendingSendSat: pendingSendSat,
+        pendingReceiveSat: pendingReceiveSat,
+        fingerprint: json['fingerprint'] as String? ?? '',
+        pubkey: json['pubkey'] as String? ?? '',
+        assetBalances: json['assetBalances'] != null
+            ? (json['assetBalances'] as List<dynamic>)
+                .map((dynamic json) => AssetBalanceFromJson.fromJson(json))
+                .toList()
+            : <AssetBalance>[],
+      );
+    } catch (e, stack) {
+      _logger.severe('Error parsing WalletInfo from JSON: $e\n$stack');
       return null;
     }
-
-    return WalletInfo(
-      balanceSat: BigInt.parse(json['balanceSat'] as String),
-      pendingSendSat: BigInt.parse(json['pendingSendSat'] as String),
-      pendingReceiveSat: BigInt.parse(json['pendingReceiveSat'] as String),
-      fingerprint: json['fingerprint'] as String,
-      pubkey: json['pubkey'] as String,
-      assetBalances: json['assetBalances'] != null
-          ? (json['assetBalances'] as List<dynamic>)
-              .map((dynamic json) => AssetBalanceFromJson.fromJson(json))
-              .toList()
-          : <AssetBalance>[],
-    );
   }
 }
 
@@ -124,14 +137,24 @@ extension BlockchainInfoFromJson on BlockchainInfo {
       return null;
     }
 
-    if (json['liquidTip'] == null || json['bitcoinTip'] == null) {
-      _logger.warning('BlockchainInfo has missing fields on AccountState JSON.');
+    try {
+      final dynamic liquidTipValue = json['liquidTip'];
+      final dynamic bitcoinTipValue = json['bitcoinTip'];
+
+      // Handle both integer and string formats
+      final int liquidTip =
+          liquidTipValue is String ? int.parse(liquidTipValue) : (liquidTipValue as int? ?? 0);
+
+      final int bitcoinTip =
+          bitcoinTipValue is String ? int.parse(bitcoinTipValue) : (bitcoinTipValue as int? ?? 0);
+
+      return BlockchainInfo(
+        liquidTip: liquidTip,
+        bitcoinTip: bitcoinTip,
+      );
+    } catch (e, stack) {
+      _logger.severe('Error parsing BlockchainInfo from JSON: $e\n$stack');
       return null;
     }
-
-    return BlockchainInfo(
-      liquidTip: int.parse(json['liquidTip'] as String),
-      bitcoinTip: int.parse(json['bitcoinTip'] as String),
-    );
   }
 }

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -43,7 +43,7 @@ class AccountState {
 
   bool get hasBalance => walletInfo != null && walletInfo!.balanceSat > BigInt.zero;
 
-  Map<String, dynamic>? toJson() {
+  Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'isRestoring': isRestoring,
       'walletInfo': walletInfo?.toJson(),

--- a/lib/cubit/account/account_state.dart
+++ b/lib/cubit/account/account_state.dart
@@ -85,6 +85,20 @@ extension WalletInfoFromJson on WalletInfo {
       return null;
     }
 
+    final List<String> requiredFields = <String>[
+      'balanceSat',
+      'pendingSendSat',
+      'pendingReceiveSat',
+      'fingerprint',
+      'pubkey',
+      'assetBalances',
+    ];
+    final List<String> missingFields = requiredFields.where((String field) => json[field] == null).toList();
+    if (missingFields.isNotEmpty) {
+      _logger.warning('WalletInfo missing required fields: ${missingFields.join(', ')}');
+      return null;
+    }
+
     try {
       return WalletInfo(
         balanceSat: JsonParsingUtils.parseToBigInt(json['balanceSat'], fieldName: 'balanceSat'),
@@ -119,6 +133,13 @@ extension BlockchainInfoFromJson on BlockchainInfo {
   static BlockchainInfo? fromJson(Map<String, dynamic>? json) {
     if (json == null) {
       _logger.info('blockchainInfo is missing from AccountState JSON.');
+      return null;
+    }
+
+    final List<String> requiredFields = <String>['liquidTip', 'bitcoinTip'];
+    final List<String> missingFields = requiredFields.where((String field) => json[field] == null).toList();
+    if (missingFields.isNotEmpty) {
+      _logger.warning('BlockchainInfo missing required fields: ${missingFields.join(', ')}');
       return null;
     }
 

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
@@ -124,5 +125,5 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyStat
   }
 
   @override
-  String get storagePrefix => 'xVa';
+  String get storagePrefix => defaultTargetPlatform == TargetPlatform.iOS ? 'xVa' : 'CurrencyCubit';
 }

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -124,5 +124,5 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyStat
   }
 
   @override
-  String get storagePrefix => 'currency_cubit';
+  String get storagePrefix => 'xVa';
 }

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -98,4 +98,7 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyStat
   Map<String, dynamic> toJson(CurrencyState state) {
     return state.toJson();
   }
+
+  @override
+  String get storagePrefix => 'currency_cubit';
 }

--- a/lib/cubit/currency/currency_cubit.dart
+++ b/lib/cubit/currency/currency_cubit.dart
@@ -3,15 +3,19 @@ import 'dart:async';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 
 export 'currency_state.dart';
+
+final Logger _logger = Logger('CurrencyCubit');
 
 class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyState> {
   final BreezSDKLiquid breezSdkLiquid;
 
   CurrencyCubit(this.breezSdkLiquid) : super(CurrencyState.initial()) {
     hydrate();
+
     _initializeCurrencyCubit();
   }
 
@@ -90,13 +94,33 @@ class CurrencyCubit extends Cubit<CurrencyState> with HydratedMixin<CurrencyStat
   }
 
   @override
-  CurrencyState fromJson(Map<String, dynamic> json) {
-    return CurrencyState.fromJson(json);
+  CurrencyState? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _logger.severe('No stored data found.');
+      return null;
+    }
+
+    try {
+      final CurrencyState result = CurrencyState.fromJson(json);
+      _logger.fine('Successfully hydrated with $result');
+      return result;
+    } catch (e, stackTrace) {
+      _logger.severe('Error hydrating: $e');
+      _logger.fine('Stack trace: $stackTrace');
+      return CurrencyState.initial();
+    }
   }
 
   @override
-  Map<String, dynamic> toJson(CurrencyState state) {
-    return state.toJson();
+  Map<String, dynamic>? toJson(CurrencyState state) {
+    try {
+      final Map<String, dynamic> result = state.toJson();
+      _logger.fine('Serialized: $result');
+      return result;
+    } catch (e) {
+      _logger.severe('Error serializing: $e');
+      return null;
+    }
   }
 
   @override

--- a/lib/cubit/currency/currency_state.dart
+++ b/lib/cubit/currency/currency_state.dart
@@ -63,11 +63,13 @@ class CurrencyState {
   }
 
   CurrencyState.fromJson(Map<String, dynamic> json)
-      : preferredCurrencies = (json['preferredCurrencies'] as List<dynamic>).cast<String>(),
+      : preferredCurrencies = (json['preferredCurrencies'] is List)
+            ? List<String>.from(json['preferredCurrencies'])
+            : const <String>['USD', 'EUR', 'GBP', 'JPY'],
         exchangeRates = <String, Rate>{},
         fiatCurrenciesData = <FiatCurrency>[],
-        fiatId = json['fiatId'],
-        bitcoinTicker = json['bitcoinTicker'];
+        fiatId = json['fiatId'] as String? ?? 'USD',
+        bitcoinTicker = json['bitcoinTicker'] as String? ?? 'SAT';
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'preferredCurrencies': preferredCurrencies,

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -4,12 +4,11 @@ import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/models/models.dart';
+import 'package:misty_breez/utils/utils.dart';
 
 final Logger _logger = Logger('PaymentData');
 
-// TODO(erdemyerebasmaz): Liquid - Remove if having PaymentData is not necessary with Liquid SDK
-/// Hold formatted data from Payment to be displayed in the UI, using the minutiae noun instead of details or
-/// info to avoid conflicts and make it easier to differentiate when reading the code.
+/// Holds formatted payment data for UI display
 class PaymentData {
   final String id;
   final String title;
@@ -77,40 +76,17 @@ class PaymentData {
 
   factory PaymentData.fromJson(Map<String, dynamic> json) {
     try {
-      PaymentType paymentType;
-      final dynamic paymentTypeValue = json['paymentType'];
-      if (paymentTypeValue is String) {
-        final String enumValue =
-            paymentTypeValue.contains('.') ? paymentTypeValue.split('.').last : paymentTypeValue;
+      final PaymentType paymentType = parseEnum(
+        value: json['paymentType'],
+        enumValues: PaymentType.values,
+        defaultValue: PaymentType.send,
+      );
 
-        try {
-          paymentType = PaymentType.values.firstWhere(
-            (PaymentType type) => type.name == enumValue,
-            orElse: () => PaymentType.send,
-          );
-        } catch (_) {
-          paymentType = PaymentType.send;
-        }
-      } else {
-        paymentType = PaymentType.send;
-      }
-
-      PaymentState status;
-      final dynamic statusValue = json['status'];
-      if (statusValue is String) {
-        final String enumValue = statusValue.contains('.') ? statusValue.split('.').last : statusValue;
-
-        try {
-          status = PaymentState.values.firstWhere(
-            (PaymentState state) => state.name == enumValue,
-            orElse: () => PaymentState.pending,
-          );
-        } catch (_) {
-          status = PaymentState.pending;
-        }
-      } else {
-        status = PaymentState.pending;
-      }
+      final PaymentState status = parseEnum(
+        value: json['status'],
+        enumValues: PaymentState.values,
+        defaultValue: PaymentState.pending,
+      );
 
       return PaymentData(
         id: json['id'] as String? ?? '',

--- a/lib/cubit/payments/models/payment/payment_filters.dart
+++ b/lib/cubit/payments/models/payment/payment_filters.dart
@@ -21,7 +21,7 @@ class PaymentFilters implements Exception {
 
   PaymentFilters.initial() : this();
 
-  bool get hasTypeFilters => filters != null && filters != PaymentType.values;
+  bool get hasTypeFilters => filters != null && !listEquals(filters, (PaymentType.values));
 
   bool get hasDateFilters => fromTimestamp != null || toTimestamp != null;
 

--- a/lib/cubit/payments/models/payment/payment_filters.dart
+++ b/lib/cubit/payments/models/payment/payment_filters.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('PaymentFilters');
 
 class PaymentFilters implements Exception {
   final List<PaymentType>? filters;
@@ -38,12 +41,45 @@ class PaymentFilters implements Exception {
     );
   }
 
-  factory PaymentFilters.fromJson(Map<String, dynamic> json) {
-    return PaymentFilters(
-      fromTimestamp: json['fromTimestamp'],
-      toTimestamp: json['toTimestamp'],
-      assetTicker: json['assetTicker'],
-    );
+  factory PaymentFilters.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return PaymentFilters.initial();
+    }
+
+    try {
+      List<PaymentType>? paymentFilters;
+      final dynamic filtersValue = json['filters'];
+
+      if (filtersValue is List) {
+        paymentFilters = <PaymentType>[];
+        for (final dynamic filter in filtersValue) {
+          if (filter is String) {
+            // Handle both formats: "PaymentType.receive" or just "receive"
+            final String enumValue = filter.contains('.') ? filter.split('.').last : filter;
+
+            try {
+              final PaymentType paymentType = PaymentType.values.firstWhere(
+                (PaymentType type) => type.name == enumValue,
+                orElse: () => throw Exception('Invalid PaymentType: $filter'),
+              );
+              paymentFilters.add(paymentType);
+            } catch (e) {
+              _logger.warning('Error parsing PaymentType: $filter - $e');
+            }
+          }
+        }
+      }
+
+      return PaymentFilters(
+        filters: paymentFilters ?? PaymentType.values,
+        fromTimestamp: json['fromTimestamp'],
+        toTimestamp: json['toTimestamp'],
+        assetTicker: json['assetTicker'],
+      );
+    } catch (e) {
+      _logger.warning('Error deserializing PaymentFilters: $e');
+      return PaymentFilters.initial();
+    }
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/cubit/payments/models/payment/payment_filters.dart
+++ b/lib/cubit/payments/models/payment/payment_filters.dart
@@ -83,8 +83,10 @@ class PaymentFilters implements Exception {
   }
 
   Map<String, dynamic> toJson() {
+    final List<String>? filtersJson = filters?.map((PaymentType type) => type.name).toList();
+
     return <String, dynamic>{
-      'filters': filters.toString(),
+      'filters': filtersJson,
       'fromTimestamp': fromTimestamp,
       'toTimestamp': toTimestamp,
       'assetTicker': assetTicker,

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
@@ -159,5 +160,5 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
   }
 
   @override
-  String get storagePrefix => 'IWa';
+  String get storagePrefix => defaultTargetPlatform == TargetPlatform.iOS ? 'IWa' : 'PaymentsCubit';
 }

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -137,4 +137,7 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
   Map<String, dynamic>? toJson(PaymentsState state) {
     return state.toJson();
   }
+
+  @override
+  String get storagePrefix => 'payments_cubit';
 }

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -159,5 +159,5 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
   }
 
   @override
-  String get storagePrefix => 'payments_cubit';
+  String get storagePrefix => 'IWa';
 }

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -129,13 +129,33 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
   }
 
   @override
-  PaymentsState? fromJson(Map<String, dynamic> json) {
-    return PaymentsState.fromJson(json);
+  PaymentsState? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _logger.severe('No stored data found.');
+      return null;
+    }
+
+    try {
+      final PaymentsState result = PaymentsState.fromJson(json);
+      _logger.fine('Successfully hydrated with $result');
+      return result;
+    } catch (e, stackTrace) {
+      _logger.severe('Error hydrating: $e');
+      _logger.fine('Stack trace: $stackTrace');
+      return PaymentsState.initial();
+    }
   }
 
   @override
   Map<String, dynamic>? toJson(PaymentsState state) {
-    return state.toJson();
+    try {
+      final Map<String, dynamic> result = state.toJson();
+      _logger.fine('Serialized: $result');
+      return result;
+    } catch (e) {
+      _logger.severe('Error serializing: $e');
+      return null;
+    }
   }
 
   @override

--- a/lib/cubit/payments/payments_state.dart
+++ b/lib/cubit/payments/payments_state.dart
@@ -66,7 +66,7 @@ class PaymentsState {
     ).toList();
   }
 
-  Map<String, dynamic>? toJson() {
+  Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'payments': payments.map((PaymentData payment) => payment.toJson()).toList(),
       'paymentFilters': paymentFilters.toJson(),

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -310,7 +310,7 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   }
 
   @override
-  String get storagePrefix => 'security_cubit';
+  String get storagePrefix => 'SWa';
 
   @override
   Future<void> close() {

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -296,6 +296,9 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   }
 
   @override
+  String get storagePrefix => 'security_cubit';
+
+  @override
   Future<void> close() {
     _cancelAutoLockTimer();
     return super.close();

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -36,6 +36,7 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   /// [_keyChain] Secure storage implementation for sensitive data
   SecurityCubit(this._keyChain) : super(const SecurityState.initial()) {
     hydrate();
+
     _initializeSecurityState();
   }
 
@@ -275,24 +276,37 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   }
 
   @override
-  SecurityState? fromJson(Map<String, dynamic> json) {
+  SecurityState? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _logger.severe('No stored data found.');
+      return null;
+    }
+
     try {
-      final SecurityState restoredState = SecurityState.fromJson(json);
+      final SecurityState result = SecurityState.fromJson(json);
+      _logger.fine('Successfully hydrated with $result');
 
       // Update lock state based on PIN status
-      _updateLockState(restoredState.pinStatus == PinStatus.enabled ? LockState.locked : LockState.unlocked);
+      _updateLockState(result.pinStatus == PinStatus.enabled ? LockState.locked : LockState.unlocked);
 
-      _logger.info('Security state restored from storage');
-      return restoredState;
-    } catch (e) {
-      _logger.severe('Error restoring security state from storage: $e');
+      return result;
+    } catch (e, stackTrace) {
+      _logger.severe('Error hydrating: $e');
+      _logger.fine('Stack trace: $stackTrace');
       return const SecurityState.initial();
     }
   }
 
   @override
   Map<String, dynamic>? toJson(SecurityState state) {
-    return state.toJson();
+    try {
+      final Map<String, dynamic> result = state.toJson();
+      _logger.fine('Serialized: $result');
+      return result;
+    } catch (e) {
+      _logger.severe('Error serializing: $e');
+      return null;
+    }
   }
 
   @override

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -310,7 +310,7 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   }
 
   @override
-  String get storagePrefix => 'SWa';
+  String get storagePrefix => defaultTargetPlatform == TargetPlatform.iOS ? 'SWa' : 'SecurityCubit';
 
   @override
   Future<void> close() {

--- a/lib/cubit/security/security_state.dart
+++ b/lib/cubit/security/security_state.dart
@@ -166,33 +166,83 @@ class SecurityState {
   /// [json] Map containing security state data
   factory SecurityState.fromJson(Map<String, dynamic> json) {
     try {
-      return SecurityState(
-        pinStatus: _parseEnum<PinStatus>(
-          value: json['pinStatus'],
+      PinStatus pinStatus;
+      final dynamic pinStatusValue = json['pinStatus'];
+      if (pinStatusValue is String) {
+        pinStatus = _parseEnum(
+          value: pinStatusValue,
           enumValues: PinStatus.values,
           defaultValue: PinStatus.initial,
-        ),
-        autoLockTimeout: Duration(
-          seconds: json['autoLockTimeout'] ?? _kDefaultLockTimeout,
-        ),
-        biometricType: _parseEnum<BiometricType>(
-          value: json['biometricType'],
+        );
+      } else if (pinStatusValue is int && pinStatusValue >= 0 && pinStatusValue < PinStatus.values.length) {
+        pinStatus = PinStatus.values[pinStatusValue];
+      } else {
+        pinStatus = PinStatus.initial;
+      }
+
+      int timeoutSeconds;
+      final dynamic timeoutValue = json['autoLockTimeout'];
+      if (timeoutValue is int) {
+        timeoutSeconds = timeoutValue;
+      } else if (timeoutValue is String) {
+        timeoutSeconds = int.tryParse(timeoutValue) ?? _kDefaultLockTimeout;
+      } else {
+        timeoutSeconds = _kDefaultLockTimeout;
+      }
+
+      BiometricType biometricType;
+      final dynamic bioTypeValue = json['biometricType'];
+      if (bioTypeValue is String) {
+        biometricType = _parseEnum(
+          value: bioTypeValue,
           enumValues: BiometricType.values,
           defaultValue: BiometricType.none,
-        ),
-        lockState: _parseEnum<LockState>(
-          value: json['lockState'],
+        );
+      } else if (bioTypeValue is int && bioTypeValue >= 0 && bioTypeValue < BiometricType.values.length) {
+        biometricType = BiometricType.values[bioTypeValue];
+      } else {
+        biometricType = BiometricType.none;
+      }
+
+      LockState lockState;
+      final dynamic lockStateValue = json['lockState'];
+      if (lockStateValue is String) {
+        lockState = _parseEnum(
+          value: lockStateValue,
           enumValues: LockState.values,
-          defaultValue: LockState.unlocked,
-        ),
-        mnemonicStatus: _parseEnum<MnemonicStatus>(
-          value: json['mnemonicStatus'],
+          defaultValue: LockState.initial,
+        );
+      } else if (lockStateValue is int && lockStateValue >= 0 && lockStateValue < LockState.values.length) {
+        lockState = LockState.values[lockStateValue];
+      } else {
+        lockState = LockState.initial;
+      }
+
+      MnemonicStatus mnemonicStatus;
+      final dynamic mnemonicStatusValue = json['mnemonicStatus'];
+      if (mnemonicStatusValue is String) {
+        mnemonicStatus = _parseEnum(
+          value: mnemonicStatusValue,
           enumValues: MnemonicStatus.values,
-          defaultValue: MnemonicStatus.initial,
-        ),
+          defaultValue: MnemonicStatus.unverified,
+        );
+      } else if (mnemonicStatusValue is int &&
+          mnemonicStatusValue >= 0 &&
+          mnemonicStatusValue < MnemonicStatus.values.length) {
+        mnemonicStatus = MnemonicStatus.values[mnemonicStatusValue];
+      } else {
+        mnemonicStatus = MnemonicStatus.unverified;
+      }
+
+      return SecurityState(
+        pinStatus: pinStatus,
+        autoLockTimeout: Duration(seconds: timeoutSeconds),
+        biometricType: biometricType,
+        lockState: lockState,
+        mnemonicStatus: mnemonicStatus,
       );
-    } catch (e) {
-      _logger.severe('Error parsing SecurityState from JSON: $e');
+    } catch (e, stack) {
+      _logger.severe('Error parsing SecurityState from JSON: $e\n$stack');
       return const SecurityState.initial();
     }
   }

--- a/lib/cubit/security/security_state.dart
+++ b/lib/cubit/security/security_state.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:logging/logging.dart';
+import 'package:misty_breez/utils/utils.dart';
 
 final Logger _logger = Logger('SecurityState');
 
@@ -166,73 +167,35 @@ class SecurityState {
   /// [json] Map containing security state data
   factory SecurityState.fromJson(Map<String, dynamic> json) {
     try {
-      PinStatus pinStatus;
-      final dynamic pinStatusValue = json['pinStatus'];
-      if (pinStatusValue is String) {
-        pinStatus = _parseEnum(
-          value: pinStatusValue,
-          enumValues: PinStatus.values,
-          defaultValue: PinStatus.initial,
-        );
-      } else if (pinStatusValue is int && pinStatusValue >= 0 && pinStatusValue < PinStatus.values.length) {
-        pinStatus = PinStatus.values[pinStatusValue];
-      } else {
-        pinStatus = PinStatus.initial;
-      }
+      final PinStatus pinStatus = parseEnum(
+        value: json['pinStatus'],
+        enumValues: PinStatus.values,
+        defaultValue: PinStatus.initial,
+      );
 
-      int timeoutSeconds;
-      final dynamic timeoutValue = json['autoLockTimeout'];
-      if (timeoutValue is int) {
-        timeoutSeconds = timeoutValue;
-      } else if (timeoutValue is String) {
-        timeoutSeconds = int.tryParse(timeoutValue) ?? _kDefaultLockTimeout;
-      } else {
-        timeoutSeconds = _kDefaultLockTimeout;
-      }
+      final int timeoutSeconds = json['autoLockTimeout'] is int
+          ? json['autoLockTimeout'] as int
+          : json['autoLockTimeout'] is String
+              ? int.tryParse(json['autoLockTimeout'] as String) ?? _kDefaultLockTimeout
+              : _kDefaultLockTimeout;
 
-      BiometricType biometricType;
-      final dynamic bioTypeValue = json['biometricType'];
-      if (bioTypeValue is String) {
-        biometricType = _parseEnum(
-          value: bioTypeValue,
-          enumValues: BiometricType.values,
-          defaultValue: BiometricType.none,
-        );
-      } else if (bioTypeValue is int && bioTypeValue >= 0 && bioTypeValue < BiometricType.values.length) {
-        biometricType = BiometricType.values[bioTypeValue];
-      } else {
-        biometricType = BiometricType.none;
-      }
+      final BiometricType biometricType = parseEnum(
+        value: json['biometricType'],
+        enumValues: BiometricType.values,
+        defaultValue: BiometricType.none,
+      );
 
-      LockState lockState;
-      final dynamic lockStateValue = json['lockState'];
-      if (lockStateValue is String) {
-        lockState = _parseEnum(
-          value: lockStateValue,
-          enumValues: LockState.values,
-          defaultValue: LockState.initial,
-        );
-      } else if (lockStateValue is int && lockStateValue >= 0 && lockStateValue < LockState.values.length) {
-        lockState = LockState.values[lockStateValue];
-      } else {
-        lockState = LockState.initial;
-      }
+      final LockState lockState = parseEnum(
+        value: json['lockState'],
+        enumValues: LockState.values,
+        defaultValue: LockState.initial,
+      );
 
-      MnemonicStatus mnemonicStatus;
-      final dynamic mnemonicStatusValue = json['mnemonicStatus'];
-      if (mnemonicStatusValue is String) {
-        mnemonicStatus = _parseEnum(
-          value: mnemonicStatusValue,
-          enumValues: MnemonicStatus.values,
-          defaultValue: MnemonicStatus.unverified,
-        );
-      } else if (mnemonicStatusValue is int &&
-          mnemonicStatusValue >= 0 &&
-          mnemonicStatusValue < MnemonicStatus.values.length) {
-        mnemonicStatus = MnemonicStatus.values[mnemonicStatusValue];
-      } else {
-        mnemonicStatus = MnemonicStatus.unverified;
-      }
+      final MnemonicStatus mnemonicStatus = parseEnum(
+        value: json['mnemonicStatus'],
+        enumValues: MnemonicStatus.values,
+        defaultValue: MnemonicStatus.unverified,
+      );
 
       return SecurityState(
         pinStatus: pinStatus,
@@ -244,31 +207,6 @@ class SecurityState {
     } catch (e, stack) {
       _logger.severe('Error parsing SecurityState from JSON: $e\n$stack');
       return const SecurityState.initial();
-    }
-  }
-
-  /// Helper method to safely parse enum values from strings
-  ///
-  /// [value] String value to parse
-  /// [enumValues] List of possible enum values
-  /// [defaultValue] Default value to use if parsing fails
-  static T _parseEnum<T extends Enum>({
-    required String? value,
-    required List<T> enumValues,
-    required T defaultValue,
-  }) {
-    if (value == null) {
-      return defaultValue;
-    }
-
-    try {
-      return enumValues.firstWhere(
-        (T e) => e.name == value,
-        orElse: () => defaultValue,
-      );
-    } catch (_) {
-      _logger.warning('Failed to parse enum value: $value, using default: ${defaultValue.name}');
-      return defaultValue;
     }
   }
 

--- a/lib/cubit/user_profile/user_profile_cubit.dart
+++ b/lib/cubit/user_profile/user_profile_cubit.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 
 import 'package:breez_preferences/breez_preferences.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
@@ -148,5 +149,5 @@ class UserProfileCubit extends Cubit<UserProfileState> with HydratedMixin<UserPr
   }
 
   @override
-  String get storagePrefix => 'XWa';
+  String get storagePrefix => defaultTargetPlatform == TargetPlatform.iOS ? 'XWa' : 'UserProfileCubit';
 }

--- a/lib/cubit/user_profile/user_profile_cubit.dart
+++ b/lib/cubit/user_profile/user_profile_cubit.dart
@@ -118,13 +118,33 @@ class UserProfileCubit extends Cubit<UserProfileState> with HydratedMixin<UserPr
   }
 
   @override
-  UserProfileState fromJson(Map<String, dynamic> json) {
-    return UserProfileState.fromJson(json);
+  UserProfileState? fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      _logger.severe('No stored data found.');
+      return null;
+    }
+
+    try {
+      final UserProfileState result = UserProfileState.fromJson(json);
+      _logger.fine('Successfully hydrated with $result');
+      return result;
+    } catch (e, stackTrace) {
+      _logger.severe('Error hydrating: $e');
+      _logger.fine('Stack trace: $stackTrace');
+      return UserProfileState.initial();
+    }
   }
 
   @override
-  Map<String, dynamic> toJson(UserProfileState state) {
-    return state.toJson();
+  Map<String, dynamic>? toJson(UserProfileState state) {
+    try {
+      final Map<String, dynamic> result = state.toJson();
+      _logger.fine('Serialized: $result');
+      return result;
+    } catch (e) {
+      _logger.severe('Error serializing: $e');
+      return null;
+    }
   }
 
   @override

--- a/lib/cubit/user_profile/user_profile_cubit.dart
+++ b/lib/cubit/user_profile/user_profile_cubit.dart
@@ -126,4 +126,7 @@ class UserProfileCubit extends Cubit<UserProfileState> with HydratedMixin<UserPr
   Map<String, dynamic> toJson(UserProfileState state) {
     return state.toJson();
   }
+
+  @override
+  String get storagePrefix => 'user_profile_cubit';
 }

--- a/lib/cubit/user_profile/user_profile_cubit.dart
+++ b/lib/cubit/user_profile/user_profile_cubit.dart
@@ -148,5 +148,5 @@ class UserProfileCubit extends Cubit<UserProfileState> with HydratedMixin<UserPr
   }
 
   @override
-  String get storagePrefix => 'user_profile_cubit';
+  String get storagePrefix => 'XWa';
 }

--- a/lib/cubit/user_profile/user_profile_state.dart
+++ b/lib/cubit/user_profile/user_profile_state.dart
@@ -1,4 +1,7 @@
+import 'package:logging/logging.dart';
 import 'package:misty_breez/models/models.dart';
+
+final Logger _logger = Logger('UserProfileState');
 
 class UserProfileState {
   final UserProfileSettings profileSettings;
@@ -12,9 +15,19 @@ class UserProfileState {
   }
 
   factory UserProfileState.fromJson(Map<String, dynamic> json) {
-    return UserProfileState(
-      profileSettings: UserProfileSettings.fromJson(json['profileSettings'] as Map<String, dynamic>),
-    );
+    try {
+      final dynamic profileSettingsJson = json['profileSettings'];
+      if (profileSettingsJson == null) {
+        return UserProfileState.initial();
+      }
+
+      return UserProfileState(
+        profileSettings: UserProfileSettings.fromJson(profileSettingsJson as Map<String, dynamic>),
+      );
+    } catch (e) {
+      _logger.warning('Error deserializing UserProfileState: $e');
+      return UserProfileState.initial();
+    }
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/main/bootstrap.dart
+++ b/lib/main/bootstrap.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:breez_logger/breez_logger.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -9,15 +8,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:flutter_svg/svg.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 // ignore: uri_does_not_exist
 import 'package:misty_breez/firebase/firebase_options.dart';
-import 'package:misty_breez/main/bootstrap_error_page.dart';
+import 'package:misty_breez/main/main.dart';
 import 'package:misty_breez/utils/utils.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:service_injector/service_injector.dart';
 import 'package:shared_preference_app_group/shared_preference_app_group.dart';
 
@@ -58,10 +54,8 @@ Future<void> bootstrap(AppBuilder builder) async {
       );
     }
 
-    final Directory appDir = await getApplicationDocumentsDirectory();
-    HydratedBloc.storage = await HydratedStorage.build(
-      storageDirectory: HydratedStorageDirectory(p.join(appDir.path, 'bloc_storage')),
-    );
+    await HydratedBlocStorage().initialize();
+
     final SdkConnectivityCubit sdkConnectivityCubit = SdkConnectivityCubit(
       breezSdkLiquid: injector.breezSdkLiquid,
       credentialsManager: injector.credentialsManager,

--- a/lib/main/hydrated_bloc_storage.dart
+++ b/lib/main/hydrated_bloc_storage.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:hive_ce/hive.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -8,185 +7,19 @@ import 'package:path_provider/path_provider.dart';
 
 final Logger _logger = Logger('HydratedBlocStorage');
 
-class _HydratedBlocStorageConfig {
-  /// Default storage directory name
-  static const String storageDirectoryName = 'bloc_storage';
-
-  /// Storage path instance for the application
-  static String? _storagePath;
-
-  /// Get the storage path, initializing it if needed
-  static Future<String> get storagePath async {
-    if (_storagePath == null) {
-      final Directory appDir = await getApplicationDocumentsDirectory();
-      _storagePath = p.join(appDir.path, storageDirectoryName);
-    }
-    return _storagePath!;
-  }
-}
-
 /// Service responsible for initializing HydratedBloc storage
 class HydratedBlocStorage {
+  static const String storageDirName = 'bloc_storage';
+
   /// Initializes HydratedBloc storage
   Future<void> initialize() async {
-    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+    final Directory appDir = await getApplicationDocumentsDirectory();
+    final String storagePath = p.join(appDir.path, storageDirName);
 
-    await _StorageDebugger().debugStorage();
-
-    // Initialize HydratedBloc storage
     HydratedBloc.storage = await HydratedStorage.build(
       storageDirectory: HydratedStorageDirectory(storagePath),
     );
 
     _logger.config('HydratedBloc storage initialized at: $storagePath');
-  }
-}
-
-/// Internal class for debugging storage contents
-class _StorageDebugger {
-  /// Debug storage contents by listing files and inspecting Hive boxes
-  Future<void> debugStorage() async {
-    _logger.config('=== STORAGE DEBUG ===');
-    await _listFiles();
-    await _inspectHiveBoxes();
-    _logger.config('====================');
-  }
-
-  /// List all files in the storage directory
-  Future<void> _listFiles() async {
-    try {
-      final String storagePath = await _HydratedBlocStorageConfig.storagePath;
-      final Directory directory = Directory(storagePath);
-
-      if (!await _checkDirectoryExists(directory)) {
-        return;
-      }
-
-      final List<FileSystemEntity> entities = await _getAllEntities(directory);
-      _logger.config('Found ${entities.length} files/directories in storage');
-
-      await _logEntityDetails(entities);
-    } catch (e) {
-      _logger.warning('Error listing files: $e');
-    }
-  }
-
-  /// Check if directory exists and log if not
-  Future<bool> _checkDirectoryExists(Directory directory) async {
-    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
-    if (!await directory.exists()) {
-      _logger.config('Storage directory does not exist yet: $storagePath');
-      return false;
-    }
-    return true;
-  }
-
-  /// Get all entities in directory recursively
-  Future<List<FileSystemEntity>> _getAllEntities(Directory directory) async {
-    return await directory.list(recursive: true).toList();
-  }
-
-  /// Log details for each entity
-  Future<void> _logEntityDetails(List<FileSystemEntity> entities) async {
-    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
-    for (final FileSystemEntity entity in entities) {
-      final String relPath = p.relative(entity.path, from: storagePath);
-      final FileSystemEntityType type = await FileSystemEntity.type(entity.path);
-
-      await _logSingleEntity(entity, relPath, type);
-    }
-  }
-
-  /// Log details for a single entity
-  Future<void> _logSingleEntity(
-    FileSystemEntity entity,
-    String relPath,
-    FileSystemEntityType type,
-  ) async {
-    final String entityType = type == FileSystemEntityType.directory ? 'Directory' : 'File';
-
-    if (type == FileSystemEntityType.file) {
-      await _logFileWithSize(entity, relPath, entityType);
-    } else {
-      _logger.config('$entityType: $relPath');
-    }
-  }
-
-  /// Log file with its size information
-  Future<void> _logFileWithSize(FileSystemEntity entity, String relPath, String entityType) async {
-    final File file = File(entity.path);
-    final int sizeInBytes = await file.length();
-    final String sizeInKB = (sizeInBytes / 1024).toStringAsFixed(2);
-
-    _logger.config('$entityType: $relPath ($sizeInKB KB)');
-  }
-
-  /// Inspect Hive boxes
-  Future<void> _inspectHiveBoxes() async {
-    try {
-      final List<FileSystemEntity> hiveFiles = await _findHiveFiles();
-
-      _logger.config('Found ${hiveFiles.length} .hive files');
-
-      for (final FileSystemEntity entity in hiveFiles) {
-        await _inspectSingleBox(entity);
-      }
-    } catch (e) {
-      _logger.warning('Error during Hive inspection: $e');
-    }
-  }
-
-  /// Find all Hive database files in the storage directory
-  Future<List<FileSystemEntity>> _findHiveFiles() async {
-    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
-    final Directory directory = Directory(storagePath);
-
-    if (!await directory.exists()) {
-      return <FileSystemEntity>[];
-    }
-
-    return await directory.list().where((FileSystemEntity entity) => entity.path.endsWith('.hive')).toList();
-  }
-
-  /// Inspect a single Hive box file
-  Future<void> _inspectSingleBox(FileSystemEntity entity) async {
-    final String boxName = p.basename(entity.path).replaceAll('.hive', '');
-
-    try {
-      final Box<dynamic> box = await _openBoxSafely(boxName);
-
-      await _logBoxContents(box, boxName);
-
-      await _closeBoxIfNeeded(box, boxName);
-    } catch (e) {
-      _logger.warning('Error inspecting box $boxName: $e');
-    }
-  }
-
-  /// Open a box, handling whether it's already open
-  Future<Box<dynamic>> _openBoxSafely(String boxName) async {
-    if (Hive.isBoxOpen(boxName)) {
-      return Hive.box(boxName);
-    } else {
-      final String storagePath = await _HydratedBlocStorageConfig.storagePath;
-      return await Hive.openBox(boxName, path: storagePath);
-    }
-  }
-
-  /// Log the contents of a box
-  Future<void> _logBoxContents(Box<dynamic> box, String boxName) async {
-    _logger.config('Box: $boxName, entries: ${box.length}');
-
-    // Only print key info for brevity
-    if (box.keys.isNotEmpty) {
-      _logger.config('  Keys: ${box.keys.join(', ')}');
-    }
-  }
-
-  /// Close the box if we opened it
-  Future<void> _closeBoxIfNeeded(Box<dynamic> box, String boxName) async {
-    if (!Hive.isBoxOpen(boxName)) {
-      await box.close();
-    }
   }
 }

--- a/lib/main/hydrated_bloc_storage.dart
+++ b/lib/main/hydrated_bloc_storage.dart
@@ -1,0 +1,283 @@
+import 'dart:io';
+
+import 'package:hive_ce/hive.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+final Logger _logger = Logger('HydratedBlocStorage');
+
+class _HydratedBlocStorageConfig {
+  /// Default box name used for storage
+  static const String boxName = 'hydrated_box';
+
+  /// Default storage directory name
+  static const String storageDirectoryName = 'bloc_storage';
+
+  /// Mapping from obfuscated keys to readable keys
+  static const Map<String, String> keyMappings = <String, String>{
+    'IWa': 'payments_cubit',
+    'SWa': 'security_cubit',
+    'XWa': 'user_profile_cubit',
+    'lVa': 'account_cubit',
+    'xVa': 'currency_cubit',
+  };
+
+  /// Storage path instance for the application
+  static String? _storagePath;
+
+  /// Get the storage path, initializing it if needed
+  static Future<String> get storagePath async {
+    if (_storagePath == null) {
+      final Directory appDir = await getApplicationDocumentsDirectory();
+      _storagePath = p.join(appDir.path, storageDirectoryName);
+    }
+    return _storagePath!;
+  }
+}
+
+/// Service responsible for initializing HydratedBloc storage with
+/// support for migrations.
+class HydratedBlocStorage {
+  /// Initializes HydratedBloc storage
+  Future<void> initialize() async {
+    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+
+    // Initialize Hive for migration
+    Hive.init(storagePath);
+
+    await _HydratedBlocMigrator().migrate();
+
+    // Initialize HydratedBloc storage
+    HydratedBloc.storage = await HydratedStorage.build(
+      storageDirectory: HydratedStorageDirectory(storagePath),
+    );
+
+    _logger.config('HydratedBloc storage initialized at: $storagePath');
+  }
+}
+
+/// Internal class for handling HydratedBloc storage migrations
+class _HydratedBlocMigrator {
+  /// Migrate data from old keys to new keys
+  Future<void> migrate() async {
+    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+    final Box<dynamic> box = await Hive.openBox(_HydratedBlocStorageConfig.boxName, path: storagePath);
+
+    try {
+      if (await _shouldSkipMigration(box)) {
+        return;
+      }
+
+      _logger.config('Starting HydratedBloc storage migration...');
+
+      /// Debug storage state before migration begins for comparison
+      await _StorageDebugger().debugStorage();
+
+      await _performMigrationAndLogResults(box);
+    } catch (e) {
+      _logger.warning('Error during migration: $e');
+    } finally {
+      await box.close();
+    }
+  }
+
+  /// Check if migration should be skipped
+  Future<bool> _shouldSkipMigration(Box<dynamic> box) async {
+    final Iterable<dynamic> allKeys = box.keys;
+
+    if (allKeys.isEmpty) {
+      _logger.config('No keys found for migration');
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Perform the migration and log the results immediately
+  Future<void> _performMigrationAndLogResults(Box<dynamic> box) async {
+    int migratedCount = 0;
+
+    for (final dynamic entry in _HydratedBlocStorageConfig.keyMappings.entries) {
+      final dynamic oldKey = entry.key;
+      final dynamic newKey = entry.value;
+
+      if (await _migrateKeyIfExists(box, oldKey, newKey)) {
+        migratedCount++;
+      }
+    }
+    await _logMigrationResults(migratedCount);
+  }
+
+  /// Migrate a single key if it exists in the box
+  Future<bool> _migrateKeyIfExists(Box<dynamic> box, dynamic oldKey, dynamic newKey) async {
+    if (box.containsKey(oldKey)) {
+      final dynamic data = box.get(oldKey);
+      await box.put(newKey, data);
+      await box.delete(oldKey);
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Log migration results and debug storage if needed
+  Future<void> _logMigrationResults(int migratedCount) async {
+    if (migratedCount > 0) {
+      _logger.config('Migration complete: $migratedCount items migrated');
+      await _StorageDebugger().debugStorage();
+    } else {
+      _logger.config('No items were migrated');
+    }
+  }
+}
+
+/// Internal class for debugging storage contents
+class _StorageDebugger {
+  /// Debug storage contents by listing files and inspecting Hive boxes
+  Future<void> debugStorage() async {
+    _logger.config('=== STORAGE DEBUG ===');
+    await _listFiles();
+    await _inspectHiveBoxes();
+    _logger.config('====================');
+  }
+
+  /// List all files in the storage directory
+  Future<void> _listFiles() async {
+    try {
+      final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+      final Directory directory = Directory(storagePath);
+
+      if (!await _checkDirectoryExists(directory)) {
+        return;
+      }
+
+      final List<FileSystemEntity> entities = await _getAllEntities(directory);
+      _logger.config('Found ${entities.length} files/directories in storage');
+
+      await _logEntityDetails(entities);
+    } catch (e) {
+      _logger.warning('Error listing files: $e');
+    }
+  }
+
+  /// Check if directory exists and log if not
+  Future<bool> _checkDirectoryExists(Directory directory) async {
+    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+    if (!await directory.exists()) {
+      _logger.config('Storage directory does not exist yet: $storagePath');
+      return false;
+    }
+    return true;
+  }
+
+  /// Get all entities in directory recursively
+  Future<List<FileSystemEntity>> _getAllEntities(Directory directory) async {
+    return await directory.list(recursive: true).toList();
+  }
+
+  /// Log details for each entity
+  Future<void> _logEntityDetails(List<FileSystemEntity> entities) async {
+    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+    for (final FileSystemEntity entity in entities) {
+      final String relPath = p.relative(entity.path, from: storagePath);
+      final FileSystemEntityType type = await FileSystemEntity.type(entity.path);
+
+      await _logSingleEntity(entity, relPath, type);
+    }
+  }
+
+  /// Log details for a single entity
+  Future<void> _logSingleEntity(
+    FileSystemEntity entity,
+    String relPath,
+    FileSystemEntityType type,
+  ) async {
+    final String entityType = type == FileSystemEntityType.directory ? 'Directory' : 'File';
+
+    if (type == FileSystemEntityType.file) {
+      await _logFileWithSize(entity, relPath, entityType);
+    } else {
+      _logger.config('$entityType: $relPath');
+    }
+  }
+
+  /// Log file with its size information
+  Future<void> _logFileWithSize(FileSystemEntity entity, String relPath, String entityType) async {
+    final File file = File(entity.path);
+    final int sizeInBytes = await file.length();
+    final String sizeInKB = (sizeInBytes / 1024).toStringAsFixed(2);
+
+    _logger.config('$entityType: $relPath ($sizeInKB KB)');
+  }
+
+  /// Inspect Hive boxes
+  Future<void> _inspectHiveBoxes() async {
+    try {
+      final List<FileSystemEntity> hiveFiles = await _findHiveFiles();
+
+      _logger.config('Found ${hiveFiles.length} .hive files');
+
+      for (final FileSystemEntity entity in hiveFiles) {
+        await _inspectSingleBox(entity);
+      }
+    } catch (e) {
+      _logger.warning('Error during Hive inspection: $e');
+    }
+  }
+
+  /// Find all Hive database files in the storage directory
+  Future<List<FileSystemEntity>> _findHiveFiles() async {
+    final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+    final Directory directory = Directory(storagePath);
+
+    if (!await directory.exists()) {
+      return <FileSystemEntity>[];
+    }
+
+    return await directory.list().where((FileSystemEntity entity) => entity.path.endsWith('.hive')).toList();
+  }
+
+  /// Inspect a single Hive box file
+  Future<void> _inspectSingleBox(FileSystemEntity entity) async {
+    final String boxName = p.basename(entity.path).replaceAll('.hive', '');
+
+    try {
+      final Box<dynamic> box = await _openBoxSafely(boxName);
+
+      await _logBoxContents(box, boxName);
+
+      await _closeBoxIfNeeded(box, boxName);
+    } catch (e) {
+      _logger.warning('Error inspecting box $boxName: $e');
+    }
+  }
+
+  /// Open a box, handling whether it's already open
+  Future<Box<dynamic>> _openBoxSafely(String boxName) async {
+    if (Hive.isBoxOpen(boxName)) {
+      return Hive.box(boxName);
+    } else {
+      final String storagePath = await _HydratedBlocStorageConfig.storagePath;
+      return await Hive.openBox(boxName, path: storagePath);
+    }
+  }
+
+  /// Log the contents of a box
+  Future<void> _logBoxContents(Box<dynamic> box, String boxName) async {
+    _logger.config('Box: $boxName, entries: ${box.length}');
+
+    // Only print key info for brevity
+    if (box.keys.isNotEmpty) {
+      _logger.config('  Keys: ${box.keys.join(', ')}');
+    }
+  }
+
+  /// Close the box if we opened it
+  Future<void> _closeBoxIfNeeded(Box<dynamic> box, String boxName) async {
+    if (!Hive.isBoxOpen(boxName)) {
+      await box.close();
+    }
+  }
+}

--- a/lib/main/main.dart
+++ b/lib/main/main.dart
@@ -1,7 +1,11 @@
 import 'package:misty_breez/app/app.dart';
 import 'package:misty_breez/cubit/cubit.dart';
-import 'package:misty_breez/main/bootstrap.dart';
+import 'package:misty_breez/main/main.dart';
 import 'package:service_injector/service_injector.dart';
+
+export 'bootstrap.dart';
+export 'bootstrap_error_page.dart';
+export 'hydrated_bloc_storage.dart';
 
 void main() {
   bootstrap(

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/theme/theme.dart';
@@ -41,7 +40,7 @@ class AccountPage extends StatelessWidget {
                 );
 
                 final bool showPaymentsList = filteredPayments.isNotEmpty;
-                final bool hasTypeFilter = paymentFilters.filters != PaymentType.values;
+                final bool hasTypeFilter = paymentFilters.hasTypeFilters;
                 final int? startDate = paymentFilters.fromTimestamp;
                 final int? endDate = paymentFilters.toTimestamp;
                 final bool hasDateFilter = startDate != null && endDate != null;

--- a/lib/utils/enum/enum_utils.dart
+++ b/lib/utils/enum/enum_utils.dart
@@ -1,0 +1,60 @@
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('EnumUtils');
+
+/// Converts a string or int representation to its corresponding enum value.
+///
+/// Takes a dynamic [value] (expected to be a String or int) and attempts to match it
+/// against the [enumValues] list by comparing their name properties or by index.
+///
+/// If [value] is not a String or int, or if no matching enum is found, returns the
+/// [defaultValue].
+///
+/// Handles qualified enum names (e.g., 'EnumType.value') by extracting just the
+/// value part.
+///
+/// Example:
+/// ```
+/// final paymentType = parseEnum(
+///   value: 'send',
+///   enumValues: PaymentType.values,
+///   defaultValue: PaymentType.unknown
+/// );
+/// ```
+///
+/// [logFailures] controls whether parsing failures are logged (defaults to false).
+T parseEnum<T extends Enum>({
+  required dynamic value,
+  required List<T> enumValues,
+  required T defaultValue,
+  bool logFailures = false,
+}) {
+  // Handle numeric values (index-based)
+  if (value is int && value >= 0 && value < enumValues.length) {
+    return enumValues[value];
+  }
+
+  // Handle String values (name-based)
+  if (value is String) {
+    // Extract the name part if in format "EnumType.value"
+    final String enumName = value.contains('.') ? value.split('.').last : value;
+
+    try {
+      return enumValues.firstWhere(
+        (T element) => element.name == enumName,
+        orElse: () {
+          if (logFailures) {
+            _logger.warning('Failed to find enum value: $value in ${enumValues.map((T e) => e.name)}');
+          }
+          return defaultValue;
+        },
+      );
+    } catch (e) {
+      if (logFailures) {
+        _logger.warning('Error parsing enum value: $value - $e');
+      }
+    }
+  }
+
+  return defaultValue;
+}

--- a/lib/utils/json_parsing/json_parsing.dart
+++ b/lib/utils/json_parsing/json_parsing.dart
@@ -1,0 +1,60 @@
+import 'package:logging/logging.dart';
+
+final Logger _logger = Logger('JsonParsingUtils');
+
+/// Utility functions for parsing JSON values
+class JsonParsingUtils {
+  /// Parses a dynamic value to BigInt, handling both string and integer inputs
+  /// If [defaultValue] is not provided, BigInt.zero will be used as default
+  static BigInt parseToBigInt(
+    dynamic value, {
+    required String fieldName,
+    BigInt? defaultValue,
+  }) {
+    final BigInt defaultVal = defaultValue ?? BigInt.zero;
+
+    try {
+      if (value == null) {
+        return defaultVal;
+      } else if (value is String) {
+        return BigInt.parse(value);
+      } else if (value is int) {
+        return BigInt.from(value);
+      } else if (value is BigInt) {
+        return value;
+      } else {
+        _logger.warning('Invalid type for BigInt field $fieldName: ${value.runtimeType}');
+        return defaultVal;
+      }
+    } catch (e, stack) {
+      _logger.severe('Error parsing BigInt from $value for field $fieldName: $e\n$stack');
+      return defaultVal;
+    }
+  }
+
+  /// Parses a dynamic value to int, handling both string and integer inputs
+  /// If [defaultValue] is not provided, 0 will be used as default
+  static int parseToInt(
+    dynamic value, {
+    required String fieldName,
+    int? defaultValue,
+  }) {
+    final int defaultVal = defaultValue ?? 0;
+
+    try {
+      if (value == null) {
+        return defaultVal;
+      } else if (value is String) {
+        return int.parse(value);
+      } else if (value is int) {
+        return value;
+      } else {
+        _logger.warning('Invalid type for int field $fieldName: ${value.runtimeType}');
+        return defaultVal;
+      }
+    } catch (e, stack) {
+      _logger.severe('Error parsing int from $value for field $fieldName: $e\n$stack');
+      return defaultVal;
+    }
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -5,6 +5,7 @@ export 'currency/bitcoin_currency_formatter.dart';
 export 'currency/currency_formatter.dart';
 export 'currency/fiat_conversion.dart';
 export 'date/breez_date_utils.dart';
+export 'enum/enum_utils.dart';
 export 'exceptions/exception_handler.dart';
 export 'payments/payment_validator.dart';
 export 'ui/overlay_manager.dart';

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -7,5 +7,6 @@ export 'currency/fiat_conversion.dart';
 export 'date/breez_date_utils.dart';
 export 'enum/enum_utils.dart';
 export 'exceptions/exception_handler.dart';
+export 'json_parsing/json_parsing.dart';
 export 'payments/payment_validator.dart';
 export 'ui/overlay_manager.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,7 +863,7 @@ packages:
     source: hosted
     version: "0.2.0"
   hive_ce:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: hive_ce
       sha256: ac66daee46ad46486a1ed12cf91e9d7479c875fb46889be8d2c96b557406647f

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,7 +863,7 @@ packages:
     source: hosted
     version: "0.2.0"
   hive_ce:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: hive_ce
       sha256: ac66daee46ad46486a1ed12cf91e9d7479c875fb46889be8d2c96b557406647f

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ dependencies:
       url: https://github.com/breez/flutter_typeahead.git
       ref: 4a494322762af9f30820f3c63aba784d46b86b69
   hex: ^0.2.0
+  hive_ce: ^2.10.1
   http: ^1.3.0
   hydrated_bloc: ^10.0.0
   image: ^4.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,6 @@ dependencies:
       url: https://github.com/breez/flutter_typeahead.git
       ref: 4a494322762af9f30820f3c63aba784d46b86b69
   hex: ^0.2.0
-  hive_ce: ^2.10.1
   http: ^1.3.0
   hydrated_bloc: ^10.0.0
   image: ^4.5.4


### PR DESCRIPTION
[![Run CI](https://github.com/breez/misty-breez/actions/workflows/CI.yml/badge.svg?branch=debug-hydrated-bloc-storage-files)](https://github.com/breez/misty-breez/actions/workflows/CI.yml)

Fixes #491

---

In release builds, Dart obfuscates class names like `PaymentsCubit` into short symbols like `IWa` to reduce binary size. `HydratedBloc` uses `runtimeType.toString()` as the default `storagePrefix`, which means it writes and reads state using the class name at runtime.

Since obfuscated builds change the `runtimeType` string, `HydratedBloc` can't find previously stored data (e.g., it looks for `PaymentsCubit` but finds `IWa` in storage). This leads to state loss between builds.

This PR adds a migration layer to map old obfuscated keys to stable identifiers. It also recommends overriding `storagePrefix` in cubits to ensure consistent keys across builds.

We have:
- Added explicit `storagePrefix` properties to override the default runtimeType-based keys
- Created a migration utility that runs during `HydratedBloc` initialization to map data from previous obfuscated keys to current keys
- Improved deserialization with better type handling and error recovery for enum values and null fields

These changes ensure user data persists correctly across app updates, even with code obfuscation enabled.

#### Changelist:
- feat: add stable storage prefixes to `HydratedMixin` `Cubits` 74f2cb6
```
  String get id => '';

  /// Storage prefix which can be overridden to provide a custom
  /// storage namespace.
  /// Defaults to [runtimeType] but should be overridden in cases
  /// where stored data should be resilient to obfuscation or persist
  /// between debug/release builds.
  String get storagePrefix => runtimeType.toString();

  /// `storageToken` is used as registration token for hydrated storage.
  /// Composed of [storagePrefix] and [id].
  @nonVirtual
  String get storageToken => '$storagePrefix$id';
```
- fix: improve enum and type handling for `JSON` deserialization 53655d2
- fix: add error handling to `toJson`/`fromJson` of `HydratedMixin` `Cubits` 06c953e
- fix: implement type casting and `null` handling for `HydratedMixin` `States` f1e47fc
- fix(`PaymentFilters`): correct the list equality check in `hasTypeFilters` 90cdbc9
  - Addresses an UI issue where filter sliver was shown incorrectly on Home page with the new default `PaymentFilters` values.
- feat: Create `HydratedBlocStorage` with migration support 575b9bc
- feat: simplify `enum` parsing in `SecurityState` and `PaymentData` models  d207b18
- fix: optimize `null` handling in LNURL metadata parsing a6fb7a7
- feat: simplify `JSON` parsing for `WalletInfo` & `BlockchainInfo` with centralized utility functions  1f346ac
- feat: use list-based approach for required field checks of `WalletInfo` & `BlockchainInfo` 9ef3c34
---

**Note:** This issue occurs sporadically during app updates. We found that certain update paths trigger the problem while others don't*, making it difficult to consistently reproduce in testing environments. I explored many approaches to this problem, and this solution is the one with the highest confidence level.

*: For example: TestFlight updates from build 6364.1 to versions below 6389.1 trigger the issue, while updates between later versions don't experience obfuscated Cubit IDs & states are hydrated w/o fail.