### PR TITLE
ci: add scheduled maintenance builds for iOS and Android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -17,6 +17,15 @@ on:
         required: false
         type: string
         default: 'main'
+  schedule:
+    # ~60-day cadence (1st of every other month at 09:00 UTC). Builds main
+    # against the published Liquid SDK plugin (production config); see the
+    # pre-setup resolve defaults below. Mirrors build-ios.yml.
+    - cron: '0 9 1 */2 *'
+
+concurrency:
+  group: build-android
+  cancel-in-progress: false
 
 jobs:
 
@@ -29,9 +38,12 @@ jobs:
       # changes that you won't want to commit to main yet.
       # You can set these values manually, to test how the CI behaves with
       # certain inputs.
-      use-published-plugins: ${{ inputs.use-published-plugins }}
-      liquid-sdk-plugin-version: ${{ inputs.liquid-sdk-plugin-version }}
-      liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
+      # Schedule events don't populate inputs.* — build main against the
+      # production published Liquid SDK plugin. Bump the pinned version when
+      # production moves to a newer breez-sdk-liquid-flutter release.
+      use-published-plugins: ${{ github.event_name == 'schedule' && 'true' || inputs.use-published-plugins }}
+      liquid-sdk-plugin-version: ${{ github.event_name == 'schedule' && 'v0.12.4' || inputs.liquid-sdk-plugin-version }}
+      liquid-sdk-ref: ${{ github.event_name == 'schedule' && 'main' || inputs.liquid-sdk-ref }}
     steps:
       - name: Checkout repository
         if:  ${{ inputs.use-published-plugins == 'true' && inputs.liquid-sdk-plugin-version == ''}}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -22,6 +22,15 @@ on:
         required: false
         type: boolean
         default: false
+  schedule:
+    # ~60-day cadence (1st of every other month at 09:00 UTC), well under the
+    # 90-day TestFlight expiration. Builds main against the published Liquid SDK
+    # plugin (production config); see the pre-setup resolve defaults below.
+    - cron: '0 9 1 */2 *'
+
+concurrency:
+  group: build-ios
+  cancel-in-progress: false
 
 jobs:
   pre-setup:
@@ -33,10 +42,13 @@ jobs:
       # changes that you won't want to commit to main yet.
       # You can set these values manually, to test how the CI behaves with
       # certain inputs.
-      use-published-plugins: ${{ inputs.use-published-plugins }}
-      liquid-sdk-plugin-version: ${{ inputs.liquid-sdk-plugin-version }}
-      liquid-sdk-ref: ${{ inputs.liquid-sdk-ref }}
-      device-only-build: ${{ inputs.device-only-build }}
+      # Schedule events don't populate inputs.* — build main against the
+      # production published Liquid SDK plugin. Bump the pinned version when
+      # production moves to a newer breez-sdk-liquid-flutter release.
+      use-published-plugins: ${{ github.event_name == 'schedule' && 'true' || inputs.use-published-plugins }}
+      liquid-sdk-plugin-version: ${{ github.event_name == 'schedule' && 'v0.12.4' || inputs.liquid-sdk-plugin-version }}
+      liquid-sdk-ref: ${{ github.event_name == 'schedule' && 'main' || inputs.liquid-sdk-ref }}
+      device-only-build: ${{ github.event_name == 'schedule' && 'false' || inputs.device-only-build }}
     steps:
       - name: Checkout repository
         if:  ${{ needs.pre-setup.outputs.use-published-plugins == 'true' && needs.pre-setup.outputs.liquid-sdk-plugin-version == ''}}


### PR DESCRIPTION
## Why

Mirrors the scheduled-build safety net added to c-breez. TestFlight builds expire after 90 days; without a periodic build, a quiet stretch can let the current TestFlight build lapse. This adds a bi-monthly build so a fresh one is always well within the window.

## What

Add a `schedule` cron (`0 9 1 */2 *`, ~60-day cadence) to **build-ios.yml** and **build-android.yml**, plus a per-workflow `concurrency` group to prevent overlapping scheduled runs.

Scheduled runs build `main` — schedule triggers fire from the default branch, and misty-breez is actively developed on `main`, so no branch-ref override is needed (unlike c-breez's maintenance-mode setup).

They build against the **published Liquid SDK plugin** (`v0.12.4`) — the production configuration. Since `schedule` events don't populate `inputs.*`, `pre-setup` resolves them for scheduled runs:

- `use-published-plugins` → `true`
- `liquid-sdk-plugin-version` → `v0.12.4`
- `liquid-sdk-ref` → `main`
- (iOS) `device-only-build` → `false` (no effect under published plugins; the from-source binding steps it gates are skipped)

### Note on the pinned version

The version is pinned explicitly because the existing "get latest tag" auto-detect is a no-op:
- **build-ios.yml**: uses the disabled `::set-output` command *and* references `needs.pre-setup` from within the `pre-setup` job itself (a job can't reference its own `needs`).
- **build-android.yml**: writes to a step output that the job output never reads (the job output is bound directly to `inputs.*`).

So `v0.12.4` must be bumped in both workflows' pre-setup defaults when production moves to a newer `breez-sdk-liquid-flutter` release. (Fixing the auto-detect to track a single source of truth is a reasonable follow-up, but out of scope here.)

Manual `workflow_dispatch` behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)