### PR TITLE
chore: update iOS build workflow to use Xcode 16 and iOS 18 SDK

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -83,7 +83,7 @@ jobs:
   build-ios:
     needs: setup
     name: Build iOS
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       SCHEME: Runner
       BUILD_CONFIGURATION: Release
@@ -109,11 +109,10 @@ jobs:
           echo "::endgroup::"
           echo "::group::Cleaned Files"
           sudo rm -rf /Users/runner/Library/Android/sdk
-          sudo rm -rf /Applications/Xcode_14.3.1.app
-          sudo rm -rf /Applications/Xcode_15.0.1.app
-          sudo rm -rf /Applications/Xcode_15.1.app
-          sudo rm -rf /Applications/Xcode_15.2.app
-          sudo rm -rf /Applications/Xcode_15.3.app
+          sudo rm -rf /Applications/Xcode_15.4.app
+          sudo rm -rf /Applications/Xcode_16.1.app
+          sudo rm -rf /Applications/Xcode_16.2.app
+          sudo rm -rf /Applications/Xcode_16.3_Release_Candidate_2.app
           echo "::endgroup::"
           echo "::group::Free space after cleanup"
           df -hI


### PR DESCRIPTION
Fixes #401

This PR addresses the warning message below from Apple:
> **ITMS-90725:** SDK version issue - This app was built with the iOS 17.5 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution.

#### Changelist:
- Update runner to `macos-15`, where XCode 16.0 & iOS 18.0 is the default.
  - Clean up other [bundled XCode versions](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode) with the runner to free up space