### PR TITLE
Create & add Universal APK to Artifacts on Build Android workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,13 +34,13 @@ jobs:
       liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
     steps:
       - name: Checkout repository
-        if:  ${{ needs.pre-setup.outputs.use-published-plugins == 'true' && needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
+        if:  ${{ inputs.use-published-plugins == 'true' && inputs.liquid-sdk-plugin-version == ''}}
         uses: actions/checkout@v4
         with:
           repository: 'breez/breez-sdk-liquid-flutter'
 
       - name: Get the latest tag and set 'liquid-sdk-plugin-version'
-        if:  ${{ needs.pre-setup.outputs.use-published-plugins == 'true' && needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
+        if:  ${{ inputs.use-published-plugins == 'true' && inputs.liquid-sdk-plugin-version == ''}}
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "liquid-sdk-plugin-version=$latest_tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -396,7 +396,7 @@ jobs:
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.universal.zip
           file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -405,7 +405,7 @@ jobs:
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.arm64-v8a.zip
           file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk.zip
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -414,7 +414,7 @@ jobs:
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.armeabi-v7a.zip
           file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk.zip
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -423,8 +423,17 @@ jobs:
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.x86_64.zip
           file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk.zip
+          overwrite: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📤 Upload APK asset
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.apk-per-abi.zip
+          file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.*.apk
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -432,7 +441,7 @@ jobs:
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Android-Bundle.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.aab.zip
           file: misty_breez/build/app/outputs/bundle/release/bundle-build.zip
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -441,21 +450,42 @@ jobs:
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.universal
           path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk
+
+      - name: 📤 Upload Arm64 APK artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.arm64-v8a
+          path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk
+
+      - name: 📤 Upload Armeabi APK artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.armeabi-v7a
+          path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk
+
+      - name: 📤 Upload x86_64 APK artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.x86_64
+          path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk
 
       - name: 📤 Upload APK artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: Android-APKs
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.apk-per-abi
           path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.*.apk
 
       - name: 📤 Upload Bundle artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: Android-Bundle
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.aab
           path: misty_breez/build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}aab
 
       - name: Cleanup Google Application Credentials

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -184,7 +184,17 @@ jobs:
 
       - name: Configure Firebase
         working-directory: misty_breez
-        run: flutterfire configure -p $FIREBASE_PROJECT -o lib/firebase/firebase_options.dart --platforms="android,ios" -a $FIREBASE_ANDROID_PACKAGE_NAME -i $FIREBASE_IOS_BUNDLE_ID -m $FIREBASE_PLACEHOLDER_APP_ID -w $FIREBASE_PLACEHOLDER_APP_ID -x $FIREBASE_PLACEHOLDER_APP_ID --service-account=google-application-credentials.json -y
+        run: |
+          flutterfire configure \
+          -p $FIREBASE_PROJECT \
+          -o lib/firebase/firebase_options.dart \
+          --platforms="android,ios" \
+          -a $FIREBASE_ANDROID_PACKAGE_NAME \
+          -i $FIREBASE_IOS_BUNDLE_ID \
+          -m $FIREBASE_PLACEHOLDER_APP_ID \
+          -w $FIREBASE_PLACEHOLDER_APP_ID \
+          -x $FIREBASE_PLACEHOLDER_APP_ID \
+          --service-account=google-application-credentials.json -y
 
       - name: 🏗️ Android cache
         id: android-cache

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -43,7 +43,7 @@ jobs:
         if:  ${{ needs.pre-setup.outputs.use-published-plugins == 'true' && needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "::set-output name=liquid-sdk-plugin-version::$latest_tag"
+          echo "liquid-sdk-plugin-version=$latest_tag" >> "$GITHUB_OUTPUT"
 
       - run: echo "set pre-setup output variables"
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -346,7 +346,7 @@ jobs:
           mv build/app/outputs/flutter-apk/app-arm64-v8a-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk
           mv build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk
           mv build/app/outputs/flutter-apk/app-x86_64-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}aab
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}.aab
 
       - name: 🗃️ Compress Universal APK
         if: github.event_name == 'release'
@@ -486,7 +486,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Misty.Breez.${{ env.BUILD_NUMBER }}.aab
-          path: misty_breez/build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}aab
+          path: misty_breez/build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}.aab
 
       - name: Cleanup Google Application Credentials
         if: success() || failure()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -287,6 +287,23 @@ jobs:
           echo "VERSION_BASE=$VERSION_BASE" >> $GITHUB_ENV
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
 
+      - name: 🚀 Build Universal APK
+        env:
+          STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        working-directory: misty_breez
+        run: |
+          flutter build apk \
+            --build-name="$VERSION_BASE" \
+            --build-number="$BUILD_NUMBER" \
+            --target="lib/main/main.dart" \
+            --release \
+            --split-debug-info="./obfuscated/debug" \
+            --obfuscate \
+            --no-pub \
+            --dart-define-from-file="config.json"
+
       - name: 🚀 Build Release APK
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
@@ -297,13 +314,13 @@ jobs:
           flutter build apk \
           --build-name="$VERSION_BASE" \
           --build-number="$BUILD_NUMBER" \
-          --target=lib/main/main.dart \
+          --target="lib/main/main.dart" \
           --release \
           --split-debug-info="./obfuscated/debug" \
           --obfuscate \
           --no-pub \
           --split-per-abi \
-          --dart-define-from-file=config.json
+          --dart-define-from-file="config.json"
 
       - name: 🚀 Build Release App Bundle
         env:
@@ -313,18 +330,58 @@ jobs:
         working-directory: misty_breez
         run: |
           flutter build appbundle \
+          --build-name="$VERSION_BASE" \
           --build-number="$BUILD_NUMBER" \
           --target="lib/main/main.dart" \
           --release \
+          --split-debug-info="./obfuscated/debug" \
+          --obfuscate \
           --no-pub \
           --dart-define-from-file="config.json"
 
-      - name: 🗃️ Compress APK build folder
+      - name: 📝 Rename APKs & App Bundle
+        working-directory: misty_breez
+        run: |
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk
+          mv build/app/outputs/flutter-apk/app-arm64-v8a-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk
+          mv build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk
+          mv build/app/outputs/flutter-apk/app-x86_64-release.apk build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}aab
+
+      - name: 🗃️ Compress Universal APK
         if: github.event_name == 'release'
         uses: TheDoctor0/zip-release@master
         with:
