### PR TITLE
feat: update to new flutter_breez_liquid following Cargokit migration

### DIFF
--- a/android/app/src/main/kotlin/com/breez/misty/BreezLogger.kt
+++ b/android/app/src/main/kotlin/com/breez/misty/BreezLogger.kt
@@ -25,7 +25,8 @@ class BreezLogger {
                 System.setProperty("tinylog.timestamp", System.currentTimeMillis().toString())
 
                 if (isInit == false) {
-                    Logger.tag(TAG).debug { "Starting ${BuildConfig.APPLICATION_ID}..." }
+                    val applicationId = applicationContext.packageName
+                    Logger.tag(TAG).debug { "Starting $applicationId..." }
                     Logger.tag(TAG).debug { "Logs directory: '$loggingDir'" }
                     isInit = true
                 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,17 +24,18 @@ subprojects {
         }
 
         Integer pluginCompileSdk = project.android.compileSdk
-        if ((project.plugins.hasPlugin("com.android.application") || project.plugins.hasPlugin("com.android.library")) && pluginCompileSdk != null && pluginCompileSdk < 31) {
+        if ((project.plugins.hasPlugin("com.android.application") || project.plugins.hasPlugin("com.android.library")) && pluginCompileSdk != null && pluginCompileSdk < 34) {
             project.logger.error(
                     "Warning: Overriding 'compileSdkVersion' version on Flutter plugin '${project.name}' from "
                             + pluginCompileSdk
-                            + " to 35 (to work around https://issuetracker.google.com/issues/199180389)."
+                            + " to 36 (to meet AndroidX dependency requirements)."
+                            + "\nSeveral AndroidX dependencies (fragment, lifecycle, core, etc.) now require compileSdk 34 or higher."
                             + "\nIf a new version of '${project.name}' is not available, consider filing an issue against '${project.name}'"
-                            + " to increase their compileSdkVersion to the latest (otherwise try updating to the latest version)."
+                            + " to increase their compileSdkVersion to at least 34 (preferably 36 for latest compatibility)."
             )
             project.android {
-                compileSdkVersion 35
-                buildToolsVersion "35.0.0"
+                compileSdkVersion 36
+                buildToolsVersion "36.0.0"
             }
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,12 +18,12 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.3.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+    id "com.android.application" version '8.13.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     // TODO: Build Step
-    id "org.jetbrains.kotlin.plugin.serialization" version "1.9.22" apply false
+    id "org.jetbrains.kotlin.plugin.serialization" version "2.2.20" apply false
     // Firebase
-    id "com.google.gms.google-services" version "4.4.2" apply false
+    id "com.google.gms.google-services" version "4.4.3" apply false
 }
 
 include ":app"

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,9 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01C3A515351E6492D7937859 /* InvoiceRequest.swift in Resources */ = {isa = PBXBuildFile; fileRef = 1E9A1E3136FCBA878C70A4CA /* InvoiceRequest.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		067C83682F249B19BC1F5453 /* SwapUpdated.swift in Resources */ = {isa = PBXBuildFile; fileRef = A264C82AC8BC7F1241E73FD9 /* SwapUpdated.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		08CB0A160D6EED2796E4EC0B /* ResourceHelper.swift in Resources */ = {isa = PBXBuildFile; fileRef = 1A192468A40839C3E1F95E41 /* ResourceHelper.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1CA6E81BA22E5A8D433E2A6B /* BreezSDKLiquidConnector.swift in Resources */ = {isa = PBXBuildFile; fileRef = A691AEFC61B41DD487588D68 /* BreezSDKLiquidConnector.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		1FA7FF66245E9A54480B8D03 /* BreezSDKLiquid.swift in Resources */ = {isa = PBXBuildFile; fileRef = F080E1387E352B2DA7C25842 /* BreezSDKLiquid.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		31104192C14940B7EC05893B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD27585A7C13BA1F972B62A9 /* Pods_Runner.framework */; };
+		3204FBEDF6EA64FCFD1F982E /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834785B5F321A496DBAA67CF /* Pods_NotificationService.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		4CCB6B81DF4A4894F6233A8A /* LnurlPayInfo.swift in Resources */ = {isa = PBXBuildFile; fileRef = 983C171B4DBC7556ACE9C35E /* LnurlPayInfo.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		54E84EBFB85C29198DCA7FAD /* TaskProtocol.swift in Resources */ = {isa = PBXBuildFile; fileRef = 45499E08C2F5FC9154490F57 /* TaskProtocol.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		6263CBA6858DF86D44F5CBC3 /* LnurlPayVerify.swift in Resources */ = {isa = PBXBuildFile; fileRef = 7DFF470DB3C6061FB5C88F4C /* LnurlPayVerify.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		66E9CFA3D6C8EF6D226D0627 /* LnurlPay.swift in Resources */ = {isa = PBXBuildFile; fileRef = 09C93A0029BCF7C29F6246C6 /* LnurlPay.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		732A3D282C6CCF13007563A8 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D272C6CCF13007563A8 /* NotificationService.swift */; };
 		732A3D2C2C6CCF13007563A8 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 732A3D252C6CCF13007563A8 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		732A3D362C6CD974007563A8 /* SdkLogListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D332C6CD974007563A8 /* SdkLogListener.swift */; };
@@ -17,13 +28,16 @@
 		732A3D382C6CD974007563A8 /* KeyChainAccessGroupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A3D352C6CD974007563A8 /* KeyChainAccessGroupHelper.swift */; };
 		733E91342CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		7901778E7B93323001FBD6E5 /* SDKNotificationService.swift in Resources */ = {isa = PBXBuildFile; fileRef = 985FDB2F7253D22D7C83884F /* SDKNotificationService.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		8C20214CF52C3CE325D5AD97 /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 83FC81B6F2E941B0C78B4EC7 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		A44CC0C20228C2455131494A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BF09E65D2C99CA7783AD9ED /* Pods_Runner.framework */; };
+		BB4EF0A995A298C7F8031962 /* ServiceLogger.swift in Resources */ = {isa = PBXBuildFile; fileRef = 9EA8496E06FD1F74149CC65B /* ServiceLogger.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 		BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */; };
-		CD4EA368A7F818FB70798B61 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5F1E6FB8662312E1F7F0C8F /* Pods_RunnerTests.framework */; };
-		D4C953F0218135CB3C271211 /* Pods_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3794A673FCADEB2E5B08FD3B /* Pods_NotificationService.framework */; };
+		CC6E627C2BAE6A90A7531EB8 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B261CEC0CED4554959BE8466 /* Pods_RunnerTests.framework */; };
+		E0EECCCCF27C6CB8871D3931 /* String+SHA256.swift in Resources */ = {isa = PBXBuildFile; fileRef = 2B61177163A6C18CE41C42D0 /* String+SHA256.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
+		EA32FA5B3C3C6C4597675D88 /* Constants.swift in Resources */ = {isa = PBXBuildFile; fileRef = 9C587F36F92392E086C80462 /* Constants.swift */; settings = {ASSET_TAGS = (BreezSDKLiquid, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,13 +82,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		077F83A64AEEF4493BBA44A3 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		3794A673FCADEB2E5B08FD3B /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		4E89123989565A872ED855FB /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		5C2BBEA10A6FAAA0FF1EDBDB /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
+		6CCED6426BE4CD0FA7823BB2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		732A3D252C6CCF13007563A8 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		732A3D272C6CCF13007563A8 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		732A3D292C6CCF13007563A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -85,11 +100,9 @@
 		733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = breez_sdk_liquidFFI.xcframework; path = .symlinks/plugins/flutter_breez_liquid/ios/Frameworks/breez_sdk_liquidFFI.xcframework; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		78F0E91AE21B46A90FB23FBF /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		7BF09E65D2C99CA7783AD9ED /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		83C227CA462521C2E3653AA0 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
-		8FD131BC2391117FEB1DED26 /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
+		80BCB9F07DB86E650244AD5C /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		834785B5F321A496DBAA67CF /* Pods_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -97,14 +110,15 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BB899037808EFC7571AEB152 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BFAAB658D7A6AE60F906989E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		9DCEC1C61A10BC76E4B7D811 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		AA1A7888752831B3355AAD23 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		AC21044ABE9A38C15EE1113D /* Pods-NotificationService.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.profile.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.profile.xcconfig"; sourceTree = "<group>"; };
+		AD27585A7C13BA1F972B62A9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AF116037A98AA7FA8FBC23F4 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		B261CEC0CED4554959BE8466 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C2353E36B485E3D9C65F0A25 /* Pods-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		C921E6B9B40EE48F3627E76B /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		D5F1E6FB8662312E1F7F0C8F /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DBFA5F390DEE327D2780E2A0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		E8F7D4EF2C073A890018DB5D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		EB7E1E311673FAD5718DF03F /* Pods-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationService.release.xcconfig"; path = "Target Support Files/Pods-NotificationService/Pods-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
-		EFE03E6C655A1D70778F7DF4 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,7 +126,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CD4EA368A7F818FB70798B61 /* Pods_RunnerTests.framework in Frameworks */,
+				CC6E627C2BAE6A90A7531EB8 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,7 +135,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				733E91342CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework in Frameworks */,
-				D4C953F0218135CB3C271211 /* Pods_NotificationService.framework in Frameworks */,
+				3204FBEDF6EA64FCFD1F982E /* Pods_NotificationService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -129,7 +143,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A44CC0C20228C2455131494A /* Pods_Runner.framework in Frameworks */,
+				31104192C14940B7EC05893B /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,9 +175,9 @@
 			isa = PBXGroup;
 			children = (
 				733E91332CB6656A00616BBD /* breez_sdk_liquidFFI.xcframework */,
-				3794A673FCADEB2E5B08FD3B /* Pods_NotificationService.framework */,
-				7BF09E65D2C99CA7783AD9ED /* Pods_Runner.framework */,
-				D5F1E6FB8662312E1F7F0C8F /* Pods_RunnerTests.framework */,
+				834785B5F321A496DBAA67CF /* Pods_NotificationService.framework */,
+				AD27585A7C13BA1F972B62A9 /* Pods_Runner.framework */,
+				B261CEC0CED4554959BE8466 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -230,15 +244,15 @@
 			isa = PBXGroup;
 			children = (
 				859CF8DB9DF068928BF5B359 /* flutter_breez_liquid-OnDemandResources */,
-				83C227CA462521C2E3653AA0 /* Pods-NotificationService.debug.xcconfig */,
-				EB7E1E311673FAD5718DF03F /* Pods-NotificationService.release.xcconfig */,
-				8FD131BC2391117FEB1DED26 /* Pods-NotificationService.profile.xcconfig */,
-				BFAAB658D7A6AE60F906989E /* Pods-Runner.debug.xcconfig */,
-				DBFA5F390DEE327D2780E2A0 /* Pods-Runner.release.xcconfig */,
-				78F0E91AE21B46A90FB23FBF /* Pods-Runner.profile.xcconfig */,
-				BB899037808EFC7571AEB152 /* Pods-RunnerTests.debug.xcconfig */,
-				EFE03E6C655A1D70778F7DF4 /* Pods-RunnerTests.release.xcconfig */,
-				4E89123989565A872ED855FB /* Pods-RunnerTests.profile.xcconfig */,
+				C2353E36B485E3D9C65F0A25 /* Pods-NotificationService.debug.xcconfig */,
+				5C2BBEA10A6FAAA0FF1EDBDB /* Pods-NotificationService.release.xcconfig */,
+				AC21044ABE9A38C15EE1113D /* Pods-NotificationService.profile.xcconfig */,
+				80BCB9F07DB86E650244AD5C /* Pods-Runner.debug.xcconfig */,
+				AA1A7888752831B3355AAD23 /* Pods-Runner.release.xcconfig */,
+				AF116037A98AA7FA8FBC23F4 /* Pods-Runner.profile.xcconfig */,
+				077F83A64AEEF4493BBA44A3 /* Pods-RunnerTests.debug.xcconfig */,
+				9DCEC1C61A10BC76E4B7D811 /* Pods-RunnerTests.release.xcconfig */,
+				6CCED6426BE4CD0FA7823BB2 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -250,7 +264,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				BC40A4CED2D28A0FF74271C0 /* [CP] Check Pods Manifest.lock */,
+				3FFB10673C08AAE582A38997 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				3FD5F7911C380DE04B2EFF62 /* Frameworks */,
@@ -269,7 +283,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 732A3D312C6CCF13007563A8 /* Build configuration list for PBXNativeTarget "NotificationService" */;
 			buildPhases = (
-				CF15A19A7D0333EC2B2E08DE /* [CP] Check Pods Manifest.lock */,
+				C5DFD1489E80A8F8ADAC3BBD /* [CP] Check Pods Manifest.lock */,
 				732A3D212C6CCF13007563A8 /* Sources */,
 				732A3D222C6CCF13007563A8 /* Frameworks */,
 				732A3D232C6CCF13007563A8 /* Resources */,
@@ -287,7 +301,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				23E513FC8463A17EDF9150B6 /* [CP] Check Pods Manifest.lock */,
+				9AFFFEDB59FA535111EFD883 /* [CP] Check Pods Manifest.lock */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				732A3D2D2C6CCF13007563A8 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
@@ -295,8 +309,8 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				181C9ACD2558B4F294ADD4B3 /* [CP] Embed Pods Frameworks */,
-				BAF5E0D8C4A5B553B4EE7B19 /* [CP] Copy Pods Resources */,
+				E9539837C1EF766EB602AD5F /* [CP] Embed Pods Frameworks */,
+				128A8ADF44798720CAF31870 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -380,49 +394,41 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				BB6F2C501DC9CB40C2482FD1 /* GoogleService-Info.plist in Resources */,
+				1FA7FF66245E9A54480B8D03 /* BreezSDKLiquid.swift in Resources */,
+				1CA6E81BA22E5A8D433E2A6B /* BreezSDKLiquidConnector.swift in Resources */,
+				EA32FA5B3C3C6C4597675D88 /* Constants.swift in Resources */,
+				08CB0A160D6EED2796E4EC0B /* ResourceHelper.swift in Resources */,
+				7901778E7B93323001FBD6E5 /* SDKNotificationService.swift in Resources */,
+				BB4EF0A995A298C7F8031962 /* ServiceLogger.swift in Resources */,
+				E0EECCCCF27C6CB8871D3931 /* String+SHA256.swift in Resources */,
+				54E84EBFB85C29198DCA7FAD /* TaskProtocol.swift in Resources */,
+				01C3A515351E6492D7937859 /* InvoiceRequest.swift in Resources */,
+				66E9CFA3D6C8EF6D226D0627 /* LnurlPay.swift in Resources */,
+				4CCB6B81DF4A4894F6233A8A /* LnurlPayInfo.swift in Resources */,
+				8C20214CF52C3CE325D5AD97 /* LnurlPayInvoice.swift in Resources */,
+				6263CBA6858DF86D44F5CBC3 /* LnurlPayVerify.swift in Resources */,
+				067C83682F249B19BC1F5453 /* SwapUpdated.swift in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		181C9ACD2558B4F294ADD4B3 /* [CP] Embed Pods Frameworks */ = {
+		128A8ADF44798720CAF31870 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		23E513FC8463A17EDF9150B6 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -441,39 +447,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		BAF5E0D8C4A5B553B4EE7B19 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BC40A4CED2D28A0FF74271C0 /* [CP] Check Pods Manifest.lock */ = {
+		3FFB10673C08AAE582A38997 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -495,7 +469,44 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CF15A19A7D0333EC2B2E08DE /* [CP] Check Pods Manifest.lock */ = {
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		9AFFFEDB59FA535111EFD883 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C5DFD1489E80A8F8ADAC3BBD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -515,6 +526,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E9539837C1EF766EB602AD5F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -628,7 +656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -639,7 +667,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 78F0E91AE21B46A90FB23FBF /* Pods-Runner.profile.xcconfig */;
+			baseConfigurationReference = AF116037A98AA7FA8FBC23F4 /* Pods-Runner.profile.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -669,7 +697,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB899037808EFC7571AEB152 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 077F83A64AEEF4493BBA44A3 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -687,7 +715,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EFE03E6C655A1D70778F7DF4 /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 9DCEC1C61A10BC76E4B7D811 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -703,7 +731,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4E89123989565A872ED855FB /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 6CCED6426BE4CD0FA7823BB2 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -719,7 +747,7 @@
 		};
 		732A3D2E2C6CCF13007563A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 83C227CA462521C2E3653AA0 /* Pods-NotificationService.debug.xcconfig */;
+			baseConfigurationReference = C2353E36B485E3D9C65F0A25 /* Pods-NotificationService.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -761,7 +789,7 @@
 		};
 		732A3D2F2C6CCF13007563A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EB7E1E311673FAD5718DF03F /* Pods-NotificationService.release.xcconfig */;
+			baseConfigurationReference = 5C2BBEA10A6FAAA0FF1EDBDB /* Pods-NotificationService.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -804,7 +832,7 @@
 		};
 		732A3D302C6CCF13007563A8 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8FD131BC2391117FEB1DED26 /* Pods-NotificationService.profile.xcconfig */;
+			baseConfigurationReference = AC21044ABE9A38C15EE1113D /* Pods-NotificationService.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -892,7 +920,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -945,7 +973,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -958,7 +986,7 @@
 		};
 		97C147061CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BFAAB658D7A6AE60F906989E /* Pods-Runner.debug.xcconfig */;
+			baseConfigurationReference = 80BCB9F07DB86E650244AD5C /* Pods-Runner.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -989,7 +1017,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DBFA5F390DEE327D2780E2A0 /* Pods-Runner.release.xcconfig */;
+			baseConfigurationReference = AA1A7888752831B3355AAD23 /* Pods-Runner.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/lib/cubit/amountless_btc/amountless_btc_cubit.dart
+++ b/lib/cubit/amountless_btc/amountless_btc_cubit.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:logging/logging.dart';
 import 'package:misty_breez/cubit/cubit.dart';
-import 'package:misty_breez/models/models.dart';
 
 export 'amountless_btc_state.dart';
 
@@ -130,7 +129,7 @@ class AmountlessBtcCubit extends Cubit<AmountlessBtcState> {
 
       // Remove the payment from waiting list and proposed fees map
       final List<Payment> updatedPayments = state.paymentsWaitingFeeAcceptance.where((Payment payment) {
-        final String paymentSwapId = payment.details.map(
+        final String paymentSwapId = payment.details.maybeMap(
           bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
           lightning: (PaymentDetails_Lightning details) => details.swapId,
           orElse: () => '',

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -149,7 +149,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
 
   Future<String?> _getBolt12Offer() async {
     try {
-      final BindingLiquidSdk sdkInstance = breezSdkLiquid.instance!;
+      final BreezSdkLiquid sdkInstance = breezSdkLiquid.instance!;
       const PrepareReceiveRequest prepareReq = PrepareReceiveRequest(
         paymentMethod: PaymentMethod.bolt12Offer,
       );

--- a/lib/cubit/ln_address/services/webhook_service.dart
+++ b/lib/cubit/ln_address/services/webhook_service.dart
@@ -87,7 +87,7 @@ class WebhookService {
   /// Registers a webhook with timeout handling.
   Future<void> _registerWebhook(String webhookUrl, Duration timeout) async {
     try {
-      final BindingLiquidSdk? sdk = _breezSdkLiquid.instance;
+      final BreezSdkLiquid? sdk = _breezSdkLiquid.instance;
       if (sdk == null) {
         throw RegisterWebhookException('Breez SDK not initialized');
       }

--- a/lib/cubit/payments/models/payment/payment_data.dart
+++ b/lib/cubit/payments/models/payment/payment_data.dart
@@ -147,13 +147,13 @@ class PaymentData {
             details.equals(other.details);
   }
 
-  int get refundTxAmountSat => details.map(
+  int get refundTxAmountSat => details.maybeMap(
     bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxAmountSat?.toInt() ?? 0,
     lightning: (PaymentDetails_Lightning details) => details.refundTxAmountSat?.toInt() ?? 0,
     orElse: () => 0,
   );
 
-  String? get refundTxId => details.map(
+  String? get refundTxId => details.maybeMap(
     bitcoin: (PaymentDetails_Bitcoin details) => details.refundTxId,
     lightning: (PaymentDetails_Lightning details) => details.refundTxId,
     orElse: () => null,
@@ -168,14 +168,15 @@ class PaymentData {
     return metadataMap['image/png;base64'] ?? metadataMap['image/jpeg;base64'];
   }
 
-  String? get swapId => details.map(
+  String? get swapId => details.maybeMap(
     bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
     lightning: (PaymentDetails_Lightning details) => details.swapId,
     orElse: () => null,
   );
 
   String get preimage =>
-      details.map(lightning: (PaymentDetails_Lightning details) => details.preimage, orElse: () => '') ?? '';
+      details.maybeMap(lightning: (PaymentDetails_Lightning details) => details.preimage, orElse: () => '') ??
+      '';
 }
 
 class _PaymentDataFactory {
@@ -185,7 +186,7 @@ class _PaymentDataFactory {
   _PaymentDataFactory(this._payment, this._texts);
 
   String _title() {
-    final String? bip353Address = _payment.details.map(
+    final String? bip353Address = _payment.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.bip353Address,
       liquid: (PaymentDetails_Liquid details) => details.bip353Address,
       orElse: () => null,
@@ -195,7 +196,7 @@ class _PaymentDataFactory {
       return bip353Address!;
     }
 
-    final LnUrlInfo? lnurlInfo = _payment.details.map(
+    final LnUrlInfo? lnurlInfo = _payment.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.lnurlInfo,
       liquid: (PaymentDetails_Liquid details) => details.lnurlInfo,
       orElse: () => null,
@@ -227,7 +228,7 @@ class _PaymentDataFactory {
   }
 
   String? _getDescriptionFromDetails() {
-    return _payment.details.map(
+    return _payment.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.description,
       bitcoin: (PaymentDetails_Bitcoin details) => details.description,
       liquid: (PaymentDetails_Liquid details) => details.description,
@@ -246,7 +247,7 @@ class _PaymentDataFactory {
 }
 
 Map<String, dynamic> getLnurlPayMetadata(PaymentDetails details) {
-  final String? lnurlPayMetadata = details.map(
+  final String? lnurlPayMetadata = details.maybeMap(
     lightning: (PaymentDetails_Lightning details) => details.lnurlInfo?.lnurlPayMetadata,
     orElse: () => null,
   );

--- a/lib/cubit/payments/payments_state.dart
+++ b/lib/cubit/payments/payments_state.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/cubit/cubit.dart';
-import 'package:misty_breez/models/models.dart';
 
 class PaymentsState {
   final List<PaymentData> payments;
@@ -17,7 +16,7 @@ class PaymentsState {
     // This is a workaround to only include BTC assets in the unfiltered payments.
     // If Misty is to support multi-assets then this prefilter should be removed.
     final List<PaymentData>? prefilteredPayments = payments?.where((PaymentData paymentData) {
-      final String? paymentAssetTicker = paymentData.details.map(
+      final String? paymentAssetTicker = paymentData.details.maybeMap(
         liquid: (PaymentDetails_Liquid details) => details.assetInfo?.ticker ?? '',
         orElse: () => null,
       );
@@ -49,7 +48,7 @@ class PaymentsState {
       final bool passTypeFilter =
           typeFilterSet == null || typeFilterSet.contains(paymentData.paymentType.name);
 
-      final String? paymentAssetTicker = paymentData.details.map(
+      final String? paymentAssetTicker = paymentData.details.maybeMap(
         liquid: (PaymentDetails_Liquid details) => details.assetInfo?.ticker ?? '',
         orElse: () => null,
       );

--- a/lib/main/bootstrap.dart
+++ b/lib/main/bootstrap.dart
@@ -78,7 +78,7 @@ Future<void> bootstrap(AppBuilder builder) async {
 
 Future<void> _initializeBreezSdkLiquid() async {
   try {
-    await liquid_sdk.initialize();
+    await liquid_sdk.FlutterBreezLiquid.init();
   } catch (error, stackTrace) {
     _logger.severe('Failed to initialize Breez SDK - Liquid: $error', error, stackTrace);
     runApp(BootstrapErrorPage(error: error, stackTrace: stackTrace));

--- a/lib/models/extensions/payment_details_extension.dart
+++ b/lib/models/extensions/payment_details_extension.dart
@@ -4,29 +4,9 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:misty_breez/models/models.dart';
 import 'package:misty_breez/utils/utils.dart';
 
-// TODO(erdemyerebasmaz): Ensure that any changes to [PaymentDetails] are reflected here on each extension.
-extension PaymentDetailsMapExtension on PaymentDetails {
-  T map<T>({
-    required T Function() orElse,
-    T Function(PaymentDetails_Bitcoin details)? bitcoin,
-    T Function(PaymentDetails_Lightning details)? lightning,
-    T Function(PaymentDetails_Liquid details)? liquid,
-  }) {
-    if (this is PaymentDetails_Bitcoin) {
-      return bitcoin != null ? bitcoin(this as PaymentDetails_Bitcoin) : orElse();
-    } else if (this is PaymentDetails_Lightning) {
-      return lightning != null ? lightning(this as PaymentDetails_Lightning) : orElse();
-    } else if (this is PaymentDetails_Liquid) {
-      return liquid != null ? liquid(this as PaymentDetails_Liquid) : orElse();
-    } else {
-      return orElse();
-    }
-  }
-}
-
 extension PaymentDetailsToJson on PaymentDetails {
   Map<String, dynamic>? toJson() {
-    return map(
+    return maybeMap(
       lightning: (PaymentDetails_Lightning details) => <String, dynamic>{
         'type': 'lightning',
         'swapId': details.swapId,
@@ -130,7 +110,7 @@ extension PaymentDetailsExtension on PaymentDetails {
   bool equals(PaymentDetails other) {
     return identical(this, other) ||
         other.runtimeType == runtimeType &&
-            other.map(
+            other.maybeMap(
               lightning: (PaymentDetails_Lightning o) {
                 final PaymentDetails_Lightning current = this as PaymentDetails_Lightning;
                 return o.swapId == current.swapId &&
@@ -177,7 +157,7 @@ extension PaymentDetailsExtension on PaymentDetails {
 
 extension PaymentDetailsHashCode on PaymentDetails {
   int calculateHashCode() {
-    return map(
+    return maybeMap(
       lightning: (PaymentDetails_Lightning o) => Object.hash(
         o.swapId,
         o.description,
@@ -224,7 +204,7 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
       return null;
     }
 
-    final int? expiryBlockheight = map(
+    final int? expiryBlockheight = maybeMap(
       bitcoin: (PaymentDetails_Bitcoin details) => details.bitcoinExpirationBlockheight,
       lightning: (PaymentDetails_Lightning details) => details.liquidExpirationBlockheight,
       orElse: () => null,
@@ -234,7 +214,7 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
       return null;
     }
 
-    final int? currentTip = map(
+    final int? currentTip = maybeMap(
       bitcoin: (_) => blockchainInfo.bitcoinTip,
       lightning: (_) => blockchainInfo.liquidTip,
       orElse: () => null,
@@ -244,7 +224,7 @@ extension PaymentDetailsExpiryDate on PaymentDetails {
       return null;
     }
 
-    return map(
+    return maybeMap(
       bitcoin: (_) =>
           BreezDateUtils.bitcoinBlockDiffToDate(blockHeight: currentTip, expiryBlock: expiryBlockheight),
       lightning: (_) =>
@@ -539,7 +519,7 @@ extension AesSuccessActionDataFromJson on AesSuccessActionData {
 
 extension PaymentDetailsBolt12Offer on PaymentDetails {
   bool get hasBolt12Offer {
-    return map(
+    return maybeMap(
       lightning: (PaymentDetails_Lightning details) =>
           details.bolt12Offer != null && details.bolt12Offer!.isNotEmpty,
       orElse: () => false,

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -88,7 +88,7 @@ class _DevelopersViewState extends State<DevelopersView> {
   /// Loads the default BOLT12 offer
   Future<void> _loadBolt12Offer() async {
     try {
-      final BindingLiquidSdk sdk = ServiceInjector().breezSdkLiquid.instance!;
+      final BreezSdkLiquid sdk = ServiceInjector().breezSdkLiquid.instance!;
       const PrepareReceiveRequest prepareReq = PrepareReceiveRequest(
         paymentMethod: PaymentMethod.bolt12Offer,
       );

--- a/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
+++ b/lib/routes/home/widgets/payments_list/widgets/payment_details_sheet/payment_details_sheet.dart
@@ -48,34 +48,34 @@ class PaymentDetailsSheet extends StatelessWidget {
     final AccountState accountState = accountCubit.state;
     final ThemeData themeData = Theme.of(context);
 
-    final String? invoice = paymentData.details.map(
+    final String? invoice = paymentData.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.invoice,
       orElse: () => null,
     );
 
-    final String destinationPubkey = paymentData.details.map(
+    final String destinationPubkey = paymentData.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.destinationPubkey ?? '',
       orElse: () => '',
     );
 
-    final String paymentPreimage = paymentData.details.map(
+    final String paymentPreimage = paymentData.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.preimage ?? '',
       orElse: () => '',
     );
 
-    final String swapId = paymentData.details.map(
+    final String swapId = paymentData.details.maybeMap(
       bitcoin: (PaymentDetails_Bitcoin details) => details.swapId,
       lightning: (PaymentDetails_Lightning details) => details.swapId,
       orElse: () => '',
     );
 
-    final String claimTxId = paymentData.details.map(
+    final String claimTxId = paymentData.details.maybeMap(
       bitcoin: (PaymentDetails_Bitcoin details) => details.claimTxId ?? '',
       orElse: () => '',
     );
 
     final String bip353Address =
-        paymentData.details.map(
+        paymentData.details.maybeMap(
           lightning: (PaymentDetails_Lightning details) => details.bip353Address,
           liquid: (PaymentDetails_Liquid details) => details.bip353Address,
           orElse: () => null,
@@ -83,14 +83,14 @@ class PaymentDetailsSheet extends StatelessWidget {
         '';
 
     final String payerNote =
-        paymentData.details.map(
+        paymentData.details.maybeMap(
           lightning: (PaymentDetails_Lightning details) => details.payerNote,
           liquid: (PaymentDetails_Liquid details) => details.payerNote,
           orElse: () => null,
         ) ??
         '';
 
-    final LnUrlInfo? lnurlInfo = paymentData.details.map(
+    final LnUrlInfo? lnurlInfo = paymentData.details.maybeMap(
       lightning: (PaymentDetails_Lightning details) => details.lnurlInfo,
       liquid: (PaymentDetails_Liquid details) => details.lnurlInfo,
       orElse: () => null,

--- a/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
+++ b/packages/breez_sdk_liquid/lib/src/breez_sdk_liquid.dart
@@ -19,9 +19,9 @@ class BreezSDKLiquid {
     didCompleteInitialSyncStream = _didCompleteInitialSyncController.stream.take(1);
   }
 
-  liquid_sdk.BindingLiquidSdk? _instance;
+  liquid_sdk.BreezSdkLiquid? _instance;
 
-  liquid_sdk.BindingLiquidSdk? get instance => _instance;
+  liquid_sdk.BreezSdkLiquid? get instance => _instance;
 
   Future<void> connect({required liquid_sdk.ConnectRequest req}) async {
     try {
@@ -47,18 +47,18 @@ class BreezSDKLiquid {
     _instance = null;
   }
 
-  Future<void> _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
+  Future<void> _fetchWalletData(liquid_sdk.BreezSdkLiquid sdk) async {
     await _getInfo(sdk);
     await _listPayments(sdk: sdk);
   }
 
-  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
+  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BreezSdkLiquid sdk) async {
     final liquid_sdk.GetInfoResponse getInfoResponse = await sdk.getInfo();
     _getInfoResponseController.add(getInfoResponse);
     return getInfoResponse;
   }
 
-  Future<List<liquid_sdk.Payment>> _listPayments({required liquid_sdk.BindingLiquidSdk sdk}) async {
+  Future<List<liquid_sdk.Payment>> _listPayments({required liquid_sdk.BreezSdkLiquid sdk}) async {
     const liquid_sdk.ListPaymentsRequest req = liquid_sdk.ListPaymentsRequest();
     final List<liquid_sdk.Payment> paymentsList = await sdk.listPayments(req: req);
     _paymentsController.add(paymentsList);
@@ -86,7 +86,7 @@ class BreezSDKLiquid {
 
   Stream<liquid_sdk.SdkEvent>? _breezEventsStream;
 
-  void _initializeEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+  void _initializeEventsStream(liquid_sdk.BreezSdkLiquid sdk) {
     _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
   }
 
@@ -105,7 +105,7 @@ class BreezSDKLiquid {
   Stream<PaymentEvent> get paymentEventStream => _paymentEventStream.stream;
 
   /// Subscribes to SdkEvent's stream
-  void _subscribeToEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+  void _subscribeToEventsStream(liquid_sdk.BreezSdkLiquid sdk) {
     _breezEventsSubscription = _breezEventsStream?.listen((liquid_sdk.SdkEvent event) async {
       if (event.isPaymentEvent) {
         _paymentEventStream.add(PaymentEvent.fromSdkEvent(event));

--- a/packages/sdk_connectivity_cubit/lib/src/sync_manager.dart
+++ b/packages/sdk_connectivity_cubit/lib/src/sync_manager.dart
@@ -14,7 +14,7 @@ class SyncManager {
   StreamSubscription<List<ConnectivityResult>>? _networkSubscription;
   DateTime _lastSync = DateTime.fromMillisecondsSinceEpoch(0);
 
-  final BindingLiquidSdk? wallet;
+  final BreezSdkLiquid? wallet;
 
   SyncManager(this.wallet);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,13 +130,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  breez_liquid:
-    dependency: "direct overridden"
-    description:
-      path: "../breez-sdk-liquid/packages/dart"
-      relative: true
-    source: path
-    version: "0.10.3"
   breez_translations:
     dependency: "direct main"
     description:
@@ -242,14 +235,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -262,10 +247,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -443,14 +428,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  ffigen:
-    dependency: transitive
-    description:
-      name: ffigen
-      sha256: "72d732c33557fc0ca9b46379d3deff2dadbdc539696dc0b270189e2989be20ef"
-      url: "https://pub.dev"
-    source: hosted
-    version: "18.1.0"
   file:
     dependency: transitive
     description:
@@ -563,7 +540,7 @@ packages:
   flutter_breez_liquid:
     dependency: "direct main"
     description:
-      path: "../breez-sdk-liquid/packages/flutter"
+      path: "../breez-sdk-liquid/packages/flutter_breez_liquid"
       relative: true
     source: path
     version: "0.10.3"
@@ -650,11 +627,12 @@ packages:
   flutter_keyboard_visibility:
     dependency: transitive
     description:
-      name: flutter_keyboard_visibility
-      sha256: "4983655c26ab5b959252ee204c2fffa4afeb4413cd030455194ec0caa3b8e7cb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.4.1"
+      path: flutter_keyboard_visibility
+      ref: "63da8c50a5be71a2c06e988cd1993a89b9873a1c"
+      resolved-ref: "63da8c50a5be71a2c06e988cd1993a89b9873a1c"
+      url: "https://github.com/Crucialjun/flutter_keyboard_visibility"
+    source: git
+    version: "6.0.0"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
@@ -789,8 +767,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4a494322762af9f30820f3c63aba784d46b86b69"
-      resolved-ref: "4a494322762af9f30820f3c63aba784d46b86b69"
+      ref: "2766f3c3c64339e6beb0a0eea258de408383d0c7"
+      resolved-ref: "2766f3c3c64339e6beb0a0eea258de408383d0c7"
       url: "https://github.com/breez/flutter_typeahead.git"
     source: git
     version: "4.0.0"
@@ -1043,10 +1021,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1423,14 +1401,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
   rxdart:
     dependency: "direct main"
     description:
@@ -1760,10 +1730,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: dbdd48a5b6a6fe9c7d75099bd2d03f9da9393f8d51a0d250301debbcecd552d2
+      sha256: "07cffecb7d68cbc6437cd803d5f11a86fe06736735c3dfe46ff73bcb0f958eed"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.19"
+    version: "6.3.21"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1940,14 +1910,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  yaml_edit:
-    dependency: transitive
-    description:
-      name: yaml_edit
-      sha256: fb38626579fb345ad00e674e2af3a5c9b0cc4b9bfb8fd7f7ff322c7c9e62aef5
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
 sdks:
   dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,7 +85,7 @@ dependencies:
   flutter_typeahead:
     git:
       url: https://github.com/breez/flutter_typeahead.git
-      ref: 4a494322762af9f30820f3c63aba784d46b86b69
+      ref: 2766f3c3c64339e6beb0a0eea258de408383d0c7
   hex: ^0.2.0
   http: ^1.4.0
   hydrated_bloc: ^10.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,11 +131,9 @@ dev_dependencies:
   test_api: ^0.7.6
 
 dependency_overrides:
-  # Comment-out to work with liquid-sdk from git repository
-  breez_liquid:
-    path: ../breez-sdk-liquid/packages/dart
+  # Comment-out to work with breez-sdk-liquid from git repository
   flutter_breez_liquid:
-    path: ../breez-sdk-liquid/packages/flutter
+    path: ../breez-sdk-liquid/packages/flutter_breez_liquid
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This PR updates flutter_breez_liquid to version with Cargokit integration that fixes framework linking and symbol stripping issues.

Depends on:
- https://github.com/breez/breez-sdk-liquid/pull/1012

- Update initialize() calls to FlutterBreezLiquid.init()
- Replace BindingLiquidSdk references with BreezSdkLiquid