### PR TITLE
regression: fix error handling during restore flow

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -35,7 +35,7 @@ Route<dynamic>? onGenerateRoute({
     case EnterMnemonicsPage.routeName:
       return FadeInRoute<String>(
         builder: (BuildContext _) => EnterMnemonicsPage(
-          initialWords: settings.arguments as List<String>? ?? <String>[],
+          arguments: settings.arguments as EnterMnemonicsPageArguments,
         ),
         settings: settings,
       );

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -4,20 +4,36 @@ import 'package:flutter/material.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/widgets/back_button.dart' as back_button;
 
-class EnterMnemonicsPage extends StatefulWidget {
+class EnterMnemonicsPageArguments {
   final List<String> initialWords;
+  final String errorMessage;
+
+  EnterMnemonicsPageArguments({
+    required this.initialWords,
+    this.errorMessage = '',
+  });
+}
+
+class EnterMnemonicsPage extends StatefulWidget {
+  final EnterMnemonicsPageArguments arguments;
 
   static const String routeName = '/enter_mnemonics';
 
-  const EnterMnemonicsPage({required this.initialWords, super.key});
+  const EnterMnemonicsPage({required this.arguments, super.key});
 
   @override
   EnterMnemonicsPageState createState() => EnterMnemonicsPageState();
 }
 
 class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
-  late int _currentPage = 1;
+  int _currentPage = 1;
   final int _lastPage = 2;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPage = widget.arguments.errorMessage.isNotEmpty ? 2 : 1;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,7 +79,8 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
             child: RestoreFormPage(
               currentPage: _currentPage,
               lastPage: _lastPage,
-              initialWords: widget.initialWords,
+              initialWords: widget.arguments.initialWords,
+              lastErrorMessage: widget.arguments.errorMessage,
               changePage: () {
                 setState(() {
                   _currentPage++;

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
@@ -4,6 +4,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
 import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/theme/theme.dart';
 import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/widgets.dart';
 
@@ -12,11 +13,13 @@ class RestoreFormPage extends StatefulWidget {
   final int lastPage;
   final VoidCallback changePage;
   final List<String> initialWords;
+  final String lastErrorMessage;
 
   const RestoreFormPage({
     required this.currentPage,
     required this.lastPage,
     required this.changePage,
+    this.lastErrorMessage = '',
     super.key,
     this.initialWords = const <String>[],
   });
@@ -46,7 +49,6 @@ class RestoreFormPageState extends State<RestoreFormPage> {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     final BreezTranslations texts = context.texts();
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -58,13 +60,19 @@ class RestoreFormPageState extends State<RestoreFormPage> {
           textEditingControllers: textEditingControllers,
           autoValidateMode: _autoValidateMode,
         ),
-        if (_hasError) ...<Widget>[
+        if ((_hasError || widget.lastErrorMessage.isNotEmpty) && widget.currentPage == 2) ...<Widget>[
+          // TODO(erdemyerebasmaz): Display the error message itself & add an option to share logs
           Padding(
             padding: const EdgeInsets.only(left: 16, right: 16),
-            child: Text(
-              texts.enter_backup_phrase_error,
-              style: themeData.textTheme.headlineMedium?.copyWith(
-                fontSize: 12,
+            child: WarningBox(
+              boxPadding: EdgeInsets.zero,
+              contentPadding: const EdgeInsets.all(16),
+              backgroundColor: warningBoxColor,
+              borderColor: warningStyle.color,
+              child: Text(
+                texts.enter_backup_phrase_error,
+                style: warningStyle,
+                textAlign: TextAlign.center,
               ),
             ),
           ),


### PR DESCRIPTION
Fixes https://github.com/breez/misty-breez/issues/506

When an error occurs on restore, we now display the error message in a flushbar & redirecting user to the same page, allowing users to retry manually when ready. Previously, we redirected user to the first page & didn't display any errors due to a regression while moving the business logic outside the UI.

The generic error message is now displayed in a `WarningBox` for consistency. We've also created `EnterMnemonicsPageArguments` to better structure the data passed to `EnterMnemonicsPage`. 