-          filename: apk-build.zip
-          directory: misty_breez/build/app/outputs/flutter-apk
+          filename: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          directory: misty_breez/build/app/outputs/flutter-apk/
+          includes: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk
+          type: zip
+
+      - name: 🗃️ Compress Arm64 APK
+        if: github.event_name == 'release'
+        uses: TheDoctor0/zip-release@master
+        with:
+          filename: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk.zip
+          directory: misty_breez/build/app/outputs/flutter-apk/
+          includes: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk
+          type: zip
+
+      - name: 🗃️ Compress Armeabi APK
+        if: github.event_name == 'release'
+        uses: TheDoctor0/zip-release@master
+        with:
+          filename: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk.zip
+          directory: misty_breez/build/app/outputs/flutter-apk/
+          includes: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk
+          type: zip
+
+      - name: 🗃️ Compress x86_64 APK
+        if: github.event_name == 'release'
+        uses: TheDoctor0/zip-release@master
+        with:
+          filename: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk.zip
+          directory: misty_breez/build/app/outputs/flutter-apk/
+          includes: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk
           type: zip
 
       - name: 🗃️ Compress Bundle build folder
@@ -335,12 +392,39 @@ jobs:
           directory: misty_breez/build/app/outputs/bundle/release
           type: zip
 
