### PR TITLE
Treat SdkEvent::PaymentWaitingFeeAcceptance as a PaymentEvent

### DIFF
--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -151,7 +151,8 @@ extension PaymentEventExtension on liquid_sdk.SdkEvent {
         this is liquid_sdk.SdkEvent_PaymentRefunded ||
         this is liquid_sdk.SdkEvent_PaymentRefundPending ||
         this is liquid_sdk.SdkEvent_PaymentSucceeded ||
-        this is liquid_sdk.SdkEvent_PaymentWaitingConfirmation;
+        this is liquid_sdk.SdkEvent_PaymentWaitingConfirmation ||
+        this is liquid_sdk.SdkEvent_PaymentWaitingFeeAcceptance;
   }
 }
 


### PR DESCRIPTION
This PR updates event handling to treat `SdkEvent::PaymentWaitingFeeAcceptance` as a `PaymentEvent`.