### PR TITLE
feat: add warning for amountless BTC address generation errors

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -49,7 +49,7 @@ Route<dynamic>? onGenerateRoute({
                   return FadeInRoute<void>(
                     builder: (BuildContext context) => BlocProvider<PaymentLimitsCubit>(
                       create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
-                      child: const ReceivePaymentPage(),
+                      child: ReceivePaymentPage(initialPageIndex: settings.arguments as int?),
                     ),
                     settings: settings,
                   );

--- a/lib/cubit/amountless_btc/amountless_btc_cubit.dart
+++ b/lib/cubit/amountless_btc/amountless_btc_cubit.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
+import 'package:misty_breez/models/models.dart';
 
 export 'amountless_btc_state.dart';
 
@@ -50,5 +51,142 @@ class AmountlessBtcCubit extends Cubit<AmountlessBtcState> {
       _logger.severe('Failed to generate amountless BTC address', e);
       emit(AmountlessBtcState(error: e));
     }
+  }
+
+  /// Lists payments waiting for fee acceptance
+  Future<void> loadPaymentsWaitingFeeAcceptance() async {
+    try {
+      _logger.info('Loading payments waiting for fee acceptance');
+
+      emit(state.copyWith(isLoadingPayments: true));
+
+      const ListPaymentsRequest request = ListPaymentsRequest(
+        filters: <PaymentType>[PaymentType.receive],
+        states: <PaymentState>[PaymentState.waitingFeeAcceptance],
+      );
+
+      final List<Payment> paymentsList = await _breezSdkLiquid.instance!.listPayments(req: request);
+
+      _logger.info('Found ${paymentsList.length} payments waiting for fee acceptance');
+
+      emit(state.copyWith(paymentsWaitingFeeAcceptance: paymentsList, isLoadingPayments: false));
+    } catch (e) {
+      _logger.severe('Failed to load payments waiting for fee acceptance', e);
+      emit(state.copyWith(error: e, isLoadingPayments: false));
+    }
+  }
+
+  /// Fetches payment proposed fees for a specific payment
+  Future<void> fetchPaymentProposedFees(String swapId) async {
+    try {
+      _logger.info('Fetching payment proposed fees for swap ID: $swapId');
+
+      emit(state.copyWith(isLoadingFees: true));
+
+      final FetchPaymentProposedFeesRequest request = FetchPaymentProposedFeesRequest(swapId: swapId);
+
+      final FetchPaymentProposedFeesResponse response = await _breezSdkLiquid.instance!
+          .fetchPaymentProposedFees(req: request);
+
+      _logger.info(
+        'Successfully fetched payment proposed fees for $swapId: '
+        'Payer amount: ${response.payerAmountSat} sat, '
+        'Fees: ${response.feesSat} sat, '
+        'Receiver amount: ${response.receiverAmountSat} sat',
+      );
+
+      final Map<String, FetchPaymentProposedFeesResponse> updatedProposedFeesMap =
+          Map<String, FetchPaymentProposedFeesResponse>.from(state.proposedFeesMap);
+      updatedProposedFeesMap[swapId] = response;
+
+      emit(state.copyWith(proposedFeesMap: updatedProposedFeesMap, isLoadingFees: false));
+    } catch (e) {
+      _logger.severe('Failed to fetch payment proposed fees for $swapId', e);
+      emit(state.copyWith(error: e, isLoadingFees: false));
+    }
+  }
+
+  /// Accepts the payment proposed fees for a specific payment
+  Future<void> acceptPaymentProposedFees(String swapId) async {
+    final FetchPaymentProposedFeesResponse? proposedFees = state.proposedFeesMap[swapId];
+    if (proposedFees == null) {
+      _logger.warning('Cannot accept payment proposed fees for $swapId: no proposed fees available');
+      emit(state.copyWith(error: 'No proposed fees available for swap ID $swapId'));
+      return;
+    }
+
+    try {
+      _logger.info('Accepting payment proposed fees for swap ID: $swapId');
+
+      emit(state.copyWith(isLoading: true));
+
+      final AcceptPaymentProposedFeesRequest request = AcceptPaymentProposedFeesRequest(
+        response: proposedFees,
+      );
+
+      await _breezSdkLiquid.instance!.acceptPaymentProposedFees(req: request);
+
+      _logger.info('Successfully accepted payment proposed fees for $swapId');
+
+      // Remove the payment from waiting list and proposed fees map
+      final List<Payment> updatedPayments = state.paymentsWaitingFeeAcceptance.where((Payment payment) {
+        final String paymentSwapId = payment.details.map(
+          bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
+          lightning: (PaymentDetails_Lightning details) => details.swapId,
+          orElse: () => '',
+        );
+        return paymentSwapId != swapId;
+      }).toList();
+
+      final Map<String, FetchPaymentProposedFeesResponse> updatedProposedFeesMap =
+          Map<String, FetchPaymentProposedFeesResponse>.from(state.proposedFeesMap);
+      updatedProposedFeesMap.remove(swapId);
+
+      emit(
+        state.copyWith(
+          paymentsWaitingFeeAcceptance: updatedPayments,
+          proposedFeesMap: updatedProposedFeesMap,
+          isLoading: false,
+        ),
+      );
+    } catch (e) {
+      _logger.severe('Failed to accept payment proposed fees for $swapId', e);
+      emit(state.copyWith(error: e, isLoading: false));
+    }
+  }
+
+  /// Rejects the payment proposed fees for a specific payment
+  void rejectPaymentProposedFees(String swapId) {
+    _logger.info('Rejecting payment proposed fees for swap ID: $swapId');
+
+    final Map<String, FetchPaymentProposedFeesResponse> updatedProposedFeesMap =
+        Map<String, FetchPaymentProposedFeesResponse>.from(state.proposedFeesMap);
+    updatedProposedFeesMap.remove(swapId);
+
+    emit(state.copyWith(proposedFeesMap: updatedProposedFeesMap));
+  }
+
+  /// Gets proposed fees for a specific swap ID
+  FetchPaymentProposedFeesResponse? getProposedFeesForSwap(String swapId) {
+    return state.proposedFeesMap[swapId];
+  }
+
+  /// Resets the entire state to initial
+  void reset() {
+    _logger.info('Resetting AmountlessBtcCubit state');
+    emit(AmountlessBtcState.initial());
+  }
+
+  /// Clears only the fees-related state while keeping the address
+  void clearFeesState() {
+    _logger.info('Clearing fees state');
+    emit(
+      state.copyWith(
+        paymentsWaitingFeeAcceptance: <Payment>[],
+        proposedFeesMap: <String, FetchPaymentProposedFeesResponse>{},
+        isLoadingPayments: false,
+        isLoadingFees: false,
+      ),
+    );
   }
 }