-      - name: 📤 Upload APK asset
+      - name: 📤 Upload Universal APK asset
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
-          asset_name: Android-APK.zip
-          file: misty_breez/build/app/outputs/flutter-apk/apk-build.zip
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          overwrite: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📤 Upload Arm64 APK asset
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk.zip
+          file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.arm64-v8a.apk.zip
+          overwrite: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📤 Upload Armeabi APK asset
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk.zip
+          file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.armeabi-v7a.apk.zip
+          overwrite: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📤 Upload x86_64 APK asset
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          asset_name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk.zip
+          file: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.x86_64.apk.zip
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -353,19 +437,26 @@ jobs:
           overwrite: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 📤 Upload Universal APK artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk.zip
+          path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.apk
+
       - name: 📤 Upload APK artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: Android-APK
-          path: misty_breez/build/app/outputs/flutter-apk/app-*.apk
+          name: Android-APKs
+          path: misty_breez/build/app/outputs/flutter-apk/Misty.Breez.${{ env.BUILD_NUMBER }}.signed_by_breez.*.apk
 
       - name: 📤 Upload Bundle artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
           name: Android-Bundle
-          path: misty_breez/build/app/outputs/bundle/release/app-release.aab
+          path: misty_breez/build/app/outputs/bundle/release/${{ env.BUILD_NUMBER }}aab
 
       - name: Cleanup Google Application Credentials
         if: success() || failure()

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -183,7 +183,17 @@ jobs:
 
       - name: Configure Firebase
         working-directory: misty_breez
-        run: flutterfire configure -p $FIREBASE_PROJECT -o lib/firebase/firebase_options.dart --platforms="android,ios" -a $FIREBASE_ANDROID_PACKAGE_NAME -i $FIREBASE_IOS_BUNDLE_ID -m $FIREBASE_PLACEHOLDER_APP_ID -w $FIREBASE_PLACEHOLDER_APP_ID -x $FIREBASE_PLACEHOLDER_APP_ID --service-account=google-application-credentials.json -y
+        run: | 
+          flutterfire configure \
+          -p $FIREBASE_PROJECT \
+          -o lib/firebase/firebase_options.dart \
+          --platforms="android,ios" \
+          -a $FIREBASE_ANDROID_PACKAGE_NAME \
+          -i $FIREBASE_IOS_BUNDLE_ID \
+          -m $FIREBASE_PLACEHOLDER_APP_ID \
+          -w $FIREBASE_PLACEHOLDER_APP_ID \
+          -x $FIREBASE_PLACEHOLDER_APP_ID \
+          --service-account=google-application-credentials.json -y
 
       - name: 🔐 Install Keychain keys
         run: |
@@ -346,11 +356,28 @@ jobs:
 
       - name: 🚀 Build app
         working-directory: misty_breez
-        run: flutter build ios --target=lib/main/main.dart --release --split-debug-info=./obsfucated/debug --obfuscate --no-config-only --no-pub --no-codesign --dart-define-from-file=config.json
+        run: |
+          flutter build ios \
+          --build-name="$VERSION_BASE" \
+          --build-number="$BUILD_NUMBER" \
+          --target=lib/main/main.dart \
+          --release \
+          --split-debug-info=./obsfucated/debug \
+          --obfuscate \
+          --no-config-only \
+          --no-pub \
+          --no-codesign \
+          --dart-define-from-file=config.json
+          
 
       - name: 📦 Resolve Swift package dependencies
         working-directory: misty_breez
-        run: xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme ${{ env.SCHEME }} -configuration ${{ env.BUILD_CONFIGURATION }}
+        run: | 
+          xcodebuild \
+          -resolvePackageDependencies \
+          -workspace ios/Runner.xcworkspace \
+          -scheme ${{ env.SCHEME }} \
+          -configuration ${{ env.BUILD_CONFIGURATION }}
 
       - name: 🔨 Build application and generate xcarchive file
         working-directory: misty_breez
