### PR TITLE
feature: add option to paste clipboard items on restore flow

### DIFF
--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -1,11 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:misty_breez/routes/routes.dart';
-import 'package:misty_breez/utils/constants/wordlist.dart';
 import 'package:misty_breez/widgets/back_button.dart' as back_button;
-import 'package:misty_breez/widgets/widgets.dart';
 
 class EnterMnemonicsPageArguments {
   final List<String> initialWords;
@@ -73,14 +70,8 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
             },
           ),
           actions: <Widget>[
-            IconButton(
-              icon: const Icon(
-                Icons.content_paste_outlined,
-                color: Colors.white,
-                size: 20,
-              ),
-              tooltip: 'Paste Backup Phrase',
-              onPressed: _pasteBackupPhrase,
+            PasteBackupPhraseButton(
+              textEditingControllers: textEditingControllers,
             ),
           ],
           title: Text(
@@ -109,43 +100,5 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
         ),
       ),
     );
-  }
-
-  void _pasteBackupPhrase() async {
-    try {
-      final ClipboardData? clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
-      final String? clipboardText = clipboardData?.text?.trim();
-
-      if (clipboardText == null) {
-        throw 'Clipboard is empty.';
-      }
-
-      final List<String> words = _extractWords(clipboardText);
-
-      if (_isValidMnemonic(words)) {
-        _populateTextFields(words);
-      } else {
-        throw 'Clipboard has invalid backup phrase.';
-      }
-    } catch (e) {
-      if (mounted) {
-        showFlushbar(context, message: e.toString());
-      }
-    }
-  }
-
-  List<String> _extractWords(String text) {
-    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
-  }
-
-  bool _isValidMnemonic(List<String> words) {
-    return words.length == 12 && words.every((String word) => wordlist.contains(word));
-  }
-
-  void _populateTextFields(List<String> words) {
-    for (int i = 0; i < words.length; i++) {
-      textEditingControllers[i].text = words[i];
-    }
-    FocusManager.instance.primaryFocus?.unfocus();
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -146,5 +146,6 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
     for (int i = 0; i < words.length; i++) {
       textEditingControllers[i].text = words[i];
     }
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -1,8 +1,11 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/utils/constants/wordlist.dart';
 import 'package:misty_breez/widgets/back_button.dart' as back_button;
+import 'package:misty_breez/widgets/widgets.dart';
 
 class EnterMnemonicsPageArguments {
   final List<String> initialWords;
@@ -28,6 +31,9 @@ class EnterMnemonicsPage extends StatefulWidget {
 class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
   int _currentPage = 1;
   final int _lastPage = 2;
+
+  List<TextEditingController> textEditingControllers =
+      List<TextEditingController>.generate(12, (_) => TextEditingController());
 
   @override
   void initState() {
@@ -66,6 +72,17 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
               }
             },
           ),
+          actions: <Widget>[
+            IconButton(
+              icon: const Icon(
+                Icons.content_paste_outlined,
+                color: Colors.white,
+                size: 20,
+              ),
+              tooltip: 'Paste Backup Phrase',
+              onPressed: _pasteBackupPhrase,
+            ),
+          ],
           title: Text(
             texts.enter_backup_phrase(
               _currentPage.toString(),
@@ -81,6 +98,7 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
               lastPage: _lastPage,
               initialWords: widget.arguments.initialWords,
               lastErrorMessage: widget.arguments.errorMessage,
+              textEditingControllers: textEditingControllers,
               changePage: () {
                 setState(() {
                   _currentPage++;
@@ -91,5 +109,42 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
         ),
       ),
     );
+  }
+
+  void _pasteBackupPhrase() async {
+    try {
+      final ClipboardData? clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      final String? clipboardText = clipboardData?.text?.trim();
+
+      if (clipboardText == null) {
+        throw 'Clipboard is empty.';
+      }
+
+      final List<String> words = _extractWords(clipboardText);
+
+      if (_isValidMnemonic(words)) {
+        _populateTextFields(words);
+      } else {
+        throw 'Clipboard has invalid backup phrase.';
+      }
+    } catch (e) {
+      if (mounted) {
+        showFlushbar(context, message: e.toString());
+      }
+    }
+  }
+
+  List<String> _extractWords(String text) {
+    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
+  }
+
+  bool _isValidMnemonic(List<String> words) {
+    return words.length == 12 && words.every((String word) => wordlist.contains(word));
+  }
+
+  void _populateTextFields(List<String> words) {
+    for (int i = 0; i < words.length; i++) {
+      textEditingControllers[i].text = words[i];
+    }
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/paste_backup_phrase_button.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/paste_backup_phrase_button.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:misty_breez/utils/constants/app_constants.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+class PasteBackupPhraseButton extends StatefulWidget {
+  final List<TextEditingController> textEditingControllers;
+
+  const PasteBackupPhraseButton({
+    required this.textEditingControllers,
+    super.key,
+  });
+
+  @override
+  State<PasteBackupPhraseButton> createState() => _PasteBackupPhraseButtonState();
+}
+
+class _PasteBackupPhraseButtonState extends State<PasteBackupPhraseButton> {
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(
+        Icons.content_paste_outlined,
+        color: Colors.white,
+        size: 20,
+      ),
+      tooltip: 'Paste Backup Phrase',
+      onPressed: _pasteBackupPhrase,
+    );
+  }
+
+  void _pasteBackupPhrase() async {
+    try {
+      final ClipboardData? clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      final String? clipboardText = clipboardData?.text?.trim();
+
+      if (clipboardText == null) {
+        throw 'Clipboard is empty.';
+      }
+
+      final List<String> words = _extractWords(clipboardText);
+
+      if (_isValidMnemonic(words)) {
+        _populateTextFields(words);
+      } else {
+        throw 'Clipboard has invalid backup phrase.';
+      }
+    } catch (e) {
+      if (mounted) {
+        showFlushbar(context, message: e.toString());
+      }
+    }
+  }
+
+  List<String> _extractWords(String text) {
+    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
+  }
+
+  bool _isValidMnemonic(List<String> words) {
+    return words.length == 12 && words.every((String word) => wordlist.contains(word));
+  }
+
+  void _populateTextFields(List<String> words) {
+    for (int i = 0; i < words.length; i++) {
+      widget.textEditingControllers[i].text = words[i];
+    }
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+}

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/paste_backup_phrase_button.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/paste_backup_phrase_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:misty_breez/utils/constants/app_constants.dart';
+import 'package:misty_breez/utils/utils.dart';
 import 'package:misty_breez/widgets/widgets.dart';
 
 class PasteBackupPhraseButton extends StatefulWidget {
@@ -32,17 +32,11 @@ class _PasteBackupPhraseButtonState extends State<PasteBackupPhraseButton> {
   void _pasteBackupPhrase() async {
     try {
       final ClipboardData? clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
-      final String? clipboardText = clipboardData?.text?.trim();
-
-      if (clipboardText == null) {
-        throw 'Clipboard is empty.';
-      }
-
-      final List<String> words = _extractWords(clipboardText);
-
-      if (_isValidMnemonic(words)) {
-        _populateTextFields(words);
-      } else {
+      final bool success = MnemonicUtils.tryPopulateTextFieldsFromText(
+        clipboardData?.text,
+        widget.textEditingControllers,
+      );
+      if (!success) {
         throw 'Clipboard has invalid backup phrase.';
       }
     } catch (e) {
@@ -50,20 +44,5 @@ class _PasteBackupPhraseButtonState extends State<PasteBackupPhraseButton> {
         showFlushbar(context, message: e.toString());
       }
     }
-  }
-
-  List<String> _extractWords(String text) {
-    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
-  }
-
-  bool _isValidMnemonic(List<String> words) {
-    return words.length == 12 && words.every((String word) => wordlist.contains(word));
-  }
-
-  void _populateTextFields(List<String> words) {
-    for (int i = 0; i < words.length; i++) {
-      widget.textEditingControllers[i].text = words[i];
-    }
-    FocusManager.instance.primaryFocus?.unfocus();
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -155,5 +155,6 @@ class RestoreFormState extends State<RestoreForm> {
     for (int i = 0; i < words.length; i++) {
       widget.textEditingControllers[i].text = words[i];
     }
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -66,6 +66,7 @@ class RestoreFormState extends State<RestoreForm> {
                   labelText: '${itemIndex + 1}',
                 ),
                 style: FieldTextStyle.textStyle,
+                onChanged: _processPotentialBackupPhrase,
               ),
               autovalidateMode: _autoValidateMode,
               validator: (String? text) => _onValidate(context, text!),
@@ -130,6 +131,29 @@ class RestoreFormState extends State<RestoreForm> {
     } else {
       final List<String> suggestionList = wordlist.where((String item) => item.startsWith(pattern)).toList();
       return suggestionList.isNotEmpty ? suggestionList : List<String>.empty();
+    }
+  }
+
+  void _processPotentialBackupPhrase(String? backupPhrase) {
+    if (backupPhrase != null && backupPhrase.contains(' ')) {
+      final List<String> words = _extractWords(backupPhrase);
+      if (_isValidMnemonic(words)) {
+        _populateTextFields(words);
+      }
+    }
+  }
+
+  List<String> _extractWords(String text) {
+    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
+  }
+
+  bool _isValidMnemonic(List<String> words) {
+    return words.length == 12 && words.every((String word) => wordlist.contains(word));
+  }
+
+  void _populateTextFields(List<String> words) {
+    for (int i = 0; i < words.length; i++) {
+      widget.textEditingControllers[i].text = words[i];
     }
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -135,26 +135,9 @@ class RestoreFormState extends State<RestoreForm> {
   }
 
   void _processPotentialBackupPhrase(String? backupPhrase) {
-    if (backupPhrase != null && backupPhrase.contains(' ')) {
-      final List<String> words = _extractWords(backupPhrase);
-      if (_isValidMnemonic(words)) {
-        _populateTextFields(words);
-      }
-    }
-  }
-
-  List<String> _extractWords(String text) {
-    return text.split(RegExp(r'\s+')).map((String word) => word.toLowerCase().trim()).toList();
-  }
-
-  bool _isValidMnemonic(List<String> words) {
-    return words.length == 12 && words.every((String word) => wordlist.contains(word));
-  }
-
-  void _populateTextFields(List<String> words) {
-    for (int i = 0; i < words.length; i++) {
-      widget.textEditingControllers[i].text = words[i];
-    }
-    FocusManager.instance.primaryFocus?.unfocus();
+    MnemonicUtils.tryPopulateTextFieldsFromText(
+      backupPhrase,
+      widget.textEditingControllers,
+    );
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
@@ -41,9 +41,10 @@ class RestoreFormPageState extends State<RestoreFormPage> {
     super.initState();
     _autoValidateMode = AutovalidateMode.disabled;
     _hasError = false;
-    for (int i = 0; i < widget.textEditingControllers.length && i < widget.initialWords.length; i++) {
-      widget.textEditingControllers[i].text = widget.initialWords[i];
-    }
+    MnemonicUtils.tryPopulateTextFieldsFromText(
+      widget.initialWords.join(' '),
+      widget.textEditingControllers,
+    );
   }
 
   @override

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
@@ -14,11 +14,13 @@ class RestoreFormPage extends StatefulWidget {
   final VoidCallback changePage;
   final List<String> initialWords;
   final String lastErrorMessage;
+  final List<TextEditingController> textEditingControllers;
 
   const RestoreFormPage({
     required this.currentPage,
     required this.lastPage,
     required this.changePage,
+    required this.textEditingControllers,
     this.lastErrorMessage = '',
     super.key,
     this.initialWords = const <String>[],
@@ -31,9 +33,6 @@ class RestoreFormPage extends StatefulWidget {
 class RestoreFormPageState extends State<RestoreFormPage> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
-  List<TextEditingController> textEditingControllers =
-      List<TextEditingController>.generate(12, (_) => TextEditingController());
-
   late AutovalidateMode _autoValidateMode;
   late bool _hasError;
 
@@ -42,8 +41,8 @@ class RestoreFormPageState extends State<RestoreFormPage> {
     super.initState();
     _autoValidateMode = AutovalidateMode.disabled;
     _hasError = false;
-    for (int i = 0; i < textEditingControllers.length && i < widget.initialWords.length; i++) {
-      textEditingControllers[i].text = widget.initialWords[i];
+    for (int i = 0; i < widget.textEditingControllers.length && i < widget.initialWords.length; i++) {
+      widget.textEditingControllers[i].text = widget.initialWords[i];
     }
   }
 
@@ -57,7 +56,7 @@ class RestoreFormPageState extends State<RestoreFormPage> {
           formKey: _formKey,
           currentPage: widget.currentPage,
           lastPage: widget.lastPage,
-          textEditingControllers: textEditingControllers,
+          textEditingControllers: widget.textEditingControllers,
           autoValidateMode: _autoValidateMode,
         ),
         if ((_hasError || widget.lastErrorMessage.isNotEmpty) && widget.currentPage == 2) ...<Widget>[
@@ -103,7 +102,7 @@ class RestoreFormPageState extends State<RestoreFormPage> {
 
   Future<void> _validateMnemonics() async {
     final BreezTranslations texts = context.texts();
-    final String mnemonic = textEditingControllers
+    final String mnemonic = widget.textEditingControllers
         .map((TextEditingController controller) => controller.text.toLowerCase().trim())
         .toList()
         .join(' ');

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/widgets.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/widgets.dart
@@ -1,5 +1,6 @@
 export 'mnemonic_item.dart';
 export 'mnemonic_seed_list.dart';
+export 'paste_backup_phrase_button.dart';
 export 'restore_form.dart';
 export 'restore_form_page.dart';
 export 'verify_form.dart';

--- a/lib/services/wallet_archive_service.dart
+++ b/lib/services/wallet_archive_service.dart
@@ -102,7 +102,7 @@ class WalletArchiveService {
       encoder.create(zipFilePath);
 
       await Future.wait(<Future<void>>[
-        _addCredentialsToZip(encoder),
+        _addCredentialsToZip(encoder, fingerprint),
         _addStorageFileToZip(encoder, fingerprint),
       ]);
 
@@ -124,11 +124,11 @@ class WalletArchiveService {
   /// Adds credential files to the zip archive
   ///
   /// [encoder] The zip encoder to which files will be added
-  static Future<void> _addCredentialsToZip(ZipFileEncoder encoder) async {
+  static Future<void> _addCredentialsToZip(ZipFileEncoder encoder, String? fingerprint) async {
     final CredentialsManager credentialsManager = ServiceInjector().credentialsManager;
 
     try {
-      final List<File> credentialFiles = await credentialsManager.exportCredentials();
+      final List<File> credentialFiles = await credentialsManager.exportCredentials(fingerprint: fingerprint);
       _logger.info('Adding ${credentialFiles.length} credential files to zip');
 
       for (File file in credentialFiles) {

--- a/lib/utils/mnemonic/mnemonic_utils.dart
+++ b/lib/utils/mnemonic/mnemonic_utils.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:misty_breez/utils/constants/app_constants.dart';
+
+class MnemonicUtils {
+  static const int wordCount = 12;
+
+  static bool tryPopulateTextFieldsFromText(
+    String? text,
+    List<TextEditingController> controllers,
+  ) {
+    if (text == null || !text.contains(' ')) {
+      return false;
+    }
+
+    final List<String> words = text.trim().toLowerCase().split(RegExp(r'\s+'));
+
+    if (words.length != wordCount || !words.every(wordlist.contains)) {
+      return false;
+    }
+
+    for (int i = 0; i < wordCount; i++) {
+      controllers[i].text = words[i];
+    }
+
+    FocusManager.instance.primaryFocus?.unfocus();
+    return true;
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -8,5 +8,6 @@ export 'date/breez_date_utils.dart';
 export 'enum/enum_utils.dart';
 export 'exceptions/exception_handler.dart';
 export 'json_parsing/json_parsing.dart';
+export 'mnemonic/mnemonic_utils.dart';
 export 'payments/payment_validator.dart';
 export 'ui/overlay_manager.dart';

--- a/packages/credentials_manager/lib/src/credentials_manager.dart
+++ b/packages/credentials_manager/lib/src/credentials_manager.dart
@@ -89,7 +89,7 @@ class CredentialsManager {
     try {
       final Directory tempDir = await getTemporaryDirectory();
       final Directory keysDir = tempDir.createTempSync('keys');
-      final File mnemonicFile = await File('${keysDir.path}/phrase').create(recursive: true);
+      final File mnemonicFile = await File('${keysDir.path}/phrase.txt').create(recursive: true);
       final String? mnemonic = await restoreMnemonic();
       if (mnemonic != null) {
         mnemonicFile.writeAsString(mnemonic);

--- a/packages/credentials_manager/lib/src/credentials_manager.dart
+++ b/packages/credentials_manager/lib/src/credentials_manager.dart
@@ -85,11 +85,14 @@ class CredentialsManager {
     await keyChain.write(accountMnemonic, mnemonic);
   }
 
-  Future<List<File>> exportCredentials() async {
+  Future<List<File>> exportCredentials({String? fingerprint}) async {
     try {
       final Directory tempDir = await getTemporaryDirectory();
       final Directory keysDir = tempDir.createTempSync('keys');
-      final File mnemonicFile = await File('${keysDir.path}/phrase.txt').create(recursive: true);
+      final String fileName = fingerprint != null && fingerprint.isNotEmpty
+          ? 'misty-breez.$fingerprint.backup-phrase.txt'
+          : 'misty-breez.backup-phrase.txt';
+      final File mnemonicFile = await File('${keysDir.path}/$fileName').create(recursive: true);
       final String? mnemonic = await restoreMnemonic();
       if (mnemonic != null) {
         mnemonicFile.writeAsString(mnemonic);


### PR DESCRIPTION
Fixes #540

This PR adds users the option to paste mnemonics on restore flow & adjusts backup phase file for usability

#### Changelist:
- A paste icon is added to top right of AppBar on restore page. This button will check if the clipboard has 12 words that are valid. This button will display errors via a flushbar.
- Pasting a 12 word, valid mnemonic on an empty input field, or pasting by overriding it's value will fill all the form. Errors won't be displayed, and the default paste behavior will take precedence on other cases.
- Backup phrase file now contains fingerpring information & the correct file extension. It's renamed to `misty-breez.$fingerprint.backup-phrase.txt`.
- `Keys` option to export keys on Dev page will only share the backup phrase file itself instead of the `.zip` that also included the wallet db file on release mode.