### PR TITLE
Fix scroll behavior on refund page by removing redundant scroll wrapper

### DIFF
--- a/lib/routes/refund/pages/get_refund/get_refund_page.dart
+++ b/lib/routes/refund/pages/get_refund/get_refund_page.dart
@@ -20,12 +20,10 @@ class GetRefundPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(leading: const back_button.BackButton(), title: Text(texts.get_refund_title)),
-      body: SingleChildScrollView(
-        child: BlocBuilder<RefundCubit, RefundState>(
-          builder: (BuildContext context, RefundState refundState) {
-            return RefundableSwapList(refundables: refundState.refundables ?? <RefundableSwap>[]);
-          },
-        ),
+      body: BlocBuilder<RefundCubit, RefundState>(
+        builder: (BuildContext context, RefundState refundState) {
+          return RefundableSwapList(refundables: refundState.refundables ?? <RefundableSwap>[]);
+        },
       ),
     );
   }


### PR DESCRIPTION
This PR fixes the scroll behavior on refund page caused by both `SingleChildScrollView` and `ListView` trying to handle scrolling.