### PR TITLE
feat(dart): add editable BOLT12 offer description in developer view

### DIFF
--- a/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
+++ b/lib/cubit/ln_address/factories/ln_address_cubit_factory.dart
@@ -27,6 +27,10 @@ class LnAddressCubitFactory {
       webhookService: webhookService,
     );
 
-    return LnAddressCubit(breezSdkLiquid: breezSdkLiquid, registrationManager: registrationManager);
+    return LnAddressCubit(
+      breezSdkLiquid: breezSdkLiquid,
+      registrationManager: registrationManager,
+      breezPreferences: breezPreferences,
+    );
   }
 }

--- a/lib/cubit/ln_address/ln_address_cubit.dart
+++ b/lib/cubit/ln_address/ln_address_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:breez_preferences/breez_preferences.dart';
 import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
@@ -16,8 +17,9 @@ final Logger _logger = Logger('LnAddressCubit');
 class LnAddressCubit extends Cubit<LnAddressState> {
   final BreezSDKLiquid breezSdkLiquid;
   final LnUrlRegistrationManager registrationManager;
+  final BreezPreferences breezPreferences;
 
-  LnAddressCubit({required this.breezSdkLiquid, required this.registrationManager})
+  LnAddressCubit({required this.breezSdkLiquid, required this.registrationManager, required this.breezPreferences})
     : super(const LnAddressState()) {
     _initializeLnAddressCubit();
   }
@@ -149,6 +151,8 @@ class LnAddressCubit extends Cubit<LnAddressState> {
 
   Future<String?> _getBolt12Offer() async {
     try {
+      final String description =
+          await breezPreferences.bolt12OfferDescription ?? PaymentConstants.bolt12OfferDescription;
       final BreezSdkLiquid sdkInstance = breezSdkLiquid.instance!;
       const PrepareReceiveRequest prepareReq = PrepareReceiveRequest(
         paymentMethod: PaymentMethod.bolt12Offer,
@@ -156,7 +160,7 @@ class LnAddressCubit extends Cubit<LnAddressState> {
       final PrepareReceiveResponse prepareRes = await sdkInstance.prepareReceivePayment(req: prepareReq);
       final ReceivePaymentRequest receiveReq = ReceivePaymentRequest(
         prepareResponse: prepareRes,
-        description: PaymentConstants.bolt12OfferDescription,
+        description: description,
       );
       final ReceivePaymentResponse receiveRes = await sdkInstance.receivePayment(req: receiveReq);
       return receiveRes.destination;

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -40,6 +40,7 @@ class _DevelopersViewState extends State<DevelopersView> {
   BugReportBehavior _bugReportBehavior = BugReportBehavior.prompt;
   String _sdkVersion = '';
   String _bolt12Offer = '';
+  String _bolt12Description = PaymentConstants.bolt12OfferDescription;
 
   @override
   void initState() {
@@ -85,9 +86,11 @@ class _DevelopersViewState extends State<DevelopersView> {
     }
   }
 
-  /// Loads the default BOLT12 offer
+  /// Loads the BOLT12 offer using the persisted or default description
   Future<void> _loadBolt12Offer() async {
     try {
+      final String description =
+          await _preferences.bolt12OfferDescription ?? PaymentConstants.bolt12OfferDescription;
       final BreezSdkLiquid sdk = ServiceInjector().breezSdkLiquid.instance!;
       const PrepareReceiveRequest prepareReq = PrepareReceiveRequest(
         paymentMethod: PaymentMethod.bolt12Offer,
@@ -95,12 +98,15 @@ class _DevelopersViewState extends State<DevelopersView> {
       final PrepareReceiveResponse prepareRes = await sdk.prepareReceivePayment(req: prepareReq);
       final ReceivePaymentRequest receiveReq = ReceivePaymentRequest(
         prepareResponse: prepareRes,
-        description: PaymentConstants.bolt12OfferDescription,
+        description: description,
       );
       final ReceivePaymentResponse receiveRes = await sdk.receivePayment(req: receiveReq);
 
       if (mounted) {
-        setState(() => _bolt12Offer = receiveRes.destination);
+        setState(() {
+          _bolt12Offer = receiveRes.destination;
+          _bolt12Description = description;
+        });
       }
     } catch (e) {
       _logger.warning('Failed to load BOLT12 offer: $e');
@@ -253,6 +259,63 @@ class _DevelopersViewState extends State<DevelopersView> {
     }
   }
 
+  /// Shows a dialog to edit the BOLT12 offer description
+  Future<void> _showEditBolt12DescriptionDialog() async {
+    final TextEditingController controller = TextEditingController(text: _bolt12Description);
+    final ThemeData themeData = Theme.of(context);
+
+    final String? newDescription = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(
+            'Edit Offer Description',
+            style: themeData.primaryTextTheme.headlineMedium?.copyWith(color: Colors.white),
+          ),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            maxLength: 90,
+            decoration: const InputDecoration(
+              labelText: 'Description',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(controller.text),
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (newDescription == null || newDescription.trim().isEmpty || newDescription == _bolt12Description) {
+      return;
+    }
+
+    _overlayManager.showLoadingOverlay(this.context);
+    try {
+      await _preferences.setBolt12OfferDescription(newDescription);
+      await _loadBolt12Offer();
+      if (mounted) {
+        _showSuccessMessage('Offer description updated.');
+      }
+    } catch (e) {
+      _logger.warning('Failed to update BOLT12 offer description: $e');
+      if (mounted) {
+        _showErrorMessage('Failed to update offer description.');
+      }
+    } finally {
+      _overlayManager.removeLoadingOverlay();
+    }
+  }
+
   /// Shows a success message to the user
   void _showSuccessMessage(String message) {
     showFlushbar(context, message: message);
@@ -315,17 +378,28 @@ class _DevelopersViewState extends State<DevelopersView> {
                     if (_bolt12Offer.isNotEmpty) ...<Widget>[
                       Padding(
                         padding: const EdgeInsets.symmetric(vertical: 8),
-                        child: ShareablePaymentRow(
-                          tilePadding: EdgeInsets.zero,
-                          dividerColor: Colors.transparent,
-                          title: 'BOLT 12 Offer',
-                          titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
-                            fontSize: 18.0,
-                            color: Colors.white,
-                          ),
-                          sharedValue: _bolt12Offer,
-                          shouldPop: false,
-                          trimTitle: false,
+                        child: Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: ShareablePaymentRow(
+                                tilePadding: EdgeInsets.zero,
+                                dividerColor: Colors.transparent,
+                                title: 'BOLT 12 Offer',
+                                titleTextStyle: themeData.primaryTextTheme.headlineMedium?.copyWith(
+                                  fontSize: 18.0,
+                                  color: Colors.white,
+                                ),
+                                sharedValue: _bolt12Offer,
+                                shouldPop: false,
+                                trimTitle: false,
+                              ),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.edit, size: 20.0, color: Colors.white),
+                              tooltip: 'Edit offer description',
+                              onPressed: _showEditBolt12DescriptionDialog,
+                            ),
+                          ],
                         ),
                       ),
                     ],

--- a/packages/breez_preferences/lib/src/breez_preferences.dart
+++ b/packages/breez_preferences/lib/src/breez_preferences.dart
@@ -13,6 +13,7 @@ class BreezPreferences {
   static const String _kWebhookUrl = 'webhook_url';
   static const String _kLnUrlWebhookRegistered = 'lnurl_webhook_registered';
   static const String _kLnAddressUsername = 'ln_address_username';
+  static const String _kBolt12OfferDescription = 'bolt12_offer_description';
 
   const BreezPreferences();
 
@@ -124,6 +125,24 @@ class BreezPreferences {
     await prefs.setString(_kLnAddressUsername, lnAddressUsername);
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       await SharedPreferenceAppGroup.setString(_kLnAddressUsername, lnAddressUsername);
+    }
+  }
+
+  // BOLT12 Offer Description
+  Future<String?> get bolt12OfferDescription async {
+    final SharedPreferences prefs = await _preferences;
+    final String? description = prefs.getString(_kBolt12OfferDescription);
+
+    _logger.info('Fetched BOLT12 Offer Description: $description');
+    return description;
+  }
+
+  Future<void> setBolt12OfferDescription(String description) async {
+    _logger.info('Setting BOLT12 Offer Description: $description');
+    final SharedPreferences prefs = await _preferences;
+    await prefs.setString(_kBolt12OfferDescription, description);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await SharedPreferenceAppGroup.setString(_kBolt12OfferDescription, description);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add an edit button next to the BOLT12 Offer row in the Developer view, allowing users to set a custom offer description
- Persist the custom description in `BreezPreferences` (with iOS app group sync)
- Both the Developer view and `LnAddressCubit` (LN Address registration) use the persisted description, falling back to the default
- Zero changes to the receive payment UI

## Motivation

Services like OCEAN require a specific description in the BOLT12 offer. This change lets users customize it from the Developer view without altering the receive screen flow.

## Test plan

- [ ] Open Developer view, expand BOLT12 Offer row, tap edit icon
- [ ] Enter a custom description, tap Save -- offer string updates
- [ ] Restart the app -- custom description persists
- [ ] Verify LN Address registration uses the custom description
- [ ] Verify empty descriptions are rejected (dialog no-ops)