### PR TITLE
receive: add Liquid Address receive option

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -49,6 +49,9 @@ class App extends StatelessWidget {
         BlocProvider<AmountlessBtcCubit>(
           create: (BuildContext context) => AmountlessBtcCubit(injector.breezSdkLiquid),
         ),
+        BlocProvider<LiquidAddressCubit>(
+          create: (BuildContext context) => LiquidAddressCubit(injector.breezSdkLiquid),
+        ),
         BlocProvider<PermissionsCubit>(create: (BuildContext context) => permissionsCubit),
       ],
       child: Provider<LnUrlService>(

--- a/lib/cubit/cubit.dart
+++ b/lib/cubit/cubit.dart
@@ -7,6 +7,7 @@ export 'chain_swap/chain_swap_cubit.dart';
 export 'connectivity/connectivity_cubit.dart';
 export 'currency/currency_cubit.dart';
 export 'input/input_cubit.dart';
+export 'liquid_address/liquid_address_cubit.dart';
 export 'ln_address/ln_address_cubit.dart';
 export 'model/models.dart';
 export 'nwc/nwc_cubit.dart';

--- a/lib/cubit/liquid_address/liquid_address_cubit.dart
+++ b/lib/cubit/liquid_address/liquid_address_cubit.dart
@@ -1,0 +1,51 @@
+import 'package:breez_sdk_liquid/breez_sdk_liquid.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
+import 'package:logging/logging.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+
+export 'liquid_address_state.dart';
+
+final Logger _logger = Logger('LiquidAddressCubit');
+
+class LiquidAddressCubit extends Cubit<LiquidAddressState> {
+  final BreezSDKLiquid _breezSdkLiquid;
+
+  LiquidAddressCubit(this._breezSdkLiquid) : super(LiquidAddressState.initial());
+
+  /// Generates a new Liquid address
+  ///
+  /// Unlike every other receive method, this one does not go through the Boltz swapper,
+  /// so there are no swapper fees and no payment limits.
+  Future<void> generateLiquidAddress() async {
+    try {
+      _logger.info('Generating Liquid address');
+
+      emit(state.copyWith(isLoading: true));
+
+      final PrepareReceiveRequest prepareReq = const PrepareReceiveRequest(
+        paymentMethod: PaymentMethod.liquidAddress,
+      );
+      final PrepareReceiveResponse prepareResp = await _breezSdkLiquid.instance!.prepareReceivePayment(
+        req: prepareReq,
+      );
+      final ReceivePaymentRequest req = ReceivePaymentRequest(prepareResponse: prepareResp);
+      final ReceivePaymentResponse resp = await _breezSdkLiquid.instance!.receivePayment(req: req);
+
+      final String address = resp.destination;
+
+      _logger.info('Successfully generated Liquid address: $address');
+
+      emit(LiquidAddressState(address: address));
+    } catch (e) {
+      _logger.severe('Failed to generate Liquid address', e);
+      emit(LiquidAddressState(error: e));
+    }
+  }
+
+  /// Resets the entire state to initial
+  void reset() {
+    _logger.info('Resetting LiquidAddressCubit state');
+    emit(LiquidAddressState.initial());
+  }
+}

--- a/lib/cubit/liquid_address/liquid_address_state.dart
+++ b/lib/cubit/liquid_address/liquid_address_state.dart
@@ -1,0 +1,40 @@
+class LiquidAddressState {
+  final String? address;
+  final bool isLoading;
+  final Object? error;
+
+  const LiquidAddressState({this.address, this.isLoading = false, this.error});
+
+  LiquidAddressState.initial() : this();
+
+  LiquidAddressState copyWith({String? address, bool? isLoading, Object? error}) => LiquidAddressState(
+    address: address ?? this.address,
+    isLoading: isLoading ?? this.isLoading,
+    error: error,
+  );
+
+  bool get hasValidAddress => address != null && address!.isNotEmpty;
+  bool get hasError => error != null;
+
+  @override
+  String toString() =>
+      'LiquidAddressState('
+      'address: ${address ?? "N/A"}, '
+      'isLoading: $isLoading, '
+      'error: ${error ?? "N/A"}'
+      ')';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is LiquidAddressState &&
+        other.address == address &&
+        other.isLoading == isLoading &&
+        other.error == error;
+  }
+
+  @override
+  int get hashCode => Object.hash(address, isLoading, error);
+}

