### PR TITLE
Fix notification permission sync after Firebase token requests

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -49,7 +49,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
-  - flutter_breez_liquid (0.7.2-dev1):
+  - flutter_breez_liquid (0.8.0):
     - Flutter
   - flutter_fgbg (0.0.1):
     - Flutter
@@ -287,7 +287,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
   FirebaseMessaging: 2b9f56aa4ed286e1f0ce2ee1d413aabb8f9f5cb9
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_breez_liquid: 20e30103b137084e12fc61413dc48d051e428516
+  flutter_breez_liquid: 8e6c28258a272f2661fda125b06854267c4649a2
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -23,6 +23,8 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final PermissionsCubit permissionsCubit = PermissionsCubit();
+
     return MultiBlocProvider(
       providers: <SingleChildWidget>[
         BlocProvider<AccountCubit>(
@@ -51,7 +53,7 @@ class App extends StatelessWidget {
           create: (BuildContext context) => UserProfileCubit(injector.breezPreferences),
         ),
         BlocProvider<LnAddressCubit>(
-          create: (BuildContext context) => LnAddressCubitFactory.create(injector),
+          create: (BuildContext context) => LnAddressCubitFactory.create(injector, permissionsCubit),
         ),
         BlocProvider<CurrencyCubit>(
           create: (BuildContext context) => CurrencyCubit(injector.breezSdkLiquid),
@@ -66,7 +68,7 @@ class App extends StatelessWidget {
           create: (BuildContext context) => ChainSwapCubit(injector.breezSdkLiquid),
         ),
         BlocProvider<PermissionsCubit>(
-          create: (BuildContext context) => PermissionsCubit(),
+          create: (BuildContext context) => permissionsCubit,
         ),
       ],
       child: Provider<LnUrlService>(

--- a/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
+++ b/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
@@ -4,10 +4,14 @@ import 'package:misty_breez/cubit/cubit.dart';
 import 'package:service_injector/service_injector.dart';
 
 class LnAddressCubitFactory {
-  static LnAddressCubit create(ServiceInjector injector) {
+  static LnAddressCubit create(ServiceInjector injector, PermissionsCubit permissionsCubit) {
     final BreezSDKLiquid breezSdkLiquid = injector.breezSdkLiquid;
     final BreezPreferences breezPreferences = injector.breezPreferences;
-    final WebhookService webhookService = WebhookService(breezSdkLiquid, injector.notifications);
+    final WebhookService webhookService = WebhookService(
+      breezSdkLiquid,
+      injector.notifications,
+      permissionsCubit,
+    );
 
     final MessageSigner messageSigner = MessageSigner(breezSdkLiquid);
     final WebhookRequestBuilder requestBuilder = WebhookRequestBuilder(messageSigner);

--- a/lib/cubit/ln_address/services/webhook_service.dart
+++ b/lib/cubit/ln_address/services/webhook_service.dart
@@ -28,6 +28,7 @@ class WebhookService {
 
   final BreezSDKLiquid _breezSdkLiquid;
   final NotificationsClient _notificationsClient;
+  final PermissionsCubit _permissionsCubit;
 
   /// Cached notification token to avoid repeated requests.
   String? _cachedToken;
@@ -40,9 +41,10 @@ class WebhookService {
 
   /// Creates a new [WebhookService] instance.
   ///
-  /// Requires [BreezSDKLiquid] for webhook registration and
-  /// [NotificationsClient] for notification token management.
-  WebhookService(this._breezSdkLiquid, this._notificationsClient);
+  /// Requires [BreezSDKLiquid] for webhook registration,
+  /// [NotificationsClient] for notification token management and
+  /// [PermissionsCubit] for notification permission management.
+  WebhookService(this._breezSdkLiquid, this._notificationsClient, this._permissionsCubit);
 
   /// Registers a webhook with the Breez SDK.
   ///
@@ -146,6 +148,10 @@ class WebhookService {
       () => _notificationsClient.getToken(),
       operationName: 'get notification token',
     );
+
+    // Update permission status after token request
+    _logger.fine('Updating permission status after token request');
+    await _permissionsCubit.checkNotificationPermission();
 
     if (token != null) {
       // Update cache

--- a/lib/cubit/permissions/permissions_cubit.dart
+++ b/lib/cubit/permissions/permissions_cubit.dart
@@ -49,11 +49,7 @@ class PermissionsCubit extends Cubit<PermissionsState> {
 
       final PermissionStatus mappedStatus = _mapPermissionStatus(status);
 
-      emit(
-        state.copyWith(
-          notificationStatus: mappedStatus,
-        ),
-      );
+      emit(state.copyWith(notificationStatus: mappedStatus));
       _logger.info('Mapped notification permission status: $mappedStatus');
     } catch (error) {
       _logger.severe('Error checking notification permission', error);
@@ -68,11 +64,7 @@ class PermissionsCubit extends Cubit<PermissionsState> {
 
       final PermissionStatus mappedStatus = _mapPermissionStatus(status);
 
-      emit(
-        state.copyWith(
-          notificationStatus: mappedStatus,
-        ),
-      );
+      emit(state.copyWith(notificationStatus: mappedStatus));
       _logger.info('Mapped notification permission request result: $mappedStatus');
     } catch (error) {
       _logger.severe('Error requesting notification permission', error);


### PR DESCRIPTION
Fixes #525

Add `PermissionsCubit` to `WebhookService` and call `checkNotificationPermission()` immediately after Firebase token requests to ensure permission state stays in sync with actual Firebase authorization status.