### PR TITLE
fix(android): support biometric auth by using FragmentActivity and handling failures properly

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         </service>
 
         <activity
-            android:name=".MainActivity"
+            android:name="io.flutter.embedding.android.FlutterFragmentActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:taskAffinity=""

--- a/android/app/src/main/kotlin/com/breez/misty/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/breez/misty/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.breez.misty
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity()

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -233,16 +233,16 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
 
       _logger.severe('Biometric error: ${error.code} - ${error.message}', error);
       await _auth.stopAuthentication();
-      return false;
       if (updateLockStateOnFailure) {
         _updateLockState(LockState.locked);
       }
+      throw '${error.code} - ${error.message}';
     } catch (e) {
       _logger.severe('Unexpected error during biometric authentication: $e');
       if (updateLockStateOnFailure) {
         _updateLockState(LockState.locked);
       }
-      return false;
+      rethrow;
     }
   }
 

--- a/lib/cubit/security/security_cubit.dart
+++ b/lib/cubit/security/security_cubit.dart
@@ -197,7 +197,10 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
   /// [localizedReason] Reason for authentication displayed to user
   ///
   /// Returns true if authentication succeeded, false otherwise
-  Future<bool> authenticateWithBiometrics(String localizedReason) async {
+  Future<bool> authenticateWithBiometrics(
+    String localizedReason, {
+    bool updateLockStateOnFailure = true,
+  }) async {
     final BiometricType detectedType = await detectBiometricType();
     if (detectedType == BiometricType.none) {
       _logger.warning('Attempted biometric authentication when not available');
@@ -217,7 +220,9 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
         ],
       );
 
-      _updateLockState(authenticated ? LockState.unlocked : LockState.locked);
+      if (authenticated || updateLockStateOnFailure) {
+        _updateLockState(authenticated ? LockState.unlocked : LockState.locked);
+      }
       _logger.info('Biometric authentication ${authenticated ? 'succeeded' : 'failed'}');
       return authenticated;
     } on PlatformException catch (error) {
@@ -228,11 +233,15 @@ class SecurityCubit extends Cubit<SecurityState> with HydratedMixin<SecurityStat
 
       _logger.severe('Biometric error: ${error.code} - ${error.message}', error);
       await _auth.stopAuthentication();
-      _updateLockState(LockState.locked);
       return false;
+      if (updateLockStateOnFailure) {
+        _updateLockState(LockState.locked);
+      }
     } catch (e) {
       _logger.severe('Unexpected error during biometric authentication: $e');
-      _updateLockState(LockState.locked);
+      if (updateLockStateOnFailure) {
+        _updateLockState(LockState.locked);
+      }
       return false;
     }
   }

--- a/lib/routes/security/services/auth_service.dart
+++ b/lib/routes/security/services/auth_service.dart
@@ -65,12 +65,15 @@ class AuthService {
   /// Authenticates using biometrics
   ///
   /// Returns an [AuthResult] with the authentication outcome
-  Future<AuthResult> authenticateWithBiometrics() async {
+  Future<AuthResult> authenticateWithBiometrics({
+    bool updateLockStateOnFailure = true,
+  }) async {
     _logger.fine('Attempting biometric authentication');
 
     try {
       final bool isValid = await _securityCubit.authenticateWithBiometrics(
         _texts.security_and_backup_validate_biometrics_reason,
+        updateLockStateOnFailure: updateLockStateOnFailure,
       );
 
       if (isValid) {

--- a/lib/routes/security/services/auth_service.dart
+++ b/lib/routes/security/services/auth_service.dart
@@ -88,10 +88,7 @@ class AuthService {
       );
     } catch (e) {
       _logger.severe('Biometric authentication error: $e');
-      return AuthResult(
-        success: false,
-        errorMessage: _texts.lock_screen_pin_match_exception,
-      );
+      rethrow;
     }
   }
 

--- a/lib/routes/security/widgets/security_settings/local_auth_switch.dart
+++ b/lib/routes/security/widgets/security_settings/local_auth_switch.dart
@@ -59,7 +59,7 @@ class LocalAuthSwitch extends StatelessWidget {
     if (switchEnabled) {
       _logger.info('Attempting to enable biometric authentication');
 
-      authService.authenticateWithBiometrics().then(
+      authService.authenticateWithBiometrics(updateLockStateOnFailure: false).then(
         (AuthResult authResult) {
           if (authResult.success) {
             _logger.info('Biometric authentication successful, enabling');

--- a/lib/routes/security/widgets/security_settings/local_auth_switch.dart
+++ b/lib/routes/security/widgets/security_settings/local_auth_switch.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/widgets.dart';
 
 final Logger _logger = Logger('LocalAuthSwitch');
@@ -66,12 +67,16 @@ class LocalAuthSwitch extends StatelessWidget {
             authService.enableBiometricAuth();
           } else {
             _logger.warning('Biometric authentication failed, not enabling');
+            _logger.warning('Reason: ${authResult.errorMessage}');
             authService.disableBiometricAuth();
           }
         },
         onError: (Object error) {
           _logger.severe('Error during biometric authentication: $error');
           authService.disableBiometricAuth();
+          if (context.mounted) {
+            showFlushbar(context, message: ExceptionHandler.extractMessage(error, context.texts()));
+          }
         },
       );
     } else {


### PR DESCRIPTION
This PR fixes biometric authentication on Android devices which was previously failing due to incompatible Activity types. The biometric switch would appear but authentication would silently fail & prompt PIN entry.

#### Root cause:
The `local_auth` plugin requires the main activity to extend `FragmentActivity` on Android:
```
Available biometrics: [BiometricType.weak, BiometricType.strong]
PlatformException(no_fragment_activity, local_auth plugin requires activity to be a FragmentActivity., null, null)
```

Now the biometric authentication works properly, does not lock the app on authentication failures and shows appropriate error messages when there are errors.

### Changelist 
- fix(android): ensure main activity meets local_auth requirements 86862461564ff53ef9e768cac47f540d63128b20
- fix: do not lock the app if enabling biometrics fail 9dae39fa7c14c437cedac36aa5326c168881c157
- fix: throw authentication errors & display them in flushbar 5cf356fd674f8c571e4a71989adb50dcbefc22d3