### PR TITLE
Fix LNURL error if effective min is less than max sendable

### DIFF
--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -555,8 +555,8 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
         _isFormEnabled = false;
       });
     } else if (rawMaxSat != null && rawMaxSat < effectiveMinSat) {
-      final String networkLimit = currencyState.bitcoinCurrency.format(effectiveMinSat);
-      message = texts.invoice_payment_validator_error_payment_below_invoice_limit(networkLimit);
+      final String networkLimit = currencyState.bitcoinCurrency.format(rawMaxSat);
+      message = texts.invoice_payment_validator_error_payment_exceeded_limit(networkLimit);
       setState(() {
         _isFormEnabled = false;
       });


### PR DESCRIPTION
This PR fixes the displayed error for LNURL payments if the effective min `min(max(min_boltz, min_sendable), max_boltz)` is less than the max_sendable.

We perhaps also need an error text if the LNURL is not payable at all (outside of the boltz limits)

```
{
    "callback": "https://btcpay.kukks.org/BTC/UILNURL/pay/i/TUjfEJjFHndJpXMgKoe5tS",
    "metadata": "[[\"text/plain\",\"Paid to Pow.Space_Summer_school (Order ID: KKnmgFCKeUv6qy8Qaxzegu)\"]]",
    "tag": "payRequest",
    "minSendable": 1000,
    "maxSendable": 1000,
    "commentAllowed": 2000,
    "nostrPubkey": "921bbaec25be04ae8086b0c20fa375b983961e90332ee181acd8f1f2032f6755",
    "allowsNostr": true
}
```

<img width="1080" height="2400" alt="Screenshot_20250723-110955" src="https://github.com/user-attachments/assets/d507dc82-57ac-409a-bc37-ec1ab26a0118" />
