### PR TITLE
Apply "Expose bitcoin destination address #928" changes

### DIFF
--- a/lib/models/extensions/payment_details_extension.dart
+++ b/lib/models/extensions/payment_details_extension.dart
@@ -101,8 +101,8 @@ extension PaymentDetailsFromJson on PaymentDetails {
       case 'bitcoin':
         return PaymentDetails.bitcoin(
           swapId: json['swapId'] as String,
-          description: json['description'] as String,
           bitcoinAddress: json['bitcoinAddress'] as String,
+          description: json['description'] as String,
           autoAcceptedFees: json['autoAcceptedFees'] as bool,
           liquidExpirationBlockheight: json['liquidExpirationBlockheight'] as int?,
           bitcoinExpirationBlockheight: json['bitcoinExpirationBlockheight'] as int?,
@@ -151,6 +151,7 @@ extension PaymentDetailsExtension on PaymentDetails {
               bitcoin: (PaymentDetails_Bitcoin o) {
                 final PaymentDetails_Bitcoin current = this as PaymentDetails_Bitcoin;
                 return o.swapId == current.swapId &&
+                    o.bitcoinAddress == current.bitcoinAddress &&
                     o.description == current.description &&
                     o.autoAcceptedFees == current.autoAcceptedFees &&
                     o.liquidExpirationBlockheight == current.liquidExpirationBlockheight &&
@@ -190,6 +191,7 @@ extension PaymentDetailsHashCode on PaymentDetails {
       ),
       bitcoin: (PaymentDetails_Bitcoin o) => Object.hash(
         o.swapId,
+        o.bitcoinAddress,
         o.description,
         o.autoAcceptedFees,
         o.liquidExpirationBlockheight,
@@ -274,6 +276,7 @@ extension PaymentDetailsFormatter on PaymentDetails {
       final PaymentDetails_Bitcoin details = this as PaymentDetails_Bitcoin;
       return 'PaymentDetails_Bitcoin('
           'swapId: ${details.swapId}, '
+          'bitcoinAddress: ${details.bitcoinAddress}, '
           'description: ${details.description}, '
           'autoAcceptedFees: ${details.autoAcceptedFees}, '
           'liquidExpirationBlockheight: ${details.liquidExpirationBlockheight ?? "N/A"}, '


### PR DESCRIPTION
This PR applies structural. changes from: * https://github.com/breez/breez-sdk-liquid/pull/928

#### Changelist:
- Adds `bitcoinAddress` to `PaymentDetails.bitcoin`'s `toJson`/`fromJson` extensions.

This field will later be utilized in scope of:
- #554