### PR TITLE
Center & Capitalize the PaymentMethodDropdown

### DIFF
--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -57,6 +57,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
           currentPaymentMethod: _currentPaymentMethod,
           onPaymentMethodChanged: _onPaymentMethodChanged,
         ),
+        centerTitle: true,
         actions: _currentPageIndex == ReceiveLightningAddressPage.pageIndex
             ? <Widget>[
                 IconButton(

--- a/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
+++ b/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/models/models.dart';
+import 'package:misty_breez/theme/theme.dart';
 
 class PaymentMethodDropdown extends StatelessWidget {
   final PaymentMethod currentPaymentMethod;
@@ -14,33 +15,63 @@ class PaymentMethodDropdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<DropdownMenuItem<PaymentMethod>> items =
-        <PaymentMethod>[PaymentMethod.lightning, PaymentMethod.bitcoinAddress]
-            .map<DropdownMenuItem<PaymentMethod>>(
-              (PaymentMethod method) => DropdownMenuItem<PaymentMethod>(
-                value: method,
-                child: Text(method.displayName),
-              ),
-            )
-            .toList();
+    final ThemeData themeData = Theme.of(context);
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        const Text('Receive with '),
-        DropdownButton<PaymentMethod>(
-          value: currentPaymentMethod,
-          underline: const SizedBox.shrink(),
-          style: Theme.of(context).appBarTheme.titleTextStyle,
-          onChanged: (PaymentMethod? newValue) {
-            if (newValue != null && newValue != currentPaymentMethod) {
-              onPaymentMethodChanged(newValue);
-            }
+    final List<PaymentMethod> allMethods = <PaymentMethod>[
+      PaymentMethod.lightning,
+      PaymentMethod.bitcoinAddress,
+    ];
+
+    return PopupMenuButton<PaymentMethod>(
+      color: themeData.customData.surfaceBgColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      constraints: const BoxConstraints(
+        minHeight: 48,
+        maxWidth: 180,
+      ),
+      elevation: 12.0,
+      initialValue: currentPaymentMethod,
+      onSelected: (PaymentMethod method) {
+        if (method != currentPaymentMethod) {
+          onPaymentMethodChanged(method);
+        }
+      },
+      position: PopupMenuPosition.under,
+      offset: currentPaymentMethod == PaymentMethod.lightning ? const Offset(-20, 0) : const Offset(0, 0),
+      itemBuilder: (BuildContext context) {
+        return allMethods
+            .where((PaymentMethod method) => method != currentPaymentMethod)
+            .map<PopupMenuItem<PaymentMethod>>(
+          (PaymentMethod method) {
+            return PopupMenuItem<PaymentMethod>(
+              value: method,
+              child: Center(
+                child: Text(
+                  method.displayName.toUpperCase(),
+                  style: themeData.appBarTheme.titleTextStyle,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
           },
-          items: items,
-          menuMaxHeight: 200,
+        ).toList();
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              currentPaymentMethod.displayName.toUpperCase(),
+              style: themeData.appBarTheme.titleTextStyle,
+            ),
+            const SizedBox(width: 4.0),
+            const Icon(Icons.arrow_drop_down, color: Colors.white),
+          ],
         ),
-      ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR is a continuation of #487

Switching between payment methods has been made clearer by centering & capitalizing `PaymentMethodDropdown`.

https://github.com/user-attachments/assets/2cd65380-93ba-4d27-8034-666ae5c72656

