### PR TITLE
feat: allow users to set payer notes on Bolt 12 invoice requests

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -472,13 +472,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -493,13 +489,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -98,7 +98,7 @@ Route<dynamic>? onGenerateRoute({
                     settings: settings,
                   );
                 case LnPaymentPage.routeName:
-                  return FadeInRoute<PrepareSendResponse?>(
+                  return FadeInRoute<SendPaymentRequest?>(
                     builder: (BuildContext context) => BlocProvider<PaymentLimitsCubit>(
                       create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
                       child: LnPaymentPage(lnInvoice: settings.arguments as LNInvoice),
@@ -106,7 +106,7 @@ Route<dynamic>? onGenerateRoute({
                     settings: settings,
                   );
                 case LnOfferPaymentPage.routeName:
-                  return FadeInRoute<PrepareSendResponse?>(
+                  return FadeInRoute<SendPaymentRequest?>(
                     builder: (BuildContext context) => BlocProvider<PaymentLimitsCubit>(
                       create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
                       child: LnOfferPaymentPage(

--- a/lib/cubit/input/input_state.dart
+++ b/lib/cubit/input/input_state.dart
@@ -104,7 +104,7 @@ class LnOfferInputState extends InputState {
 
   @override
   String toString() {
-    return 'LnOfferInputState{lnInvoice: $lnOffer, bip353Address: $bip353Address, source: $source}';
+    return 'LnOfferInputState{lnOffer: ${lnOffer.toFormattedString()}, bip353Address: $bip353Address, source: $source}';
   }
 
   @override

--- a/lib/cubit/payments/payments_cubit.dart
+++ b/lib/cubit/payments/payments_cubit.dart
@@ -70,10 +70,16 @@ class PaymentsCubit extends Cubit<PaymentsState> with HydratedMixin<PaymentsStat
     }
   }
 
-  Future<SendPaymentResponse> sendPayment(PrepareSendResponse prepareResponse) async {
+  Future<SendPaymentResponse> sendPayment({
+    required PrepareSendResponse prepareResponse,
+    String? payerNote,
+  }) async {
     _logger.info('sendPayment\nSending payment for ${prepareResponse.toFormattedString()}');
     try {
-      final SendPaymentRequest req = SendPaymentRequest(prepareResponse: prepareResponse);
+      final SendPaymentRequest req = SendPaymentRequest(
+        prepareResponse: prepareResponse,
+        payerNote: payerNote,
+      );
       return await _breezSdkLiquid.instance!.sendPayment(req: req);
     } catch (e) {
       _logger.severe('sendPayment\nError sending payment', e);

--- a/lib/handlers/input_handler/src/input_handler.dart
+++ b/lib/handlers/input_handler/src/input_handler.dart
@@ -108,11 +108,11 @@ class InputHandler extends Handler {
   Future<dynamic> handleLnInvoice(BuildContext context, LNInvoice lnInvoice) async {
     _logger.info('handle LnInvoice ${lnInvoice.toFormattedString()}');
     final NavigatorState navigator = Navigator.of(context);
-    final PrepareSendResponse? prepareResponse = await navigator.pushNamed<PrepareSendResponse?>(
+    final SendPaymentRequest? sendPaymentRequest = await navigator.pushNamed<SendPaymentRequest?>(
       LnPaymentPage.routeName,
       arguments: lnInvoice,
     );
-    if (prepareResponse == null || !context.mounted) {
+    if (sendPaymentRequest == null || !context.mounted) {
       return Future<dynamic>.value();
     }
 
@@ -122,7 +122,7 @@ class InputHandler extends Handler {
       isLnPayment: true,
       paymentFunc: () async {
         final PaymentsCubit paymentsCubit = context.read<PaymentsCubit>();
-        return await paymentsCubit.sendPayment(prepareResponse);
+        return await paymentsCubit.sendPayment(prepareResponse: sendPaymentRequest.prepareResponse);
       },
     ).then((dynamic result) {
       // TODO(erdemyerebasmaz): Handle SendPaymentResponse results, return a SendPaymentResult to be handled by handleResult()
@@ -147,11 +147,11 @@ class InputHandler extends Handler {
       lnOffer: lnOffer,
       bip353Address: bip353Address,
     );
-    final PrepareSendResponse? prepareResponse = await navigator.pushNamed<PrepareSendResponse?>(
+    final SendPaymentRequest? sendPaymentRequest = await navigator.pushNamed<SendPaymentRequest?>(
       LnOfferPaymentPage.routeName,
       arguments: arguments,
     );
-    if (prepareResponse == null || !context.mounted) {
+    if (sendPaymentRequest == null || !context.mounted) {
       return Future<dynamic>.value();
     }
 
@@ -161,7 +161,10 @@ class InputHandler extends Handler {
       isLnPayment: true,
       paymentFunc: () async {
         final PaymentsCubit paymentsCubit = context.read<PaymentsCubit>();
-        return await paymentsCubit.sendPayment(prepareResponse);
+        return await paymentsCubit.sendPayment(
+          prepareResponse: sendPaymentRequest.prepareResponse,
+          payerNote: sendPaymentRequest.payerNote,
+        );
       },
     ).then((dynamic result) {
       // TODO(erdemyerebasmaz): Handle SendPaymentResponse results, return a SendPaymentResult to be handled by handleResult()

--- a/lib/models/extensions/payment_details_extension.dart
+++ b/lib/models/extensions/payment_details_extension.dart
@@ -39,6 +39,7 @@ extension PaymentDetailsToJson on PaymentDetails {
         'destinationPubkey': details.destinationPubkey,
         'lnurlInfo': details.lnurlInfo?.toJson(),
         'bip353Address': details.bip353Address,
+        'payerNote': details.payerNote,
         'claimTxId': details.claimTxId,
         'refundTxId': details.refundTxId,
         'refundTxAmountSat': details.refundTxAmountSat?.toString(),
@@ -51,6 +52,7 @@ extension PaymentDetailsToJson on PaymentDetails {
         'assetInfo': details.assetInfo?.toJson(),
         'lnurlInfo': details.lnurlInfo?.toJson(),
         'bip353Address': details.bip353Address,
+        'payerNote': details.payerNote,
       },
       bitcoin: (PaymentDetails_Bitcoin details) => <String, dynamic>{
         'type': 'bitcoin',
@@ -84,6 +86,7 @@ extension PaymentDetailsFromJson on PaymentDetails {
           destinationPubkey: json['destinationPubkey'] as String?,
           lnurlInfo: json['lnurlInfo'] != null ? LnUrlInfoFromJson.fromJson(json['lnurlInfo']) : null,
           bip353Address: json['bip353Address'] as String?,
+          payerNote: json['payerNote'] as String?,
           claimTxId: json['claimTxId'] as String?,
           refundTxId: json['refundTxId'] as String?,
           refundTxAmountSat: json['refundTxAmountSat'] != null
@@ -99,6 +102,7 @@ extension PaymentDetailsFromJson on PaymentDetails {
           assetInfo: json['assetInfo'] != null ? AssetInfoFromJson.fromJson(json['assetInfo']) : null,
           lnurlInfo: json['lnurlInfo'] != null ? LnUrlInfoFromJson.fromJson(json['lnurlInfo']) : null,
           bip353Address: json['bip353Address'] as String?,
+          payerNote: json['payerNote'] as String?,
         );
 
       case 'bitcoin':
@@ -139,6 +143,7 @@ extension PaymentDetailsExtension on PaymentDetails {
                     o.destinationPubkey == current.destinationPubkey &&
                     (o.lnurlInfo?.toJson() == current.lnurlInfo?.toJson()) &&
                     o.bip353Address == current.bip353Address &&
+                    o.payerNote == current.payerNote &&
                     o.claimTxId == current.claimTxId &&
                     o.refundTxId == current.refundTxId &&
                     o.refundTxAmountSat == current.refundTxAmountSat;
@@ -150,7 +155,8 @@ extension PaymentDetailsExtension on PaymentDetails {
                     o.assetId == current.assetId &&
                     (o.assetInfo?.toJson() == current.assetInfo?.toJson()) &&
                     (o.lnurlInfo?.toJson() == current.lnurlInfo?.toJson()) &&
-                    o.bip353Address == current.bip353Address;
+                    o.bip353Address == current.bip353Address &&
+                    o.payerNote == current.payerNote;
               },
               bitcoin: (PaymentDetails_Bitcoin o) {
                 final PaymentDetails_Bitcoin current = this as PaymentDetails_Bitcoin;
@@ -183,12 +189,19 @@ extension PaymentDetailsHashCode on PaymentDetails {
         o.destinationPubkey,
         o.lnurlInfo?.toJson(),
         o.bip353Address,
+        o.payerNote,
         o.claimTxId,
         o.refundTxId,
         o.refundTxAmountSat,
       ),
-      liquid: (PaymentDetails_Liquid o) =>
-          Object.hash(o.destination, o.description, o.assetId, o.assetInfo?.toJson()),
+      liquid: (PaymentDetails_Liquid o) => Object.hash(
+        o.destination,
+        o.description,
+        o.assetId,
+        o.assetInfo?.toJson(),
+        o.bip353Address,
+        o.payerNote,
+      ),
       bitcoin: (PaymentDetails_Bitcoin o) => Object.hash(
         o.swapId,
         o.bitcoinAddress,
@@ -256,6 +269,7 @@ extension PaymentDetailsFormatter on PaymentDetails {
           'destinationPubkey: ${details.destinationPubkey ?? "N/A"}, '
           'lnurlInfo: ${details.lnurlInfo?.toFormattedString() ?? "N/A"}, '
           'bip353Address: ${details.bip353Address ?? "N/A"}, '
+          'payerNote: ${details.payerNote ?? "N/A"}, '
           'claimTxId: ${details.claimTxId ?? "N/A"}, '
           'refundTxId: ${details.refundTxId ?? "N/A"}, '
           'refundTxAmountSat: ${details.refundTxAmountSat ?? "N/A"}'
@@ -269,6 +283,7 @@ extension PaymentDetailsFormatter on PaymentDetails {
           'assetInfo: ${details.assetInfo ?? "N/A"}'
           'lnurlInfo: ${details.lnurlInfo?.toFormattedString() ?? "N/A"}, '
           'bip353Address: ${details.bip353Address ?? "N/A"}, '
+          'payerNote: ${details.payerNote ?? "N/A"}, '
           ')';
     } else if (this is PaymentDetails_Bitcoin) {
       final PaymentDetails_Bitcoin details = this as PaymentDetails_Bitcoin;

--- a/lib/models/extensions/sdk_formatted_string_extensions.dart
+++ b/lib/models/extensions/sdk_formatted_string_extensions.dart
@@ -118,9 +118,8 @@ extension SendDestinationFormatter on SendDestination {
         offer: final LNOffer offer,
         receiverAmountSat: final BigInt receiverAmountSat,
         bip353Address: final String? bip353Address,
-        payerNote: final String? payerNote,
       ) =>
-        'BOLT12 Offer: ${offer.toFormattedString()}, Amount: $receiverAmountSat sats${bip353Address != null ? ' (resolved from $bip353Address)' : ''}${payerNote != null ? ' with note: "$payerNote"' : ''}',
+        'BOLT12 Offer: ${offer.toFormattedString()}, Amount: $receiverAmountSat sats${bip353Address != null ? ' (resolved from $bip353Address)' : ''}}',
     };
   }
 }

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -82,6 +82,14 @@ class PaymentDetailsSheet extends StatelessWidget {
         ) ??
         '';
 
+    final String payerNote =
+        paymentData.details.map(
+          lightning: (PaymentDetails_Lightning details) => details.payerNote,
+          liquid: (PaymentDetails_Liquid details) => details.payerNote,
+          orElse: () => null,
+        ) ??
+        '';
+
     final LnUrlInfo? lnurlInfo = paymentData.details.map(
       lightning: (PaymentDetails_Lightning details) => details.lnurlInfo,
       liquid: (PaymentDetails_Liquid details) => details.lnurlInfo,
@@ -175,6 +183,9 @@ class PaymentDetailsSheet extends StatelessWidget {
                             ],
                             if (lnAddress.isNotEmpty) ...<Widget>[
                               PaymentDetailsSheetLnUrlLnAddress(lnAddress: lnAddress),
+                            ],
+                            if (payerNote.isNotEmpty) ...<Widget>[
+                              PaymentDetailsSheetPayerNote(payerNote: payerNote),
                             ],
                             if (lnurlPayComment.isNotEmpty) ...<Widget>[
                               PaymentDetailsSheetLnUrlPayComment(payComment: lnurlPayComment),

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_payer_note.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/payment_details_sheet_payer_note.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+class PaymentDetailsSheetPayerNote extends StatelessWidget {
+  final String payerNote;
+
+  const PaymentDetailsSheetPayerNote({required this.payerNote, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
+    return ShareablePaymentRow(
+      tilePadding: EdgeInsets.zero,
+      dividerColor: Colors.transparent,
+      // TODO(erdemyerebasmaz): Add message to Breez-Translations
+      title: 'Payer Note:',
+      titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
+        fontSize: 18.0,
+        color: Colors.white,
+      ),
+      sharedValue: payerNote,
+    );
+  }
+}

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/widgets/widgets.dart
@@ -14,6 +14,7 @@ export 'payment_details_sheet_lnurl_pay_domain.dart';
 export 'payment_details_sheet_lnurl_pay_success_description.dart';
 export 'payment_details_sheet_lnurl_pay_success_message.dart';
 export 'payment_details_sheet_lnurl_pay_success_url.dart';
+export 'payment_details_sheet_payer_note.dart';
 export 'payment_details_sheet_preimage.dart';
 export 'payment_details_sheet_refund_tx_amount.dart';
 export 'payment_details_sheet_swap_id.dart';

--- a/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_invoice_payment_page.dart
@@ -206,7 +206,10 @@ class LnPaymentPageState extends State<LnPaymentPage> {
               text: texts.ln_payment_action_send,
               enabled: _prepareResponse != null && errorMessage.isEmpty,
               onPressed: () async {
-                Navigator.pop(context, _prepareResponse);
+                final SendPaymentRequest sendPaymentRequest = SendPaymentRequest(
+                  prepareResponse: _prepareResponse!,
+                );
+                Navigator.pop(context, sendPaymentRequest);
               },
             ),
     );

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -414,13 +414,16 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
                                     ),
                                   ],
                                 ],
-                                LnUrlPaymentComment(
-                                  isConfirmation: widget.isConfirmation,
-                                  enabled: _isFormEnabled,
-                                  descriptionController: _descriptionController,
-                                  descriptionFocusNode: _descriptionFocusNode,
-                                  maxCommentLength: 255,
-                                ),
+                                if (!(widget.isConfirmation &&
+                                    _descriptionController.text.isEmpty)) ...<Widget>[
+                                  LnUrlPaymentComment(
+                                    isConfirmation: widget.isConfirmation,
+                                    enabled: _isFormEnabled,
+                                    descriptionController: _descriptionController,
+                                    descriptionFocusNode: _descriptionFocusNode,
+                                    maxCommentLength: 255,
+                                  ),
+                                ],
                               ].expand((Widget widget) sync* {
                                 yield widget;
                                 yield const Divider(

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -156,13 +156,7 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
           ? const PayAmount_Drain()
           : PayAmount_Bitcoin(receiverAmountSat: BigInt.from(amountSat));
 
-      final String comment = widget.comment ?? _descriptionController.text;
-
-      final PrepareSendRequest req = PrepareSendRequest(
-        destination: destination,
-        amount: payAmount,
-        comment: comment,
-      );
+      final PrepareSendRequest req = PrepareSendRequest(destination: destination, amount: payAmount);
 
       final PrepareSendResponse response = await paymentsCubit.prepareSendPayment(req: req);
       setState(() {
@@ -479,7 +473,12 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
               stickToBottom: true,
               text: texts.ln_payment_action_send,
               onPressed: () async {
-                Navigator.pop(context, _prepareResponse);
+                final String comment = widget.comment ?? _descriptionController.text;
+                final SendPaymentRequest sendPaymentRequest = SendPaymentRequest(
+                  prepareResponse: _prepareResponse!,
+                  payerNote: comment,
+                );
+                Navigator.pop(context, sendPaymentRequest);
               },
             )
           : const SizedBox.shrink(),

--- a/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
+++ b/lib/routes/send_payment/lightning/ln_offer_payment_page.dart
@@ -553,8 +553,8 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
     final CurrencyState currencyState = currencyCubit.state;
     final int amountSat = currencyState.bitcoinCurrency.parse(_amountController.text);
 
-    final PrepareSendResponse? prepareResponse = await Navigator.of(context).push<PrepareSendResponse?>(
-      FadeInRoute<PrepareSendResponse?>(
+    final SendPaymentRequest? sendPaymentRequest = await Navigator.of(context).push<SendPaymentRequest?>(
+      FadeInRoute<SendPaymentRequest?>(
         builder: (_) => BlocProvider<PaymentLimitsCubit>(
           create: (BuildContext context) => PaymentLimitsCubit(ServiceInjector().breezSdkLiquid),
           child: LnOfferPaymentPage(
@@ -567,11 +567,11 @@ class LnOfferPaymentPageState extends State<LnOfferPaymentPage> {
         ),
       ),
     );
-    if (prepareResponse == null || !context.mounted) {
+    if (sendPaymentRequest == null || !context.mounted) {
       return Future<void>.value();
     }
     if (mounted) {
-      Navigator.pop(context, prepareResponse);
+      Navigator.pop(context, sendPaymentRequest);
     }
   }
 

--- a/lib/utils/currency/bitcoin_currency_formatter.dart
+++ b/lib/utils/currency/bitcoin_currency_formatter.dart
@@ -74,6 +74,9 @@ class BitcoinCurrencyFormatter {
   /// Returns the amount in satoshis
   int parse(String amount, BitcoinCurrency currency) {
     _logger.fine('Parsing "$amount" in ${currency.displayName}');
+    if (amount.isEmpty) {
+      return 0;
+    }
 
     switch (currency) {
       case BitcoinCurrency.btc:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "82.0.0"
+    version: "85.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "904ae5bb474d32c38fb9482e2d925d5454cda04ddd0e55d2e6826bc72f6ba8c0"
+      sha256: "3394478cd571a8dbbe130a35e10bd365a2a8e7a867308142f7fd20336a08c3be"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.5"
+    version: "7.5.1"
   another_flushbar:
     dependency: "direct main"
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.4"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -182,26 +182,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.5.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.1.2"
   built_collection:
     dependency: transitive
     description:
@@ -350,18 +350,18 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "0c6396126421b590089447154c5f98a5de423b70cfb15b1578fd018843ee6f53"
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "11.5.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "7.0.3"
   diacritic:
     dependency: "direct main"
     description:
@@ -776,10 +776,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: d44bf546b13025ec7353091516f6881f1d4c633993cb109c3916c3a0159dadf1
+      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1864,10 +1864,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   web:
     dependency: transitive
     description:
@@ -1904,10 +1904,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.14.0"
   win32_registry:
     dependency: transitive
     description:


### PR DESCRIPTION
[![Run CI](https://github.com/breez/misty-breez/actions/workflows/CI.yml/badge.svg?branch=bolt12_payer_note&event=status)](https://github.com/breez/misty-breez/actions/workflows/CI.yml)

This PR is a continuation of #558, that applies changes from:
- https://github.com/breez/breez-sdk-liquid/pull/955

that persists payer notes on both send & receive sides.

#### Changelist:
* pop `SendPaymentRequest` instead of `PrepareSendResponse` on LN invoice & offer pages.
* pass values of `SendPaymentRequest` to `sendPayment` of `PaymentsCubit` on input handlers
* removed `payerNote` from `SendDestination_Bolt12` formatter