--- a/lib/cubit/amountless_btc/amountless_btc_state.dart
+++ b/lib/cubit/amountless_btc/amountless_btc_state.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+
 class AmountlessBtcState {
   final String? address;
   final int? estimateBaseFeeSat;
@@ -5,12 +7,21 @@ class AmountlessBtcState {
   final bool isLoading;
   final Object? error;
 
+  final List<Payment> paymentsWaitingFeeAcceptance;
+  final Map<String, FetchPaymentProposedFeesResponse> proposedFeesMap;
+  final bool isLoadingPayments;
+  final bool isLoadingFees;
+
   const AmountlessBtcState({
     this.address,
     this.estimateBaseFeeSat,
     this.estimateProportionalFee,
     this.isLoading = false,
     this.error,
+    this.paymentsWaitingFeeAcceptance = const <Payment>[],
+    this.proposedFeesMap = const <String, FetchPaymentProposedFeesResponse>{},
+    this.isLoadingPayments = false,
+    this.isLoadingFees = false,
   });
 
   AmountlessBtcState.initial() : this();
@@ -21,25 +32,39 @@ class AmountlessBtcState {
     double? estimateProportionalFee,
     bool? isLoading,
     Object? error,
+    List<Payment>? paymentsWaitingFeeAcceptance,
+    Map<String, FetchPaymentProposedFeesResponse>? proposedFeesMap,
+    bool? isLoadingPayments,
+    bool? isLoadingFees,
   }) => AmountlessBtcState(
     address: address ?? this.address,
     estimateBaseFeeSat: estimateBaseFeeSat ?? this.estimateBaseFeeSat,
     estimateProportionalFee: estimateProportionalFee ?? this.estimateProportionalFee,
     isLoading: isLoading ?? this.isLoading,
     error: error,
+    paymentsWaitingFeeAcceptance: paymentsWaitingFeeAcceptance ?? this.paymentsWaitingFeeAcceptance,
+    proposedFeesMap: proposedFeesMap ?? this.proposedFeesMap,
+    isLoadingPayments: isLoadingPayments ?? this.isLoadingPayments,
+    isLoadingFees: isLoadingFees ?? this.isLoadingFees,
   );
 
   bool get hasValidAddress => address != null && address!.isNotEmpty;
   bool get hasError => error != null;
+  bool get hasPaymentsWaitingFeeAcceptance => paymentsWaitingFeeAcceptance.isNotEmpty;
+  bool get hasProposedFees => proposedFeesMap.isNotEmpty;
 
   @override
   String toString() =>
       'AmountlessBtcState('
       'address: ${address ?? "N/A"}, '
       'estimateBaseFeeSat: ${estimateBaseFeeSat ?? "N/A"}, '
-      'estimateProportionalFee: ${estimateProportionalFee ?? "N/A"}'
+      'estimateProportionalFee: ${estimateProportionalFee ?? "N/A"}, '
       'isLoading: $isLoading, '
-      'error: ${error ?? "N/A"}'
+      'error: ${error ?? "N/A"}, '
+      'paymentsWaitingCount: ${paymentsWaitingFeeAcceptance.length}, '
+      'proposedFeesCount: ${proposedFeesMap.length}, '
+      'isLoadingPayments: $isLoadingPayments, '
+      'isLoadingFees: $isLoadingFees'
       ')';
 
   @override
@@ -52,9 +77,23 @@ class AmountlessBtcState {
         other.estimateBaseFeeSat == estimateBaseFeeSat &&
         other.estimateProportionalFee == estimateProportionalFee &&
         other.isLoading == isLoading &&
-        other.error == error;
+        other.error == error &&
+        other.paymentsWaitingFeeAcceptance == paymentsWaitingFeeAcceptance &&
+        other.proposedFeesMap == proposedFeesMap &&
+        other.isLoadingPayments == isLoadingPayments &&
+        other.isLoadingFees == isLoadingFees;
   }
 
   @override
-  int get hashCode => Object.hash(address, estimateBaseFeeSat, estimateProportionalFee, isLoading, error);
+  int get hashCode => Object.hash(
+    address,
+    estimateBaseFeeSat,
+    estimateProportionalFee,
+    isLoading,
+    error,
+    paymentsWaitingFeeAcceptance,
+    proposedFeesMap,
+    isLoadingPayments,
+    isLoadingFees,
+  );
 }

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -167,6 +167,12 @@ class PaymentData {
     final Map<String, dynamic> metadataMap = getLnurlPayMetadata(details);
     return metadataMap['image/png;base64'] ?? metadataMap['image/jpeg;base64'];
   }
