### PR TITLE
exception_handler: make swap outage errors actionable

### DIFF
--- a/lib/utils/exceptions/exception_handler.dart
+++ b/lib/utils/exceptions/exception_handler.dart
@@ -74,8 +74,9 @@ class ExceptionHandler {
       if (error.err.toLowerCase().contains('non-final') ||
           error.err.toLowerCase().contains('rpc error -26')) {
         message = 'The transaction cannot be broadcast at this time. Please try again later.';
+      } else {
+        message = 'Payment error: ${error.err}';
       }
-      message = 'Payment error: ${error.err}';
     } else if (error is PaymentError_InvalidOrExpiredFees) {
       message = 'The provided fees have expired';
     } else if (error is PaymentError_InsufficientFunds) {
@@ -87,7 +88,9 @@ class ExceptionHandler {
     } else if (error is PaymentError_InvalidPreimage) {
       message = 'The generated preimage is not valid';
     } else if (error is PaymentError_PairsNotFound) {
-      message = 'Boltz did not return any pairs from the request';
+      // The swapper answered but offers no BTC/L-BTC pair, which is what a suspended
+      // swap service looks like. Liquid send & receive need no swapper, so point there.
+      message = 'Swaps are temporarily unavailable. You can still send and receive using a Liquid address.';
     } else if (error is PaymentError_PaymentTimeout) {
       message = 'Payment start could not be verified within the configured timeout';
     } else if (error is PaymentError_PersistError) {


### PR DESCRIPTION
This PR replaces a developer-facing swap error with an actionable one.

Boltz [suspended its service](https://x.com/Boltzhq/status/2084311537502630319), that's why users hit `PairsNotFound` on every Lightning and onchain path. Liquid needs no swapper.

### Changelist:

* exception_handler: make swap outage errors actionable 195e952a