@@ -358,11 +385,23 @@ jobs:
           buildNumber=$(($GITHUB_RUN_NUMBER + 6000)).1
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $buildNumber" ios/Runner/Info.plist
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ env.IOS_VERSION_STRING }}" ios/Runner/Info.plist
-          xcodebuild -workspace ios/Runner.xcworkspace -scheme ${{ env.SCHEME }} -configuration ${{ env.BUILD_CONFIGURATION }} -sdk 'iphoneos' -destination 'generic/platform=iOS' -archivePath build-output/app.xcarchive clean archive
+          xcodebuild \
+          -workspace ios/Runner.xcworkspace \
+          -scheme ${{ env.SCHEME }} \
+          -configuration ${{ env.BUILD_CONFIGURATION }} \
+          -sdk 'iphoneos' \
+          -destination 'generic/platform=iOS' \
+          -archivePath build-output/app.xcarchive \
+          clean archive
 
       - name: 📤 Export the archive to an ipa file
         working-directory: misty_breez
-        run: xcodebuild -exportArchive -archivePath build-output/app.xcarchive -exportPath build-output/ios -exportOptionsPlist ios/ExportOptions.plist
+        run: |
+          xcodebuild \
+          -exportArchive \
+          -archivePath build-output/app.xcarchive \
+          -exportPath build-output/ios \
+          -exportOptionsPlist ios/ExportOptions.plist
 
       - name: 🗃️ Compress build folder
         if: github.event_name == 'release'
@@ -392,7 +431,12 @@ jobs:
         run: |
           altool="$(dirname "$(xcode-select -p)")/Developer/usr/bin/altool"
           ipa="$PWD/misty_breez/build-output/ios/misty_breez.ipa"
-          "$altool" --upload-app --type ios --file "$ipa" --username $TESTFLIGHT_USERNAME --password $TESTFLIGHT_PASSWORD
+          "$altool" \
+          --upload-app \
+          --type ios \
+          --file "$ipa" \
+          --username $TESTFLIGHT_USERNAME \
+          --password $TESTFLIGHT_PASSWORD
 
       - name: Cleanup Google Application Credentials
         if: success() || failure()

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -360,14 +360,14 @@ jobs:
           flutter build ios \
           --build-name="$VERSION_BASE" \
           --build-number="$BUILD_NUMBER" \
-          --target=lib/main/main.dart \
+          --target="lib/main/main.dart" \
           --release \
-          --split-debug-info=./obsfucated/debug \
+          --split-debug-info="./obfuscated/debug" \
           --obfuscate \
           --no-config-only \
           --no-pub \
           --no-codesign \
-          --dart-define-from-file=config.json
+          --dart-define-from-file="config.json"
           
 
       - name: 📦 Resolve Swift package dependencies

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,7 +67,7 @@ android {
     }
 
     // Load keystore properties
-    def keystorePropertiesFile = rootProject.file("keystore.properties")
+    def keystorePropertiesFile = rootProject.file("key.properties")
     def keystoreProperties = new Properties()
 
     if (keystorePropertiesFile.exists()) {


### PR DESCRIPTION
This PR introduces several improvements to the Android build workflow:
- Adds the universal APK to the Artifacts section in the Build Android workflow.
- Each ABI APK is now uploaded individually, which is beneficial for users with low bandwidth, as it allows for downloading only the relevant APK.
- Renames APKs and App Bundles to the format `Misty.Breez.{BUILD_NUMBER}.{type}` for convenience and clarity.
- Enhances the clarity of build commands by splitting them into multiple lines for easier understanding and maintenance.
- Ensures consistent build parameters across the workflow.
- Replaced the incorrect reference to `needs.pre-setup.outputs `with `inputs` in the `pre-setup` job.
- Removed the deprecated `set-output` command to avoid issues with newer GitHub Actions versions.

### Visual Reference:
![image](https://github.com/user-attachments/assets/db82f21a-7550-417d-aba9-3d50b40aed06)
