### PR TITLE
fix: hide identical txID and claimTxID in transaction details screen

### DIFF
--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -214,7 +214,7 @@ class PaymentDetailsSheet extends StatelessWidget {
                                 unblindingData: paymentData.unblindingData,
                               ),
                             ],
-                            if (claimTxId.isNotEmpty) ...<Widget>[
+                            if (claimTxId.isNotEmpty && claimTxId != paymentData.txId) ...<Widget>[
                               PaymentDetailsSheetTxId(
                                 txId: claimTxId,
                                 unblindingData: paymentData.unblindingData,


### PR DESCRIPTION
Fixes #575