### PR TITLE
lnurl_pay: forward sender comment to prepare request

### DIFF
--- a/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
+++ b/lib/routes/send_payment/lnurl/lnurl_payment_page.dart
@@ -72,6 +72,10 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
 
   bool _isDrain = false;
 
+  bool get _shouldPrepareEagerly =>
+      _isFixedAmount &&
+      (widget.isConfirmation || widget.lnUrlPaymentArguments.requestData.commentAllowed <= 0);
+
   @override
   void initState() {
     super.initState();
@@ -135,7 +139,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       effectiveMaxSat: effectiveMaxSat,
       throwError: true,
     );
-    if (errorMessage == null && _isFixedAmount) {
+    if (errorMessage == null && _shouldPrepareEagerly) {
       await _prepareLnUrlPayment(amountSat);
       if (mounted && _isDrain) {
         final AccountCubit accountCubit = context.read<AccountCubit>();
@@ -170,10 +174,12 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
       final PayAmount payAmount = _isDrain
           ? const PayAmount_Drain()
           : PayAmount_Bitcoin(receiverAmountSat: BigInt.from(amountSat));
+      final String? comment = _descriptionController.text.isEmpty ? null : _descriptionController.text;
       final PrepareLnUrlPayRequest req = PrepareLnUrlPayRequest(
         data: widget.lnUrlPaymentArguments.requestData,
         bip353Address: widget.lnUrlPaymentArguments.bip353Address,
         amount: payAmount,
+        comment: comment,
         validateSuccessActionUrl: false,
       );
       final PrepareLnUrlPayResponse response = await lnUrlService.prepareLnurlPay(req: req);
@@ -432,15 +438,16 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                                       hasError: !_isFormEnabled || errorMessage.isNotEmpty,
                                     ),
                                   ),
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 8.0),
-                                    child: LnPaymentFee(
-                                      isCalculatingFees: _isCalculatingFees,
-                                      feesSat: errorMessage.isEmpty
-                                          ? _prepareResponse?.feesSat.toInt()
-                                          : null,
+                                  if (_shouldPrepareEagerly)
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                                      child: LnPaymentFee(
+                                        isCalculatingFees: _isCalculatingFees,
+                                        feesSat: errorMessage.isEmpty
+                                            ? _prepareResponse?.feesSat.toInt()
+                                            : null,
+                                      ),
                                     ),
-                                  ),
                                   if (metadataText != null && metadataText.isNotEmpty) ...<Widget>[
                                     Padding(
                                       padding: _prepareResponse == null
@@ -500,7 +507,7 @@ class LnUrlPaymentPageState extends State<LnUrlPaymentPage> {
                 Navigator.of(context).pop();
               },
             )
-          : !_isFixedAmount
+          : !_shouldPrepareEagerly
           ? SingleButtonBottomBar(
               stickToBottom: true,
               text: texts.lnurl_payment_page_action_next,


### PR DESCRIPTION
## Summary

The sender comment entered on the LNURL pay screen was not being forwarded to the LNURL callback, so recipient apps never saw it.

The comment was collected into `_descriptionController` and handed between the input and confirmation pages, but the `PrepareLnUrlPayRequest` was constructed without the `comment` field — so the SDK invoked the LNURL callback without `?comment=...` and the payee never received the text the user typed.

## Changes

- Pass the comment into `PrepareLnUrlPayRequest`.
- Defer prepare when there is still a comment to collect: when `commentAllowed > 0` and the amount is fixed, the initial page now acts as an input step and routes through the confirmation page, which issues a single prepare with the amount and comment already set.
- Hide the fee row on the initial page in that deferred case, since there is no prepare response to show yet.

End result: exactly one prepare per payment, and the comment is always included.

## Test plan

- [ ] Variable-amount LNURL with a comment: type amount + comment on page 1 → Next → confirmation page shows fees and comment → Send. Verify recipient sees the comment.
- [ ] Fixed-amount LNURL with a comment (e.g. LN address with `commentAllowed > 0` and equal min/max): type comment → Next → confirmation page shows fees and comment → Send. Verify recipient sees the comment.
- [ ] Fixed-amount LNURL without a comment: behavior unchanged — fees shown upfront, direct Send.
- [ ] Variable-amount LNURL without a comment: behavior unchanged.