### PR TITLE
style: apply dart format to Liquid address send page

### DIFF
--- a/lib/app/routes/routes.dart
+++ b/lib/app/routes/routes.dart
@@ -105,9 +105,8 @@ Route<dynamic>? onGenerateRoute({
                     );
                   case LiquidAddressPaymentPage.routeName:
                     return FadeInRoute<SendPaymentRequest?>(
-                      builder: (BuildContext _) => LiquidAddressPaymentPage(
-                        addressData: settings.arguments as LiquidAddressData,
-                      ),
+                      builder: (BuildContext _) =>
+                          LiquidAddressPaymentPage(addressData: settings.arguments as LiquidAddressData),
                       settings: settings,
                     );
                   case LnPaymentPage.routeName:

--- a/lib/routes/send_payment/liquid/liquid_address_payment_page.dart
+++ b/lib/routes/send_payment/liquid/liquid_address_payment_page.dart
@@ -206,9 +206,7 @@ class _LiquidAddressPaymentPageState extends State<LiquidAddressPaymentPage> {
                                 errorMessage,
                                 maxLines: 3,
                                 textAlign: TextAlign.left,
-                                style: FieldTextStyle.labelStyle.copyWith(
-                                  color: themeData.colorScheme.error,
-                                ),
+                                style: FieldTextStyle.labelStyle.copyWith(color: themeData.colorScheme.error),
                               ),
                             ],
                           ] else ...<Widget>[
@@ -253,10 +251,8 @@ class _LiquidAddressPaymentPageState extends State<LiquidAddressPaymentPage> {
                 ? SingleButtonBottomBar(
                     stickToBottom: true,
                     text: texts.ln_payment_action_send,
-                    onPressed: () => Navigator.pop(
-                      context,
-                      SendPaymentRequest(prepareResponse: _prepareResponse!),
-                    ),
+                    onPressed: () =>
+                        Navigator.pop(context, SendPaymentRequest(prepareResponse: _prepareResponse!)),
                   )
                 : errorMessage.isNotEmpty
                 ? SingleButtonBottomBar(
@@ -287,10 +283,7 @@ class _LiquidAddressPaymentPageState extends State<LiquidAddressPaymentPage> {
           style: themeData.primaryTextTheme.headlineMedium?.copyWith(fontSize: 18.0, color: Colors.white),
         ),
         const SizedBox(height: 8.0),
-        Text(
-          widget.addressData.address,
-          style: FieldTextStyle.labelStyle.copyWith(fontSize: 14.0),
-        ),
+        Text(widget.addressData.address, style: FieldTextStyle.labelStyle.copyWith(fontSize: 14.0)),
       ],
     );
   }


### PR DESCRIPTION
This PR fixes the formatting that turned CI red on `main`.

`dart format` was missed in #653, that's why CI has been failing since. `flutter analyze` does not check formatting.

### Changelist:

* style: apply dart format to Liquid address send page 3ec50200