--- a/lib/routes/receive_payment/liquid/receive_liquid_address_payment_page.dart
+++ b/lib/routes/receive_payment/liquid/receive_liquid_address_payment_page.dart
@@ -1,0 +1,142 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:breez_translations/generated/breez_translations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:misty_breez/cubit/cubit.dart';
+import 'package:misty_breez/routes/routes.dart';
+import 'package:misty_breez/theme/theme.dart';
+import 'package:misty_breez/utils/utils.dart';
+import 'package:misty_breez/widgets/widgets.dart';
+
+/// Page that displays the user's Liquid address for receiving payments.
+///
+/// Liquid receives do not go through the Boltz swapper, so this page has no
+/// fee message box and no payment limits bottom bar.
+class ReceiveLiquidAddressPage extends StatefulWidget {
+  static const String routeName = '/liquid_address';
+  static const int pageIndex = 4;
+
+  const ReceiveLiquidAddressPage({super.key});
+
+  @override
+  State<StatefulWidget> createState() => ReceiveLiquidAddressPageState();
+}
+
+class ReceiveLiquidAddressPageState extends State<ReceiveLiquidAddressPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<LiquidAddressCubit>().generateLiquidAddress();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+
+    return BlocBuilder<LiquidAddressCubit, LiquidAddressState>(
+      builder: (BuildContext context, LiquidAddressState state) {
+        return Scaffold(
+          body: _buildContent(state),
+          bottomNavigationBar: Padding(
+            padding: const EdgeInsets.only(top: 16.0),
+            child: SingleButtonBottomBar(
+              stickToBottom: true,
+              text: state.hasError
+                  ? texts.invoice_btc_address_action_retry
+                  : texts.qr_code_dialog_action_close,
+              onPressed: state.hasError
+                  ? () => context.read<LiquidAddressCubit>().generateLiquidAddress()
+                  : () => Navigator.of(context).pop(),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(LiquidAddressState state) {
+    if (state.isLoading) {
+      return const CenteredLoader();
+    }
+
+    if (state.hasError) {
+      return _LiquidAddressErrorView(error: state.error!);
+    }
+
+    if (state.hasValidAddress) {
+      return _LiquidAddressSuccessView(address: state.address!);
+    }
+
+    return const SizedBox.shrink();
+  }
+}
+
+class _LiquidAddressSuccessView extends StatelessWidget {
+  final String address;
+
+  const _LiquidAddressSuccessView({required this.address});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 16.0),
+      child: SingleChildScrollView(
+        child: Container(
+          decoration: ShapeDecoration(
+            shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
+            color: themeData.customData.surfaceBgColor,
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 8),
+          // TODO(erdemyerebasmaz): Add message to Breez-Translations
+          child: DestinationWidget(destination: address, paymentLabel: 'Liquid Address'),
+        ),
+      ),
+    );
+  }
+}
+
+class _LiquidAddressErrorView extends StatelessWidget {
+  final Object error;
+
+  const _LiquidAddressErrorView({required this.error});
+
+  @override
+  Widget build(BuildContext context) {
+    final BreezTranslations texts = context.texts();
+    final ThemeData themeData = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 32.0),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () => context.read<LiquidAddressCubit>().generateLiquidAddress(),
+        child: WarningBox(
+          boxPadding: EdgeInsets.zero,
+          backgroundColor: themeData.colorScheme.error.withValues(alpha: .1),
+          contentPadding: const EdgeInsets.all(16.0),
+          child: RichText(
+            text: TextSpan(
+              text: ExceptionHandler.extractMessage(error, texts),
+              style: themeData.textTheme.bodyLarge?.copyWith(color: themeData.colorScheme.error),
+              children: <InlineSpan>[
+                TextSpan(
+                  // TODO(erdemyerebasmaz): Add message to Breez-Translations
+                  text: '\n\nTap here to retry',
+                  style: themeData.textTheme.titleLarge?.copyWith(
+                    color: themeData.colorScheme.error.withValues(alpha: .7),
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ],
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/receive_payment/receive_payment.dart
+++ b/lib/routes/receive_payment/receive_payment.dart
@@ -1,4 +1,5 @@
 export 'lightning/receive_lightning_page.dart';
+export 'liquid/receive_liquid_address_payment_page.dart';
 export 'ln_address/receive_lightning_address_page.dart';
 export 'lnurl/lnurl_withdraw_page.dart';
 export 'onchain/onchain.dart';

--- a/lib/routes/receive_payment/receive_payment_page.dart
+++ b/lib/routes/receive_payment/receive_payment_page.dart
@@ -22,6 +22,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
     ReceiveLightningAddressPage(),
     ReceiveAmountlessBitcoinAddressPage(),
     ReceiveBitcoinAddressPaymentPage(),
+    ReceiveLiquidAddressPage(),
   ];
 
   bool _hasNotificationPermission = false;
@@ -143,6 +144,9 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   }
 
   PaymentMethod get _currentPaymentMethod {
+    if (_currentPageIndex == ReceiveLiquidAddressPage.pageIndex) {
+      return PaymentMethod.liquidAddress;
+    }
     return _currentPageIndex == ReceiveAmountlessBitcoinAddressPage.pageIndex ||
             _currentPageIndex == ReceiveBitcoinAddressPaymentPage.pageIndex
         ? PaymentMethod.bitcoinAddress
@@ -150,7 +154,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
   }
 
   Future<void> _onPaymentMethodChanged(PaymentMethod newMethod) async {
-    if (newMethod == PaymentMethod.liquidAddress || newMethod == _currentPaymentMethod) {
+    if (newMethod == _currentPaymentMethod) {
       return;
     }
     Future<void>.microtask(() async {
@@ -173,7 +177,7 @@ class _ReceivePaymentPageState extends State<ReceivePaymentPage> {
       case PaymentMethod.bolt11Invoice:
         return ReceiveLightningAddressPage.pageIndex;
       case PaymentMethod.liquidAddress:
-        return ReceiveAmountlessBitcoinAddressPage.pageIndex; // Fallback
+        return ReceiveLiquidAddressPage.pageIndex;
     }
   }
 }

--- a/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
+++ b/lib/routes/receive_payment/widgets/payment_method_dropdown/payment_method_dropdown.dart
@@ -25,6 +25,7 @@ class PaymentMethodDropdown extends StatelessWidget {
     final List<PaymentMethod> allMethods = <PaymentMethod>[
       PaymentMethod.bolt11Invoice,
       PaymentMethod.bitcoinAddress,
+      PaymentMethod.liquidAddress,
     ];
 
     return PopupMenuButton<PaymentMethod>(


### PR DESCRIPTION
This PR introduces a Liquid Address receive option, mirroring the send-to-Liquid-address support.

Boltz is currently down, that's why Lightning and onchain BTC receives fail. `PaymentMethod.liquidAddress` needs no swapper, so it still works.

### Changelist:

* receive: add Liquid Address receive option 53907b6a