### PR TITLE
Notification Extension: Unsubscribe log listener on shutdown

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -160,6 +160,11 @@ jobs:
           flutter-version: 3.32.8
           cache: true
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+
       - name: Set up just
         if: ${{ needs.setup.outputs.use-published-plugins == 'false' }}
         uses: extractions/setup-just@v3

--- a/android/app/src/main/resources/tinylog.properties
+++ b/android/app/src/main/resources/tinylog.properties
@@ -1,5 +1,5 @@
 writer          = file
-writer.level    = info
+writer.level    = debug
 writer.format   = [{class}] {opening-curly-bracket}{level}{closing-curly-bracket} ({date: yyyy-MM-dd HH:mm:ss.SSS}) : {message|indent=2}
 writer.file     = #{tinylog.directory}/#{tinylog.timestamp}.android-extension.log
 writer.charset  = UTF-8


### PR DESCRIPTION
Increases the log level to `debug` to see Notification Plugin logs and makes sure we unsubscribe the log listener to avoid multiple duplicate log lines being logged