+
+  String? get swapId => details.map(
+    bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
+    lightning: (PaymentDetails_Lightning details) => details.swapId,
+    orElse: () => null,
+  );
 }
 
 class _PaymentDataFactory {

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_header.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/cubit/cubit.dart';
 import 'package:misty_breez/routes/routes.dart';
 import 'package:misty_breez/theme/theme.dart';
+import 'package:misty_breez/widgets/widgets.dart';
 
 class PaymentDetailsSheetHeader extends StatefulWidget {
   final PaymentData paymentData;
@@ -14,9 +18,88 @@ class PaymentDetailsSheetHeader extends StatefulWidget {
 }
 
 class _PaymentDetailsSheetHeaderState extends State<PaymentDetailsSheetHeader> {
+  Timer? _feesPollingTimer;
+  Timer? _uiUpdateTimer;
+
+  // UI-only state
+  int _secondsUntilNextUpdate = 60;
+  bool _isTimerActive = false;
+  bool _isAcceptingFees = false;
+  bool _isRejectingFees = false;
+  bool _hasProcessedFees = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.paymentData.status == PaymentState.waitingFeeAcceptance) {
+      _startFeesPolling();
+    }
+  }
+
+  @override
+  void dispose() {
+    _feesPollingTimer?.cancel();
+    _uiUpdateTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startFeesPolling() {
+    final String? swapId = widget.paymentData.swapId;
+    if (swapId == null) {
+      return;
+    }
+
+    // Fetch fees immediately
+    context.read<AmountlessBtcCubit>().fetchPaymentProposedFees(swapId);
+
+    // Start UI timer
+    _startUiTimer();
+
+    // Poll every minute
+    _feesPollingTimer = Timer.periodic(const Duration(minutes: 1), (Timer timer) {
+      if (mounted && !_hasProcessedFees && widget.paymentData.status == PaymentState.waitingFeeAcceptance) {
+        context.read<AmountlessBtcCubit>().fetchPaymentProposedFees(swapId);
+        _resetTimer();
+      } else {
+        timer.cancel();
+        _stopUiTimer();
+      }
+    });
+  }
+
+  void _startUiTimer() {
+    _isTimerActive = true;
+    _secondsUntilNextUpdate = 60;
+
+    _uiUpdateTimer = Timer.periodic(const Duration(seconds: 1), (Timer timer) {
+      if (mounted && _isTimerActive) {
+        setState(() {
+          _secondsUntilNextUpdate--;
+          if (_secondsUntilNextUpdate <= 0) {
+            _secondsUntilNextUpdate = 60;
+          }
+        });
+      } else {
+        timer.cancel();
+      }
+    });
+  }
+
+  void _stopUiTimer() {
+    _isTimerActive = false;
+    _uiUpdateTimer?.cancel();
+  }
+
+  void _resetTimer() {
+    setState(() {
+      _secondsUntilNextUpdate = 60;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
+
     return Center(
       child: Column(
         children: <Widget>[
@@ -36,6 +119,19 @@ class _PaymentDetailsSheetHeaderState extends State<PaymentDetailsSheetHeader> {
           ),
           PaymentDetailsSheetContentTitle(paymentData: widget.paymentData),
           PaymentDetailsSheetDescription(paymentData: widget.paymentData),
+
+          if (!_hasProcessedFees &&
+              widget.paymentData.status == PaymentState.waitingFeeAcceptance) ...<Widget>[
+            Padding(
+              padding: const EdgeInsets.only(top: 8, bottom: 20),
+              child: Chip(
+                label: const Text('Pending Approval'),
+                backgroundColor: themeData.customData.pendingTextColor,
+              ),
+            ),
+            _buildFeeAcceptanceCard(),
+          ],
+
           if (widget.paymentData.status == PaymentState.refundPending) ...<Widget>[
             Padding(
               padding: const EdgeInsets.only(top: 8),
@@ -55,5 +151,258 @@ class _PaymentDetailsSheetHeaderState extends State<PaymentDetailsSheetHeader> {
         ],
       ),
     );
+  }
+
+  Widget _buildFeeAcceptanceCard() {
+    final ThemeData themeData = Theme.of(context);
+
+    final String? swapId = widget.paymentData.swapId;
+    if (swapId == null) {
+      return const SizedBox.shrink();
+    }
+
+    return BlocBuilder<AmountlessBtcCubit, AmountlessBtcState>(
+      builder: (BuildContext context, AmountlessBtcState state) {
+        final FetchPaymentProposedFeesResponse? proposedFees = state.proposedFeesMap[swapId];
+
+        return Card(
+          color: themeData.customData.surfaceBgColor,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              if (proposedFees != null) ...<Widget>[
+                _buildFeeDetails(proposedFees),
+              ] else if (state.isLoadingFees) ...<Widget>[
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+                    border: Border.all(color: themeData.colorScheme.onSurface.withValues(alpha: .4)),
+                    color: themeData.customData.surfaceBgColor,
+                  ),
+                  child: const Center(
+                    child: Column(
+                      children: <Widget>[
+                        CircularProgressIndicator(),
+                        SizedBox(height: 12),
+                        LoadingAnimatedText(loadingMessage: 'Retrieving fees'),
+                      ],
+                    ),
+                  ),
+                ),
+              ] else if (state.hasError) ...<Widget>[_buildErrorState(state.error)],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTimerDisplay() {
+    if (!_isTimerActive || _hasProcessedFees) {
+      return const SizedBox.shrink();
+    }
+    final ThemeData themeData = Theme.of(context);
+    final double progress = (_secondsUntilNextUpdate / 60.0);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Center(
+            child: Text(
+              'Expect fee variation depending on network usage.',
+              style: themeData.textTheme.bodySmall?.copyWith(
+                color: themeData.colorScheme.onSurface.withValues(alpha: 0.7),
+                fontStyle: FontStyle.italic,
+                fontSize: 13.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          SizedBox(
+            width: 24,
+            height: 24,
+            child: Stack(
+              alignment: Alignment.center,
+              children: <Widget>[
+                CircularProgressIndicator(
+                  value: progress,
+                  strokeWidth: 2,
+                  backgroundColor: themeData.colorScheme.onSurface.withValues(alpha: 0.2),
+                  valueColor: AlwaysStoppedAnimation<Color>(themeData.colorScheme.primary),
+                ),
+                Text(
+                  '$_secondsUntilNextUpdate',
+                  style: themeData.textTheme.bodySmall?.copyWith(
+                    fontSize: 8,
+                    fontWeight: FontWeight.bold,
+                    color: themeData.colorScheme.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFeeDetails(FetchPaymentProposedFeesResponse fees) {
+    final ThemeData themeData = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+        border: Border.all(color: themeData.colorScheme.onSurface.withValues(alpha: .4)),
+        color: themeData.customData.surfaceBgColor,
+      ),
+      child: Column(
+        children: <Widget>[
+          SenderAmount(title: 'Sent:', amountSat: fees.payerAmountSat.toInt()),
+          const Divider(height: 8.0, color: Color.fromRGBO(40, 59, 74, 0.5), indent: 16.0, endIndent: 16.0),
+          TransactionFee(nonTransparent: true, txFeeSat: fees.feesSat.toInt()),
+          const Divider(height: 8.0, color: Color.fromRGBO(40, 59, 74, 0.5), indent: 16.0, endIndent: 16.0),
+          RecipientAmount(amountSat: fees.receiverAmountSat.toInt()),
+          _buildTimerDisplay(),
+          _buildActionButtons(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionButtons() {
+    final ThemeData themeData = Theme.of(context);
+    final bool isProcessing = _isAcceptingFees || _isRejectingFees;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8.0, left: 16, right: 16, bottom: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Expanded(
+            child: OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                side: BorderSide(color: themeData.colorScheme.onSurface.withValues(alpha: .4)),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+              onPressed: isProcessing ? null : () => _rejectFees(),
+              label: _isRejectingFees
+                  ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Text('REJECT'),
+            ),
+          ),
+          const SizedBox(width: 32),
+          Expanded(
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: themeData.primaryColor,
+                foregroundColor: Colors.white,
+                elevation: 0.0,
+                disabledBackgroundColor: themeData.disabledColor,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+              ),
+              onPressed: isProcessing ? null : () => _acceptFees(),
+              child: _isAcceptingFees
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    )
+                  : const Text('ACCEPT'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorState(Object? error) {
+    final ThemeData themeData = Theme.of(context);
+
+    return BlocBuilder<AmountlessBtcCubit, AmountlessBtcState>(
+      builder: (BuildContext context, AmountlessBtcState state) {
+        final bool isRetrying = state.isLoadingFees;
+
+        return GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: isRetrying ? null : () => _retryFetchFees(),
+          child: WarningBox(
+            boxPadding: EdgeInsets.zero,
+            backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
+            contentPadding: const EdgeInsets.all(16.0),
+            child: isRetrying
+                ? const CenteredLoader()
+                : RichText(
+                    text: TextSpan(
+                      text: 'Failed to retrieve fees.',
+                      style: themeData.textTheme.bodyLarge?.copyWith(color: themeData.colorScheme.error),
+                      children: <InlineSpan>[
+                        TextSpan(
+                          text: '\n\nTap here to retry',
+                          style: themeData.textTheme.titleLarge?.copyWith(
+                            color: themeData.colorScheme.error.withValues(alpha: .7),
+                            decoration: TextDecoration.underline,
+                          ),
+                        ),
+                      ],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _acceptFees() async {
+    setState(() {
+      _isAcceptingFees = true;
+      _hasProcessedFees = true;
+    });
+    _stopUiTimer();
+
+    try {
+      await context.read<AmountlessBtcCubit>().acceptPaymentProposedFees(widget.paymentData.swapId!);
+      if (mounted) {
+        Navigator.of(context).popUntil((Route<dynamic> route) => route.settings.name == Home.routeName);
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAcceptingFees = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _rejectFees() async {
+    setState(() {
+      _isRejectingFees = true;
+      _hasProcessedFees = true;
+    });
+    _stopUiTimer();
+
+    try {
+      context.read<AmountlessBtcCubit>().rejectPaymentProposedFees(widget.paymentData.swapId!);
+      if (mounted) {
+        Navigator.of(context).popUntil((Route<dynamic> route) => route.settings.name == Home.routeName);
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRejectingFees = false;
+        });
+      }
+    }
+  }
+
+  void _retryFetchFees() {
+    context.read<AmountlessBtcCubit>().fetchPaymentProposedFees(widget.paymentData.swapId!);
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_item/widgets/payment_item_subtitle.dart
@@ -41,6 +41,14 @@ class PaymentItemSubtitle extends StatelessWidget {
             style: subtitleTextStyle.copyWith(color: themeData.customData.pendingTextColor),
           ),
         ],
+        if (paymentData.status == PaymentState.waitingFeeAcceptance) ...<Widget>[
+          Text(
+            ' (Pending Approval)',
+            style: subtitleTextStyle.copyWith(
+              color: themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/routes/receive_payment/onchain/amountless/receive_amountless_btc_address_payment.dart
+++ b/lib/routes/receive_payment/onchain/amountless/receive_amountless_btc_address_payment.dart
@@ -145,11 +145,7 @@ class AmountlessBtcAddressErrorView extends StatelessWidget {
           contentPadding: const EdgeInsets.all(16.0),
           child: RichText(
             text: TextSpan(
-              text: ExceptionHandler.extractMessage(
-                error,
-                texts,
-                defaultErrorMsg: 'Failed to generate amountless Bitcoin address.',
-              ),
+              text: ExceptionHandler.extractMessage(error, texts),
               style: themeData.textTheme.bodyLarge?.copyWith(color: themeData.colorScheme.error),
               children: <InlineSpan>[
                 TextSpan(

--- a/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
+++ b/lib/routes/receive_payment/onchain/bitcoin_address/receive_bitcoin_address_payment_page.dart
@@ -69,10 +69,21 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
             return const CenteredLoader();
           }
 
+          final bool hasAmountlessStateError = context.select<AmountlessBtcCubit, bool>(
+            (AmountlessBtcCubit cubit) => cubit.state.hasError,
+          );
+
           return prepareResponseFuture == null
               ? Padding(
-                  padding: const EdgeInsets.only(top: 32.0, bottom: 40.0),
-                  child: SingleChildScrollView(child: _buildForm(onchainPaymentLimits)),
+                  padding: const EdgeInsets.only(top: 32, bottom: 40.0),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: <Widget>[
+                        _buildForm(onchainPaymentLimits),
+                        _buildAmountlessAddressWarnings(hasAmountlessStateError: hasAmountlessStateError),
+                      ],
+                    ),
+                  ),
                 )
               : _buildQRCode();
         },
@@ -306,5 +317,13 @@ class _ReceiveBitcoinAddressPaymentPageState extends State<ReceiveBitcoinAddress
     final int balance = accountState.walletInfo!.balanceSat.toInt();
     final ChainSwapCubit chainSwapCubit = context.read<ChainSwapCubit>();
     return chainSwapCubit.validateSwap(BigInt.from(amount), outgoing, onchainPaymentLimits, balance);
+  }
+
+  Widget _buildAmountlessAddressWarnings({required bool hasAmountlessStateError}) {
+    if (hasAmountlessStateError) {
+      return const AmountlessBtcAddressWarningBox();
+    }
+
+    return const SizedBox.shrink();
   }
 }

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -8,7 +8,9 @@ import 'package:misty_breez/widgets/back_button.dart' as back_button;
 class ReceivePaymentPage extends StatefulWidget {
   static const String routeName = '/receive_payment';
 
-  const ReceivePaymentPage({super.key});
+  final int? initialPageIndex;
+
+  const ReceivePaymentPage({this.initialPageIndex, super.key});
 
   @override
   State<ReceivePaymentPage> createState() => _ReceivePaymentPageState();
@@ -26,9 +28,17 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   bool _hasLnAddressStateError = false;
   bool _hasAmountlessBtcAddressError = false;
 
-  int _currentPageIndex = ReceiveLightningAddressPage.pageIndex;
+  late int _currentPageIndex;
   bool _showInvoicePage = false;
   bool _showBtcPaymentRequestPage = false;
+
+  @override
+  void initState() {
+    super.initState();
+    setState(() {
+      _currentPageIndex = widget.initialPageIndex ?? ReceiveLightningAddressPage.pageIndex;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
@@ -1,0 +1,68 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/utils/utils.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+class AmountlessBtcAddressWarningBox extends StatelessWidget {
+  const AmountlessBtcAddressWarningBox({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
+
+    return BlocBuilder<AmountlessBtcCubit, AmountlessBtcState>(
+      builder: (BuildContext context, AmountlessBtcState state) {
+        if (!state.hasError) {
+          // Redirect to Amountless BTC Address Page after AmountlessBtcState error is resolved
+          Future<void>.microtask(() {
+            if (context.mounted) {
+              Navigator.of(context).pushReplacementNamed(ReceivePaymentPage.routeName);
+            }
+          });
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 32.0),
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () {
+              final AmountlessBtcCubit amountlessBtcCubit = context.read<AmountlessBtcCubit>();
+              amountlessBtcCubit.generateAmountlessAddress();
+            },
+            child: WarningBox(
+              boxPadding: EdgeInsets.zero,
+              backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
+              contentPadding: const EdgeInsets.all(16.0),
+              child: RichText(
+                text: TextSpan(
+                  text: ExceptionHandler.extractMessage(
+                    state.error!,
+                    texts,
+                    defaultErrorMsg: 'Failed to generate amountless Bitcoin address.',
+                  ),
+                  style: themeData.textTheme.bodyLarge?.copyWith(color: themeData.colorScheme.error),
+                  children: <InlineSpan>[
+                    TextSpan(
+                      text: '\n\nTap here to retry',
+                      style: themeData.textTheme.titleLarge?.copyWith(
+                        color: themeData.colorScheme.error.withValues(alpha: .7),
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ],
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
@@ -21,7 +21,10 @@ class AmountlessBtcAddressWarningBox extends StatelessWidget {
           // Redirect to Amountless BTC Address Page after AmountlessBtcState error is resolved
           Future<void>.microtask(() {
             if (context.mounted) {
-              Navigator.of(context).pushReplacementNamed(ReceivePaymentPage.routeName);
+              Navigator.of(context).pushReplacementNamed(
+                ReceivePaymentPage.routeName,
+                arguments: ReceiveAmountlessBitcoinAddressPage.pageIndex,
+              );
             }
           });
           return const SizedBox.shrink();

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/amountless_address_warning_box.dart
@@ -44,11 +44,7 @@ class AmountlessBtcAddressWarningBox extends StatelessWidget {
               contentPadding: const EdgeInsets.all(16.0),
               child: RichText(
                 text: TextSpan(
-                  text: ExceptionHandler.extractMessage(
-                    state.error!,
-                    texts,
-                    defaultErrorMsg: 'Failed to generate amountless Bitcoin address.',
-                  ),
+                  text: ExceptionHandler.extractMessage(state.error!, texts),
                   style: themeData.textTheme.bodyLarge?.copyWith(color: themeData.colorScheme.error),
                   children: <InlineSpan>[
                     TextSpan(

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/payment_message_boxes.dart
@@ -1,3 +1,4 @@
+export 'amountless_address_warning_box.dart';
 export 'ln_address_error_warning_box.dart';
 export 'notification_permission_warning_box.dart';
 export 'payment_fees_message_box.dart';

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/sender_amount.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/sender_amount.dart
@@ -10,8 +10,9 @@ import 'package:misty_breez/utils/utils.dart';
 
 class SenderAmount extends StatelessWidget {
   final int amountSat;
+  final String? title;
 
-  const SenderAmount({required this.amountSat, super.key});
+  const SenderAmount({required this.amountSat, this.title, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +26,7 @@ class SenderAmount extends StatelessWidget {
         children: <Widget>[
           AutoSizeText(
             // TODO(erdemyerebasmaz): Add message to Breez-Translations
-            'To send:',
+            title ?? 'To send:',
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(fontSize: 18.0, color: Colors.white),
             maxLines: 1,
             minFontSize: minFont.minFontSize,

--- a/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/transaction_fee.dart
+++ b/lib/routes/send_payment/chainswap/widgets/fee/fee_breakdown/widgets/transaction_fee.dart
@@ -8,8 +8,9 @@ import 'package:misty_breez/utils/utils.dart';
 
 class TransactionFee extends StatelessWidget {
   final int txFeeSat;
+  final bool nonTransparent;
 
-  const TransactionFee({required this.txFeeSat, super.key});
+  const TransactionFee({required this.txFeeSat, this.nonTransparent = false, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +26,7 @@ class TransactionFee extends StatelessWidget {
             texts.sweep_all_coins_label_transaction_fee,
             style: themeData.primaryTextTheme.headlineMedium?.copyWith(
               fontSize: 18.0,
-              color: Colors.white.withValues(alpha: .4),
+              color: Colors.white.withValues(alpha: nonTransparent ? 1 : .4),
             ),
             maxLines: 1,
             minFontSize: minFont.minFontSize,
@@ -42,7 +43,8 @@ class TransactionFee extends StatelessWidget {
                 texts.sweep_all_coins_fee(BitcoinCurrency.sat.format(txFeeSat)),
                 style: themeData.primaryTextTheme.displaySmall!.copyWith(
                   fontSize: 18.0,
-                  color: themeData.colorScheme.error.withValues(alpha: .4),
+                  color: themeData.colorScheme.error.withValues(alpha: nonTransparent ? 1 : .4),
+                  fontWeight: nonTransparent ? FontWeight.w500 : null,
                 ),
                 textAlign: TextAlign.right,
                 maxLines: 1,

--- a/lib/utils/exceptions/exception_handler.dart
+++ b/lib/utils/exceptions/exception_handler.dart
@@ -176,11 +176,13 @@ class ExceptionHandler {
     final RegExp messageRegex = RegExp(r'((?<=message: ")(.*)(?=.*"))');
     final RegExp causedByRegex = RegExp(r'((?<=Caused by: )(.*)(?=.*))');
     final RegExp reasonRegex = RegExp(r'((?<=FAILURE_REASON_)(.*)(?=.*))');
+    final RegExp jsonErrorRegex = RegExp(r'JSON\(Error\("([^"]+)"');
 
     return innerMessageRegex.stringMatch(content) ??
         messageRegex.stringMatch(content) ??
         causedByRegex.stringMatch(content) ??
-        reasonRegex.stringMatch(content);
+        reasonRegex.stringMatch(content) ??
+        jsonErrorRegex.firstMatch(content)?.group(1);
   }
 
   /// Maps error messages to localized strings


### PR DESCRIPTION
This PR adds a warning on BTC invoice page if there's been an error generating an amountless BTC address. Users can tap the error to attempt generating a new amountless BTC address. If successful, they'll be automatically redirected to amountless BTC address page.

#### Screenshot:
<img src="https://github.com/user-attachments/assets/619810b0-11f5-4420-b0a0-bc438bb1f5d7" width="50%" />


#### The error message is subject to change.