### PR TITLE
fix(android): save logs archive to temp directory for sharing

### DIFF
--- a/lib/services/wallet_archive_service.dart
+++ b/lib/services/wallet_archive_service.dart
@@ -54,9 +54,8 @@ class WalletArchiveService {
   static Future<String> createLogsArchive() async {
     _logger.info('Creating logs archive...');
 
-    final AppConfig config = await _getAppConfig();
-    final String workingDir = config.sdkConfig.workingDir;
-    final String zipFilePath = '$workingDir/$_logsArchiveFilename';
+    final Directory tempDir = await getTemporaryDirectory();
+    final String zipFilePath = '${tempDir.path}/$_logsArchiveFilename';
     final ZipFileEncoder encoder = ZipFileEncoder();
 
     try {


### PR DESCRIPTION
## Summary
- The logs archive zip was being created in the SDK's internal working directory (`getApplicationDocumentsDirectory()`), which on Android resolves to `/data/data/<package>/app_flutter/`. When `share_plus` copies this file to its cache folder for sharing via `content://` URI, the receiving app may not be able to properly access the shared file, causing its UI to become unresponsive.
- Changed the output location to `getTemporaryDirectory()` (cache directory), matching the pattern used by the CSV exporter. The log files are still read from the SDK working directory — only the output zip location changed.

## Test plan
- [ ] Share logs from Preferences > Developers > Logs on Android
- [ ] Verify the share sheet opens and the receiving app can process the file
- [ ] Test sharing to multiple apps (email, messaging apps, file managers)

Fixes https://github.com/breez/misty-breez/issues/625

🤖 Generated with [Claude Code](https://claude.com/claude-code)