### PR TITLE
app_link: setup 'mistybreez' as an app link

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,4 +1,6 @@
+#--------------------------------------
 # Preserve Flutter Wrapper code
+#--------------------------------------
 -keep class io.flutter.app.** { *; }
 -keep class io.flutter.plugin.**  { *; }
 -keep class io.flutter.util.**  { *; }
@@ -7,20 +9,41 @@
 -keep class io.flutter.plugins.**  { *; }
 -keep class io.flutter.plugin.editing.** { *; }
 
- # Tinylog
+#--------------------------------------
+# Tinylog
+#--------------------------------------
 -keepnames interface org.tinylog.**
 -keepnames class * implements org.tinylog.**
 -keepclassmembers class * implements org.tinylog.** { <init>(...); }
 
+#--------------------------------------
 # JNA
+#--------------------------------------
 -keep class com.sun.jna.** { *; }
 -keep class * implements com.sun.jna.** { *; }
 
+#--------------------------------------
 # To ignore minifyEnabled: true error
 # https://github.com/flutter/flutter/issues/19250
 # https://github.com/flutter/flutter/issues/37441
+#--------------------------------------
 -dontwarn io.flutter.embedding.**
 -ignorewarnings
 -keep class * {
     public private *;
 }
+
+#--------------------------------------
+# Android App Links & MicroG SafeParcelable
+#--------------------------------------
+-keep public class * extends org.microg.safeparcel.AutoSafeParcelable {
+    @org.microg.safeparcel.SafeParcelable.Field *;
+    @org.microg.safeparcel.SafeParceled *;
+}
+
+# Keep asInterface method cause it's accessed from SafeParcel
+-keepattributes InnerClasses
+-keepclassmembers interface * extends android.os.IInterface {
+    public static class *;
+}
+-keep public class * extends android.os.Binder { public static *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <!-- Deep links -->
-            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -110,6 +110,12 @@
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="mistybreez"/>
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:host="breez.link"/>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -472,9 +472,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -489,9 +493,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -40,6 +40,8 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
 			<key>CFBundleURLName</key>
 			<string>lightning.link</string>
 			<key>CFBundleURLSchemes</key>
@@ -62,6 +64,16 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>breez</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.breez.misty</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mistybreez</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,7 +68,7 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
+			<string>Viewer</string>
 			<key>CFBundleURLName</key>
 			<string>com.breez.misty</string>
 			<key>CFBundleURLSchemes</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,7 +70,7 @@
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>FlutterDeepLinkingEnabled</key>
-	<true/>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/packages/lightning_links/lib/src/lightning_links.dart
+++ b/packages/lightning_links/lib/src/lightning_links.dart
@@ -20,6 +20,7 @@ class LightningLinksService {
     Rx.merge(<Stream<String?>>[
       appLinks.getInitialLinkString().asStream(),
       appLinks.stringLinkStream,
+      appLinks.uriLinkStream.map((Uri uri) => uri.toString()),
     ]).where((String? link) => _isValidLink(link)).listen((String? link) => _handleLink(link));
   }
 
@@ -28,6 +29,7 @@ class LightningLinksService {
       return false;
     }
     const List<String> validPrefixes = <String>[
+      'mistybreez:',
       'breez:',
       'lightning:',
       'lnurlc:',


### PR DESCRIPTION
This PR adds `mistybreez` scheme to list of valid app links.

This scheme will be used post check-out on Buy Bitcoin flows to redirect the user back to the app.

### Changelist:
- Setup `mistybreez` as an app link 
  - Listen on `uriLinkStream` as well
  - Added platform specific configurations
    - misc: organized proguard rules into sections
- `app_links` requirement: disable default Flutter deep linking 
  - From Flutter 3.24, Flutter deep linking must be disabled explicitly.
