### PR TITLE
ui: align text to start on receive page messages boxes

### DIFF
--- a/lib/routes/receive_payment/onchain/amountless/widgets/amountless_btc_address_message_box.dart
+++ b/lib/routes/receive_payment/onchain/amountless/widgets/amountless_btc_address_message_box.dart
@@ -34,12 +34,12 @@ class AmountlessBtcAddressMessageBox extends StatelessWidget {
         final String limitsMessage = _formatAmountlessBtcMessage(context, snapshot, amountlessBtcState);
         const String feeInfoUrl =
             'https://sdk-doc-liquid.breez.technology/guide/base_fees.html#receiving-from-a-btc-address';
+
         return WarningBox(
           boxPadding: EdgeInsets.zero,
           backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
           contentPadding: const EdgeInsets.all(16.0),
           child: RichText(
-            textAlign: TextAlign.center,
             text: TextSpan(
               text: limitsMessage,
               style: themeData.textTheme.titleLarge?.copyWith(color: themeData.colorScheme.error),

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/notification_permission_warning_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/notification_permission_warning_box.dart
@@ -64,7 +64,6 @@ class NotificationPermissionWarningBox extends StatelessWidget {
                     ),
                   ],
                 ),
-                textAlign: TextAlign.center,
               ),
             ),
           ),

--- a/lib/routes/receive_payment/widgets/payment_message_boxes/payment_info_message_box.dart
+++ b/lib/routes/receive_payment/widgets/payment_message_boxes/payment_info_message_box.dart
@@ -19,7 +19,6 @@ class PaymentInfoMessageBox extends StatelessWidget {
       contentPadding: const EdgeInsets.all(16.0),
       child: linkUrl != null
           ? RichText(
-              textAlign: TextAlign.center,
               text: TextSpan(
                 text: message,
                 style: themeData.textTheme.titleLarge?.copyWith(color: themeData.colorScheme.error),
@@ -43,7 +42,6 @@ class PaymentInfoMessageBox extends StatelessWidget {
           : Text(
               message,
               style: themeData.textTheme.titleLarge?.copyWith(color: themeData.colorScheme.error),
-              textAlign: TextAlign.center,
             ),
     );
   }


### PR DESCRIPTION
[RichText](https://api.flutter.dev/flutter/widgets/RichText-class.html) widget provides limited control over word-breaking behavior. Alignment can be customized with `textAlign`, but detailed control over line-breaking rules is not directly supported.

<img width="50%" height="300" alt="image" src="https://github.com/user-attachments/assets/03d38fb9-0b83-4d6e-b230-a98065216777" /><img width="50%" height="244" alt="Screenshot_20250718-165039" src="https://github.com/user-attachments/assets/548dc87e-fc2e-4d55-883a-7aff5fab8470" />

We opted to align messages to the start (left in LTR locales, right in RTL) as a workaround to achieve a consistent appearance across devices with different screen sizes.
