### PR TITLE
BOLT12 receive

### DIFF
--- a/lib/models/extensions/payment_method_extension.dart
+++ b/lib/models/extensions/payment_method_extension.dart
@@ -3,10 +3,8 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 extension PaymentMethodExtension on PaymentMethod {
   String get displayName {
     switch (this) {
-      case PaymentMethod.bolt12Invoice:
-        return 'BOLT12 Invoice';
       case PaymentMethod.bolt12Offer:
-        return 'BOLT12 Offer';
+        return 'BOLT 12 Offer';
       case PaymentMethod.lightning:
         return 'Lightning';
       case PaymentMethod.bitcoinAddress:

--- a/lib/models/extensions/payment_method_extension.dart
+++ b/lib/models/extensions/payment_method_extension.dart
@@ -3,6 +3,10 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 extension PaymentMethodExtension on PaymentMethod {
   String get displayName {
     switch (this) {
+      case PaymentMethod.bolt12Invoice:
+        return 'BOLT12 Invoice';
+      case PaymentMethod.bolt12Offer:
+        return 'BOLT12 Offer';
       case PaymentMethod.lightning:
         return 'Lightning';
       case PaymentMethod.bitcoinAddress:

--- a/lib/models/extensions/payment_method_extension.dart
+++ b/lib/models/extensions/payment_method_extension.dart
@@ -5,6 +5,7 @@ extension PaymentMethodExtension on PaymentMethod {
     switch (this) {
       case PaymentMethod.bolt12Offer:
         return 'BOLT 12 Offer';
+      case PaymentMethod.bolt11Invoice:
       case PaymentMethod.lightning:
         return 'Lightning';
       case PaymentMethod.bitcoinAddress:

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -289,13 +289,14 @@ class _DevelopersViewState extends State<DevelopersView> {
                 child: ShareablePaymentRow(
                   tilePadding: EdgeInsets.zero,
                   dividerColor: Colors.transparent,
-                  title: 'Public Key ',
+                  title: 'Public Key',
                   titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
                     fontSize: 18.0,
                     color: Colors.white,
                   ),
                   sharedValue: walletInfo.pubkey,
                   shouldPop: false,
+                  trimTitle: false,
                 ),
               ),
               if (_bolt12Offer.isNotEmpty) ...<Widget>[
@@ -304,13 +305,14 @@ class _DevelopersViewState extends State<DevelopersView> {
                   child: ShareablePaymentRow(
                     tilePadding: EdgeInsets.zero,
                     dividerColor: Colors.transparent,
-                    title: 'BOLT 12 Offer ',
+                    title: 'BOLT 12 Offer',
                     titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
                       fontSize: 18.0,
                       color: Colors.white,
                     ),
                     sharedValue: _bolt12Offer,
                     shouldPop: false,
+                    trimTitle: false,
                   ),
                 ),
               ],

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -289,7 +289,7 @@ class _DevelopersViewState extends State<DevelopersView> {
                 child: ShareablePaymentRow(
                   tilePadding: EdgeInsets.zero,
                   dividerColor: Colors.transparent,
-                  title: 'Public Key',
+                  title: 'Public Key ',
                   titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
                     fontSize: 18.0,
                     color: Colors.white,
@@ -304,7 +304,7 @@ class _DevelopersViewState extends State<DevelopersView> {
                   child: ShareablePaymentRow(
                     tilePadding: EdgeInsets.zero,
                     dividerColor: Colors.transparent,
-                    title: 'BOLT 12 Offer',
+                    title: 'BOLT 12 Offer ',
                     titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
                       fontSize: 18.0,
                       color: Colors.white,

--- a/lib/routes/receive_payment/lightning/receive_lightning_page.dart
+++ b/lib/routes/receive_payment/lightning/receive_lightning_page.dart
@@ -18,7 +18,7 @@ final Logger _logger = Logger('ReceiveLightningPaymentPage');
 
 class ReceiveLightningPaymentPage extends StatefulWidget {
   static const String routeName = '/receive_lightning';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
   static const int pageIndex = 0;
 
   const ReceiveLightningPaymentPage({super.key});
@@ -322,7 +322,7 @@ class ReceiveLightningPaymentPageState extends State<ReceiveLightningPaymentPage
       currencyCubit.state.bitcoinCurrency.parse(_amountController.text),
     );
     final Future<PrepareReceiveResponse> prepareReceiveResponse = paymentsCubit.prepareReceivePayment(
-      paymentMethod: PaymentMethod.lightning,
+      paymentMethod: PaymentMethod.bolt11Invoice,
       payerAmountSat: payerAmountSat,
     );
 

--- a/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
+++ b/lib/routes/receive_payment/ln_address/receive_lightning_address_page.dart
@@ -11,7 +11,7 @@ import 'package:misty_breez/widgets/widgets.dart';
 /// Page that displays the user's Lightning Address for receiving payments.
 class ReceiveLightningAddressPage extends StatefulWidget {
   static const String routeName = '/lightning_address';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
   static const int pageIndex = 1;
 
   const ReceiveLightningAddressPage({super.key});

--- a/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
+++ b/lib/routes/receive_payment/lnurl/lnurl_withdraw_page.dart
@@ -25,7 +25,7 @@ class LnUrlWithdrawPage extends StatefulWidget {
   final LnUrlWithdrawRequestData requestData;
 
   static const String routeName = '/lnurl_withdraw';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
 
   const LnUrlWithdrawPage({
     required this.onFinish,

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -103,7 +103,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
     // - without notification permissions
     // - when LN Address state had errors
     final bool shouldRedirect = !_hasNotificationPermission || _hasLnAddressStateError;
-    if (_showInvoicePage || _currentPaymentMethod == PaymentMethod.lightning && shouldRedirect) {
+    if (_showInvoicePage || _currentPaymentMethod == PaymentMethod.bolt11Invoice && shouldRedirect) {
       return ReceiveLightningPaymentPage.pageIndex;
     }
 
@@ -113,7 +113,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   PaymentMethod get _currentPaymentMethod {
     return _currentPageIndex == ReceiveBitcoinAddressPaymentPage.pageIndex
         ? PaymentMethod.bitcoinAddress
-        : PaymentMethod.lightning;
+        : PaymentMethod.bolt11Invoice;
   }
 
   Future<void> _onPaymentMethodChanged(PaymentMethod newMethod) async {
@@ -136,6 +136,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       case PaymentMethod.bolt12Offer:
         // TODO: Add a BOLT12 offer to the Lightning address page
         return ReceiveLightningAddressPage.pageIndex;
+      case PaymentMethod.bolt11Invoice:
       case PaymentMethod.lightning:
         return ReceiveLightningAddressPage.pageIndex;
       case PaymentMethod.liquidAddress:

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -134,7 +134,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       case PaymentMethod.bitcoinAddress:
         return ReceiveBitcoinAddressPaymentPage.pageIndex;
       case PaymentMethod.bolt12Offer:
-        // TODO: Add a BOLT12 offer to the Lightning address page
+        // TODO(dangeross): Add a BOLT12 offer to the Lightning address page
         return ReceiveLightningAddressPage.pageIndex;
       case PaymentMethod.bolt11Invoice:
       case PaymentMethod.lightning:

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -131,6 +131,13 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   // Get the appropriate page index for a payment method
   int _getPageIndexForPaymentMethod(PaymentMethod method) {
     switch (method) {
+      case PaymentMethod.bolt12Invoice:
+        // We should not have to handle this payment method as a user
+        // selection, it is purely the task of the Notifification Plugin
+        return ReceiveBitcoinAddressPaymentPage.pageIndex;
+      case PaymentMethod.bolt12Offer:
+        // TODO: Add a BOLT12 offer payment page to show the offer QR code
+        return ReceiveBitcoinAddressPaymentPage.pageIndex;
       case PaymentMethod.bitcoinAddress:
         return ReceiveBitcoinAddressPaymentPage.pageIndex;
       case PaymentMethod.lightning:

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -131,15 +131,11 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   // Get the appropriate page index for a payment method
   int _getPageIndexForPaymentMethod(PaymentMethod method) {
     switch (method) {
-      case PaymentMethod.bolt12Invoice:
-        // We should not have to handle this payment method as a user
-        // selection, it is purely the task of the Notifification Plugin
-        return ReceiveBitcoinAddressPaymentPage.pageIndex;
-      case PaymentMethod.bolt12Offer:
-        // TODO: Add a BOLT12 offer payment page to show the offer QR code
-        return ReceiveBitcoinAddressPaymentPage.pageIndex;
       case PaymentMethod.bitcoinAddress:
         return ReceiveBitcoinAddressPaymentPage.pageIndex;
+      case PaymentMethod.bolt12Offer:
+        // TODO: Add a BOLT12 offer to the Lightning address page
+        return ReceiveLightningAddressPage.pageIndex;
       case PaymentMethod.lightning:
         return ReceiveLightningAddressPage.pageIndex;
       case PaymentMethod.liquidAddress:

--- a/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
+++ b/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
@@ -18,7 +18,7 @@ class PaymentMethodDropdown extends StatelessWidget {
     final ThemeData themeData = Theme.of(context);
 
     final List<PaymentMethod> allMethods = <PaymentMethod>[
-      PaymentMethod.lightning,
+      PaymentMethod.bolt11Invoice,
       PaymentMethod.bitcoinAddress,
     ];
 
@@ -39,7 +39,7 @@ class PaymentMethodDropdown extends StatelessWidget {
         }
       },
       position: PopupMenuPosition.under,
-      offset: currentPaymentMethod == PaymentMethod.lightning ? const Offset(-20, 0) : const Offset(0, 0),
+      offset: currentPaymentMethod == PaymentMethod.bolt11Invoice ? const Offset(-20, 0) : const Offset(0, 0),
       itemBuilder: (BuildContext context) {
         return allMethods
             .where((PaymentMethod method) => method != currentPaymentMethod)

--- a/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
@@ -16,7 +16,7 @@ class LnPaymentPage extends StatefulWidget {
   final LNInvoice lnInvoice;
 
   static const String routeName = '/ln_invoice_payment';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
 
   const LnPaymentPage({required this.lnInvoice, super.key});
 

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -32,7 +32,7 @@ class LnOfferPaymentPage extends StatefulWidget {
   final String? comment;
 
   static const String routeName = '/ln_offer_payment';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
 
   const LnOfferPaymentPage({
     required this.lnOfferPaymentArguments,

--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -37,7 +37,7 @@ class LnUrlPaymentPage extends StatefulWidget {
   final String? comment;
 
   static const String routeName = '/lnurl_payment';
-  static const PaymentMethod paymentMethod = PaymentMethod.lightning;
+  static const PaymentMethod paymentMethod = PaymentMethod.bolt11Invoice;
 
   const LnUrlPaymentPage({
     required this.lnUrlPaymentArguments,

--- a/lib/widgets/shareable_payment_row.dart
+++ b/lib/widgets/shareable_payment_row.dart
@@ -11,6 +11,7 @@ import 'package:share_plus/share_plus.dart';
 class ShareablePaymentRow extends StatelessWidget {
   final String title;
   final Widget? titleWidget;
+  final bool trimTitle;
   final String sharedValue;
   final String? urlValue;
   final bool isURL;
@@ -42,6 +43,7 @@ class ShareablePaymentRow extends StatelessWidget {
     this.labelAutoSizeGroup,
     this.valueAutoSizeGroup,
     this.shouldPop = true,
+    this.trimTitle = true,
   });
 
   @override
@@ -125,7 +127,7 @@ class ShareablePaymentRow extends StatelessWidget {
                             showFlushbar(
                               context,
                               message: texts.payment_details_dialog_copied(
-                                title.substring(0, title.length - 1),
+                                trimTitle ? title.substring(0, title.length - 1) : title,
                               ),
                               duration: const Duration(seconds: 4),
                             );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -136,7 +136,7 @@ packages:
       path: "../breez-sdk-liquid/packages/dart"
       relative: true
     source: path
-    version: "0.7.2-dev1"
+    version: "0.8.0"
   breez_translations:
     dependency: "direct main"
     description:
@@ -589,7 +589,7 @@ packages:
       path: "../breez-sdk-liquid/packages/flutter"
       relative: true
     source: path
-    version: "0.7.2-dev1"
+    version: "0.8.0"
   flutter_cache_manager:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This is PR adds the minimum UI to enable BOLT12 receive via BOLT12 offer.

Depends on https://github.com/breez/breez-sdk-liquid/pull/882

**Testing notes:**
- The raw **BOLT 12 Offer** ("lno...") to receive payments is available in the Developers page
- When paying the offer:
  - while Misty is in the foreground, the receive payment should complete without notifications
  - while Misty is in the background, the receive payment should complete with `Fetching Invoice` and `Received 666 sats` notifications
  - sending below the minimum receive amount will result in a failure to pay for the payer
- Test sending to the raw BOLT12 Offer from Phoenix
- Test sending to the raw BOLT12 Offer from another Misty/SDK app. The payment should be received by a direct Liquid transaction
