### PR TITLE
feature: allow users to drain via bolt 12 offers

### DIFF
--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -68,15 +68,10 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
   }
 
   Future<PrepareSendResponse> prepareSendPayment({
-    required String destination,
-    BigInt? amountSat,
+    required PrepareSendRequest req,
   }) async {
-    _logger.info('prepareSendPayment\nPreparing send payment for destination: $destination');
+    _logger.info('prepareSendPayment\nPreparing send payment for destination: ${req.destination}');
     try {
-      // TODO(erdemyerebasmaz): Handle the drain option for PrepareSendRequest
-      final PayAmount_Bitcoin? payAmount =
-          amountSat != null ? PayAmount_Bitcoin(receiverAmountSat: amountSat) : null;
-      final PrepareSendRequest req = PrepareSendRequest(destination: destination, amount: payAmount);
       return await _breezSdkLiquid.instance!.prepareSendPayment(req: req);
     } catch (e) {
       _logger.severe('prepareSendPayment\nError preparing send payment', e);

--- a/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
@@ -99,10 +99,16 @@ class LnPaymentPageState extends State<LnPaymentPage> {
         errorMessage = '';
       });
 
-      final PrepareSendResponse response = await paymentsCubit.prepareSendPayment(
-        destination: widget.lnInvoice.bolt11,
-        amountSat: BigInt.from(amountSat),
+      final PayAmount payAmount = PayAmount_Bitcoin(
+        receiverAmountSat: BigInt.from(amountSat),
       );
+
+      final PrepareSendRequest req = PrepareSendRequest(
+        destination: widget.lnInvoice.bolt11,
+        amount: payAmount,
+      );
+
+      final PrepareSendResponse response = await paymentsCubit.prepareSendPayment(req: req);
       setState(() {
         _prepareResponse = response;
       });

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -28,6 +28,7 @@ class LnOfferPaymentArguments {
 
 class LnOfferPaymentPage extends StatefulWidget {
   final LnOfferPaymentArguments lnOfferPaymentArguments;
+  final bool isConfirmation;
   final bool isDrain;
   final int? amountSat;
   final String? comment;
@@ -37,6 +38,7 @@ class LnOfferPaymentPage extends StatefulWidget {
 
   const LnOfferPaymentPage({
     required this.lnOfferPaymentArguments,
+    this.isConfirmation = false,
     this.isDrain = false,
     this.amountSat,
     this.comment,
@@ -78,7 +80,6 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
     _isFixedAmount = widget.amountSat != null;
     _isDrain = widget.isDrain;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      _updateFormFields();
       await _fetchLightningLimits();
     });
   }
@@ -115,37 +116,38 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
   }
 
   Future<void> _handleLightningPaymentLimitsResponse() async {
-    if (_isFixedAmount) {
-      final String? errorMessage = validatePayment(
-        amountSat: widget.amountSat!,
-        throwError: true,
-      );
-      if (errorMessage == null) {
-        await _prepareSendPayment(widget.amountSat!);
-        if (mounted && _isDrain) {
-          final AccountCubit accountCubit = context.read<AccountCubit>();
-          final AccountState accountState = accountCubit.state;
-          final int balance = accountState.walletInfo!.balanceSat.toInt();
-          final int feesSat = _prepareResponse?.feesSat?.toInt() ?? 0;
+    final int amountSat = widget.amountSat ?? effectiveMinSat;
+    _updateFormFields(amountSat: amountSat);
+    final String? errorMessage = validatePayment(
+      amountSat: amountSat,
+      throwError: true,
+    );
+    if (errorMessage == null && _isFixedAmount) {
+      await _prepareSendPayment(amountSat);
+      if (mounted && _isDrain) {
+        final AccountCubit accountCubit = context.read<AccountCubit>();
+        final AccountState accountState = accountCubit.state;
+        final int balance = accountState.walletInfo!.balanceSat.toInt();
+        final int feesSat = _prepareResponse?.feesSat?.toInt() ?? 0;
 
-          _updateFormFields(amountSat: balance - feesSat);
-        }
+        _updateFormFields(amountSat: balance - feesSat);
       }
     }
   }
 
-  void _updateFormFields({int? amountSat}) {
+  void _updateFormFields({
+    required int amountSat,
+  }) {
     final CurrencyCubit currencyCubit = context.read<CurrencyCubit>();
     final CurrencyState currencyState = currencyCubit.state;
 
-    if (amountSat != null) {
+    setState(() {
       _amountController.text = currencyState.bitcoinCurrency.format(
         amountSat,
         includeDisplayName: false,
       );
-    }
-
-    _descriptionController.text = widget.comment ?? '';
+      _descriptionController.text = widget.comment ?? '';
+    });
   }
 
   Future<void> _prepareSendPayment(int amountSat) async {
@@ -201,11 +203,16 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
     final BreezTranslations texts = context.texts();
     final ThemeData themeData = Theme.of(context);
 
+    final String? issuer = widget.lnOfferPaymentArguments.lnOffer.issuer;
+    final bool hasIssuer = issuer != null && issuer.isNotEmpty;
+
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
         leading: const back_button.BackButton(),
-        title: Text(texts.ln_payment_send_payment_title),
+        title: Text(
+          hasIssuer ? texts.lnurl_fetch_invoice_pay_to_payee(issuer) : texts.ln_payment_send_payment_title,
+        ),
       ),
       body: BlocBuilder<CurrencyCubit, CurrencyState>(
         builder: (BuildContext context, CurrencyState currencyState) {
@@ -223,6 +230,11 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
             );
           }
 
+          final int amountSat = currencyState.bitcoinCurrency.parse(_amountController.text);
+
+          final bool offerHasDescription = widget.lnOfferPaymentArguments.lnOffer.description != null &&
+              widget.lnOfferPaymentArguments.lnOffer.description!.isNotEmpty;
+
           return Form(
             key: _formKey,
             child: Padding(
@@ -235,8 +247,8 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                       Padding(
                         padding: const EdgeInsets.only(bottom: 32),
                         child: LnPaymentHeader(
-                          payeeName: widget.lnOfferPaymentArguments.lnOffer.issuer ?? '',
-                          totalAmount: widget.amountSat! + (_prepareResponse?.feesSat?.toInt() ?? 0),
+                          payeeName: issuer ?? '',
+                          totalAmount: amountSat,
                           errorMessage: errorMessage,
                         ),
                       ),
@@ -256,6 +268,11 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                       ),
                       child: Column(
                         children: <Widget>[
+                          if (!_isFixedAmount && offerHasDescription) ...<Widget>[
+                            LnPaymentDescription(
+                              metadataText: widget.lnOfferPaymentArguments.lnOffer.description!,
+                            ),
+                          ],
                           if (!_isFixedAmount) ...<Widget>[
                             Column(
                               children: <Widget>[
@@ -398,13 +415,10 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                             Padding(
                               padding: const EdgeInsets.symmetric(vertical: 8.0),
                               child: LnPaymentAmount(
-                                amountSat: widget.amountSat!,
+                                amountSat: amountSat,
                                 hasError: !_isFormEnabled || errorMessage.isNotEmpty,
                               ),
                             ),
-                          ],
-                          if (_prepareResponse != null &&
-                              _prepareResponse!.feesSat?.toInt() != 0) ...<Widget>[
                             Padding(
                               padding: const EdgeInsets.symmetric(vertical: 8.0),
                               child: LnPaymentFee(
@@ -412,19 +426,21 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                                 feesSat: errorMessage.isEmpty ? _prepareResponse?.feesSat?.toInt() : null,
                               ),
                             ),
-                          ],
-                          if (widget.lnOfferPaymentArguments.lnOffer.description != null &&
-                              widget.lnOfferPaymentArguments.lnOffer.description!.isNotEmpty) ...<Widget>[
-                            Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 8.0),
-                              child: LnPaymentDescription(
-                                metadataText: widget.lnOfferPaymentArguments.lnOffer.description!,
+                            if (offerHasDescription) ...<Widget>[
+                              Padding(
+                                padding: _prepareResponse == null
+                                    ? EdgeInsets.zero
+                                    : const EdgeInsets.only(top: 8.0),
+                                child: LnPaymentDescription(
+                                  metadataText: widget.lnOfferPaymentArguments.lnOffer.description!,
+                                ),
                               ),
-                            ),
+                            ],
                           ],
-                          if (widget.comment?.isNotEmpty ?? false) ...<Widget>[
+                          if (widget.isConfirmation && _descriptionController.text.isNotEmpty ||
+                              !widget.isConfirmation && (widget.comment?.isNotEmpty ?? false)) ...<Widget>[
                             LnUrlPaymentComment(
-                              isConfirmation: false,
+                              isConfirmation: widget.isConfirmation,
                               enabled: _isFormEnabled,
                               descriptionController: _descriptionController,
                               descriptionFocusNode: _descriptionFocusNode,
@@ -505,7 +521,7 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
 
     final int effectiveMaxSat = _lightningLimits!.send.maxSat.toInt();
 
-    if (!_isFixedAmount && effectiveMinSat == effectiveMaxSat) {
+    if (!widget.isConfirmation && !_isFixedAmount && effectiveMinSat == effectiveMaxSat) {
       final int minNetworkLimit = _lightningLimits!.send.minSat.toInt();
       final int maxNetworkLimit = _lightningLimits!.send.maxSat.toInt();
       final String minNetworkLimitFormatted = currencyState.bitcoinCurrency.format(minNetworkLimit);
@@ -568,6 +584,7 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
         builder: (_) => BlocProvider<PaymentLimitsCubit>(
           create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
           child: LnOfferPaymentPage(
+            isConfirmation: true,
             isDrain: _isDrain,
             amountSat: amountSat,
             lnOfferPaymentArguments: widget.lnOfferPaymentArguments,

--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -159,11 +159,13 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
     final CurrencyCubit currencyCubit = context.read<CurrencyCubit>();
     final CurrencyState currencyState = currencyCubit.state;
 
-    _amountController.text = currencyState.bitcoinCurrency.format(
-      amountSat,
-      includeDisplayName: false,
-    );
-    _descriptionController.text = widget.comment ?? '';
+    setState(() {
+      _amountController.text = currencyState.bitcoinCurrency.format(
+        amountSat,
+        includeDisplayName: false,
+      );
+      _descriptionController.text = widget.comment ?? '';
+    });
   }
 
   Future<void> _prepareLnUrlPayment(int amountSat) async {
@@ -521,29 +523,37 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                     _fetchLightningLimits();
                   },
                 )
-              : !_isFixedAmount
+              : !_isFormEnabled || _isFixedAmount && errorMessage.isNotEmpty
                   ? SingleButtonBottomBar(
                       stickToBottom: true,
-                      text: texts.lnurl_payment_page_action_next,
-                      enabled: _isFormEnabled,
-                      onPressed: () async {
-                        if (_formKey.currentState?.validate() ?? false) {
-                          final FocusScopeNode currentFocus = FocusScope.of(context);
-                          if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
-                            FocusManager.instance.primaryFocus?.unfocus();
-                          }
-                          await _openConfirmationPage();
-                        }
+                      text: texts.ln_payment_action_close,
+                      onPressed: () {
+                        Navigator.of(context).pop();
                       },
                     )
-                  : SingleButtonBottomBar(
-                      stickToBottom: true,
-                      enabled: _prepareResponse != null && errorMessage.isEmpty,
-                      text: texts.ln_payment_action_send,
-                      onPressed: () async {
-                        Navigator.pop(context, _prepareResponse);
-                      },
-                    ),
+                  : !_isFixedAmount
+                      ? SingleButtonBottomBar(
+                          stickToBottom: true,
+                          text: texts.lnurl_payment_page_action_next,
+                          enabled: _isFormEnabled,
+                          onPressed: () async {
+                            if (_formKey.currentState?.validate() ?? false) {
+                              final FocusScopeNode currentFocus = FocusScope.of(context);
+                              if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                                FocusManager.instance.primaryFocus?.unfocus();
+                              }
+                              await _openConfirmationPage();
+                            }
+                          },
+                        )
+                      : SingleButtonBottomBar(
+                          stickToBottom: true,
+                          enabled: _prepareResponse != null && errorMessage.isEmpty,
+                          text: texts.ln_payment_action_send,
+                          onPressed: () async {
+                            Navigator.pop(context, _prepareResponse);
+                          },
+                        ),
     );
   }
 


### PR DESCRIPTION
Fixes #544

This PR allow users to drain their wallet via Bolt12 offers.

### Other changes:
- Made several changes to align LN Offer page with the updated LNURL pay page.
- Displayed amount takes fees into consideration on confirmation page when draining,
- "Use All Funds" switch behavior is made consistent with other pages:
  - When reset, the amount field is populated with minimum limit.