### PR TITLE
Replace PaymentEvent stream with Payment stream to improve tracking reliability

### DIFF
--- a/lib/cubit/payments/models/payment/models.dart
+++ b/lib/cubit/payments/models/payment/models.dart
@@ -2,3 +2,5 @@ export 'payment_data.dart';
 export 'payment_error.dart';
 export 'payment_filters.dart';
 export 'payment_result.dart';
+export 'payment_tracking_config.dart';
+export 'payment_tracking_filter.dart';

--- a/lib/cubit/payments/models/payment/payment_tracking_config.dart
+++ b/lib/cubit/payments/models/payment/payment_tracking_config.dart
@@ -1,0 +1,7 @@
+class PaymentTrackingConfig {
+  final String? expectedDestination;
+  final String? lnAddress;
+  final bool isBitcoinPayment;
+
+  const PaymentTrackingConfig({this.expectedDestination, this.lnAddress, this.isBitcoinPayment = false});
+}

--- a/lib/cubit/payments/models/payment/payment_tracking_filter.dart
+++ b/lib/cubit/payments/models/payment/payment_tracking_filter.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:misty_breez/cubit/payments/models/payment/payment_tracking_config.dart';
+
+/// A filter utility for tracking incoming payments
+class PaymentTrackingFilter {
+  final PaymentTrackingConfig trackingConfig;
+  final Set<String> excludedIds;
+
+  const PaymentTrackingFilter({required this.trackingConfig, required this.excludedIds});
+
+  bool passes(Payment payment) =>
+      _isNewPayment(payment) &&
+      _isReceivePayment(payment) &&
+      _hasValidState(payment) &&
+      _matchesConfig(payment);
+
+  bool _isNewPayment(Payment payment) => !excludedIds.contains(payment.trackingId);
+
+  bool _isReceivePayment(Payment payment) => payment.paymentType == PaymentType.receive;
+
+  bool _hasValidState(Payment payment) =>
+      payment.status == PaymentState.pending || payment.status == PaymentState.complete;
+
+  bool _matchesConfig(Payment payment) {
+    if (trackingConfig.lnAddress != null) {
+      return payment.details is PaymentDetails_Lightning;
+    }
+    if (trackingConfig.expectedDestination != null) {
+      // TODO(erdemyerebasmaz): Cleanup isBitcoinPayment workaround once SDK includes destination or swap ID on resulting payment.
+      // Depends on: https://github.com/breez/breez-sdk-liquid/issues/913
+      // Treat any incoming BTC payment as valid until we can match it via destination (BIP21 URI) or swap ID.
+      // TODO(erdemyerebasmaz): Issue above is resolved but not tested yet.
+      /*
+      final PaymentDetails paymentDetails = payment.details;
+      if (paymentDetails is PaymentDetails_Bitcoin) {
+        return paymentDetails.bitcoinAddress == expectedDestination;
+      }
+      */
+      return trackingConfig.isBitcoinPayment
+          ? payment.details is PaymentDetails_Bitcoin
+          : payment.destination == trackingConfig.expectedDestination;
+    }
+    return false;
+  }
+}
+
+extension PaymentTrackingId on Payment {
+  String get trackingId => txId ?? destination ?? '';
+}


### PR DESCRIPTION
This PR addresses payment tracking issue for payments handled by Notification Extension Service as the payment events are isolated to the instance on the extension.

NSE - Instance A - Emits Payment Event
App - Instance B - Unaware of the Payment Event